### PR TITLE
Added assertion for link that does not exist on the page.

### DIFF
--- a/src/LinkTrait.php
+++ b/src/LinkTrait.php
@@ -57,6 +57,51 @@ trait LinkTrait {
   }
 
   /**
+   * Assert link with a href does not exist.
+   *
+   * Note that simplified wildcard is supported in "href".
+   *
+   * @code
+   * Then I should not see the link "About us" with "/about-us"
+   * Then I should not see the link "About us" with "/about-us" in ".main-nav"
+   * Then I should not see the link "About us" with "/about*" in ".main-nav"
+   * @endcode
+   *
+   * @Then I should not see the link :text with :href
+   * @Then I should not see the link :text with :href in :locator
+   */
+  public function linkAssertTextHrefNotExists($text, $href, $locator = NULL) {
+    /** @var \Behat\Mink\Element\DocumentElement $page */
+    $page = $this->getSession()->getPage();
+
+    if ($locator) {
+      $element = $page->find('css', $locator);
+      if (!$element) {
+        return;
+      }
+    }
+    else {
+      $element = $page;
+    }
+
+    $link = $element->findLink($text);
+    if (!$link) {
+      return;
+    }
+
+    if (!$link->hasAttribute('href')) {
+      return;
+    }
+
+    $pattern = '/' . preg_quote($href, '/') . '/';
+    // Support for simplified wildcard using '*'.
+    $pattern = strpos($href, '*') !== FALSE ? str_replace('\*', '.*', $pattern) : $pattern;
+    if (preg_match($pattern, $link->getAttribute('href'))) {
+      throw new \Exception(sprintf('The link href "%s" matches the specified href "%s" but should not', $link->getAttribute('href'), $href));
+    }
+  }
+
+  /**
    * Assert that a link with a title exists.
    *
    * @Then the link with title :title exists

--- a/tests/behat/features/link.feature
+++ b/tests/behat/features/link.feature
@@ -15,6 +15,23 @@ Feature: Check that LinkTrait works
     Given I go to "/"
     Then I should see the link "Drupal" with "https://www.drupal*"
 
+  @d9
+  Scenario: Assert link with href without locator does not exist
+    Given I go to "/"
+    Then I should not see the link "RandomLinkText" with "https://www.drupal.org"
+    Then I should not see the link "Drupal" with "https://www.randomhref.org"
+
+  @d9
+  Scenario: Assert link with href with locator does not exist
+    Given I go to "/"
+    Then I should not see the link "RandomLinkText" with "https://www.randomhref.org" in "#block-system-powered-by,#block-bartik-powered"
+    Then I should not see the link "Drupal" with "https://www.drupal.org" in "#random-locator"
+
+  @d9
+  Scenario: Assert link with wildcard in href without locator does not exist
+    Given I go to "/"
+    Then I should not see the link "Drupal" with "https://www.randomhref*"
+
   @api @d9
   Scenario: Assert link with title
     Given I am logged in as a user with the "administrator" role


### PR DESCRIPTION
### What has changed
1. Added an assertion that checks that a link with given text, given href and an optional locator does **not** exist on the page.