### PR TITLE
Updated drupal/drupal-extension version.

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -18,7 +18,7 @@ default:
         - IntegratedExperts\BehatScreenshotExtension\Context\ScreenshotContext
 
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       goutte: ~
       base_url: http://nginx:8080
       files_path: '%paths.base%/tests/behat/fixtures'

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "cweagans/composer-patches": "^1.6.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
         "drupal/coder": "^8.2.12",
-        "drupal/drupal-extension": "^v3.4",
+        "drupal/drupal-extension": "^4.1",
         "integratedexperts/behat-format-progress-fail": "^0.2",
         "integratedexperts/behat-screenshot": "^0.7",
         "jakub-onderka/php-parallel-lint": "^1.0",
@@ -28,12 +28,7 @@
         "branch-alias": {
             "dev-master": "1.x-dev"
         },
-        "enable-patching": true,
-        "patches": {
-            "drupal/drupal-driver": {
-                "Prevent PHP warning when creating a node with Drupal 7.79 and it's new field storage optimization": "https://patch-diff.githubusercontent.com/raw/jhedstrom/DrupalDriver/pull/233.patch"
-            }
-        }
+        "enable-patching": true
     },
     "config": {
         "platform": {

--- a/src/D7/FieldCollectionTrait.php
+++ b/src/D7/FieldCollectionTrait.php
@@ -56,7 +56,7 @@ trait FieldCollectionTrait {
       [$field_name, $fc_field_name] = explode(':', $field, 2);
       $fc_field_names = explode(self::fieldCollectionGetInstanceDelimiter(), $fc_field_name);
       $node_field_types = self::$fieldCollectionCoreDriver->getCore()
-        ->getEntityFieldTypes('node', $field_name);
+        ->getEntityFieldTypes('node', [$field_name]);
       // Although node field parser may validate filed existence, we still need
       // to do it here before validating its type.
       if (!array_key_exists($field_name, $node_field_types)) {


### PR DESCRIPTION
### Background
The version of drupal extension that behat-steps uses does not have Drupal9 compatibility. This PR updates the package to the latest.

### What has changed
1. Updating the drupal-extension version to the latest.
2. Updating breaking api changes in D7 field collection trait.
3. Updated namespace for mink extension
