### PR TITLE
Fixed regression with JS driver autostart.

### DIFF
--- a/src/JsTrait.php
+++ b/src/JsTrait.php
@@ -31,10 +31,11 @@ trait JsTrait {
       $session = $this->getSession();
       $driver = $session->getDriver();
 
-      $session->resizeWindow(1440, 900, 'current');
       if (!$driver->isStarted()) {
         $driver->start();
       }
+
+      $session->resizeWindow(1440, 900, 'current');
     }
   }
 


### PR DESCRIPTION
The browser should be started prior to resizing the window in JS tests.