### PR TITLE
Filter users by mail field instead of name

### DIFF
--- a/src/UserTrait.php
+++ b/src/UserTrait.php
@@ -137,7 +137,7 @@ trait UserTrait {
       return $mail;
     }
 
-    $users = $this->userLoadMultiple(['name' => $mail]);
+    $users = $this->userLoadMultiple(['mail' => $mail]);
     $user = reset($users);
 
     if (!$user) {


### PR DESCRIPTION
`userGetByMail()` function incorrectly filters by `name` field but it should use `mail` field instead.