### PR TITLE
Added more verbose output for watchdog step.

### DIFF
--- a/src/D7/WatchdogTrait.php
+++ b/src/D7/WatchdogTrait.php
@@ -93,7 +93,12 @@ trait WatchdogTrait {
         ->condition('wid', array_keys($errors), 'IN')
         ->execute();
 
-      throw new \Exception(sprintf('PHP errors were logged to watchdog during this scenario: %s', PHP_EOL . implode(PHP_EOL . PHP_EOL, $errors)));
+      throw new \Exception(sprintf(
+          'PHP errors were logged to watchdog during scenario "%s" (line %s): %s',
+          $scope->getScenario()->getTitle(),
+          $scope->getScenario()->getLine(),
+          PHP_EOL . implode(PHP_EOL . PHP_EOL, $errors))
+      );
     }
   }
 

--- a/src/WatchdogTrait.php
+++ b/src/WatchdogTrait.php
@@ -94,7 +94,12 @@ trait WatchdogTrait {
         ->condition('wid', array_keys($errors), 'IN')
         ->execute();
 
-      throw new \Exception(sprintf('PHP errors were logged to watchdog during this scenario: %s', PHP_EOL . implode(PHP_EOL . PHP_EOL, $errors)));
+      throw new \Exception(sprintf(
+          'PHP errors were logged to watchdog during scenario "%s" (line %s): %s',
+          $scope->getScenario()->getTitle(),
+          $scope->getScenario()->getLine(),
+          PHP_EOL . implode(PHP_EOL . PHP_EOL, $errors))
+      );
     }
   }
 

--- a/tests/behat/features/d7.watchdog.feature
+++ b/tests/behat/features/d7.watchdog.feature
@@ -11,7 +11,7 @@ Feature: Check that WatchdogTrait works for D7
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      PHP errors were logged to watchdog during this scenario:
+      PHP errors were logged to watchdog during scenario "Stub scenario title" (line 3):
       """
 
   @api

--- a/tests/behat/features/watchdog.feature
+++ b/tests/behat/features/watchdog.feature
@@ -11,7 +11,7 @@ Feature: Check that WatchdogTrait works for or D9
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      PHP errors were logged to watchdog during this scenario:
+      PHP errors were logged to watchdog during scenario "Stub scenario title" (line 3):
       """
 
   @api


### PR DESCRIPTION
<img width="593" alt="Cursor_and_behat-steps_–_d7_watchdog_feature" src="https://user-images.githubusercontent.com/378794/192902497-5ac922d4-6ac0-4012-bfab-7d84cac139df.png">
