### PR TITLE
Remove patch which has been merged in upstream project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,7 @@
         "branch-alias": {
             "dev-master": "1.x-dev"
         },
-        "enable-patching": true,
-        "patches": {
-            "drupal/drupal-driver": {
-                "Prevent PHP warning when creating a node with Drupal 7.79 and it's new field storage optimization": "https://patch-diff.githubusercontent.com/raw/jhedstrom/DrupalDriver/pull/233.patch"
-            }
-        }
+        "enable-patching": true
     },
     "config": {
         "platform": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "cweagans/composer-patches": "^1.6.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
         "drupal/coder": "^8.2.12",
-        "drupal/drupal-extension": "^v3.4",
+        "drupal/drupal-extension": "^v4.1",
         "integratedexperts/behat-format-progress-fail": "^0.2",
         "integratedexperts/behat-screenshot": "^0.7",
         "jakub-onderka/php-parallel-lint": "^1.0",


### PR DESCRIPTION
Patch no longer applies and may cause build failures (if requiring project has composer-exit-on-patch-failure set).

See https://github.com/jhedstrom/DrupalDriver/pull/233