### PR TITLE
Added handling for multiple sessions in bigpipe.

### DIFF
--- a/src/BigPipeTrait.php
+++ b/src/BigPipeTrait.php
@@ -81,16 +81,14 @@ trait BigPipeTrait {
       return;
     }
     try {
-      $session = $this->getSession();
+      if ($this->bigPipeNoJS && !$this->getSession()->getCookie(BigPipeStrategy::NOJS_COOKIE)) {
+        $this->getSession()
+          ->setCookie(BigPipeStrategy::NOJS_COOKIE, 'true');
+      }
     }
     catch (DriverException $e) {
       // Mute not visited page exception.
       return;
-    }
-
-    if ($this->bigPipeNoJS && !$session->getCookie(BigPipeStrategy::NOJS_COOKIE)) {
-      $session
-        ->setCookie(BigPipeStrategy::NOJS_COOKIE, 'true');
     }
   }
 

--- a/src/BigPipeTrait.php
+++ b/src/BigPipeTrait.php
@@ -23,11 +23,11 @@ trait BigPipeTrait {
   protected $bigPipeNoJS;
 
   /**
-   * Skip Big Pipe scenario.
+   * Skip Big Pipe BeforeStep.
    *
    * @var bool
    */
-  protected $skipBigPipeScenario = FALSE;
+  protected bool $skipBigPipeBeforeStep = FALSE;
 
   /**
    * Prepares Big Pipe NOJS cookie if needed.
@@ -37,7 +37,7 @@ trait BigPipeTrait {
   public function bigPipeBeforeScenarioInit(BeforeScenarioScope $scope) {
     // Allow to skip resetting cookies on step.
     if ($scope->getScenario()->hasTag('behat-steps-skip:bigPipeBeforeStep')) {
-      $this->skipBigPipeScenario = TRUE;
+      $this->skipBigPipeBeforeStep = TRUE;
     }
     // Allow to skip this by adding a tag.
     if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
@@ -62,7 +62,7 @@ trait BigPipeTrait {
       $this->bigPipeNoJS = TRUE;
       $this
         ->getSession()
-        ->setCookie(BigPipeStrategy::NOJS_COOKIE, '1');
+        ->setCookie(BigPipeStrategy::NOJS_COOKIE, 'true');
     }
     catch (\Exception $e) {
       // Mute exceptions.
@@ -75,19 +75,18 @@ trait BigPipeTrait {
    * @BeforeStep
    */
   public function bigPipeBeforeStep(BeforeStepScope $scope) {
-    // Allow to skip this by skipping scenario with tag.
-    if ($this->skipBigPipeScenario) {
+    if ($this->skipBigPipeBeforeStep) {
       return;
     }
     try {
       if ($this->bigPipeNoJS && !$this->getSession()->getCookie(BigPipeStrategy::NOJS_COOKIE)) {
         $this
           ->getSession()
-          ->setCookie(BigPipeStrategy::NOJS_COOKIE, '1');
+          ->setCookie(BigPipeStrategy::NOJS_COOKIE, 'true');
       }
     }
     catch (DriverException $e) {
-      // Mute not visited page.
+      // Mute not visited page exception.
     }
   }
 

--- a/src/BigPipeTrait.php
+++ b/src/BigPipeTrait.php
@@ -3,6 +3,7 @@
 namespace DrevOps\BehatSteps;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Drupal\big_pipe\Render\Placeholder\BigPipeStrategy;
 
@@ -12,6 +13,13 @@ use Drupal\big_pipe\Render\Placeholder\BigPipeStrategy;
  * Behat trait for handling BigPipe functionality.
  */
 trait BigPipeTrait {
+
+  /**
+   * Flag for JS not supported by driver.
+   *
+   * @var bool
+   */
+  protected $bigPipeNoJS;
 
   /**
    * Prepares Big Pipe NOJS cookie if needed.
@@ -36,14 +44,26 @@ trait BigPipeTrait {
         $driver->start();
       }
       $driver->executeScript('true');
+      $this->bigPipeNoJS = FALSE;
     }
     catch (UnsupportedDriverActionException $e) {
-      $this
-        ->getSession()
-        ->setCookie(BigPipeStrategy::NOJS_COOKIE, 'true');
+      $this->bigPipeNoJS = TRUE;
     }
     catch (\Exception $e) {
       // Mute exceptions.
+    }
+  }
+
+  /**
+   * Prepares Big Pipe NO JS cookie if needed.
+   *
+   * @BeforeStep
+   */
+  public function bigPipeBeforeStep(BeforeStepScope $scope) {
+    if ($this->bigPipeNoJS) {
+      $this
+        ->getSession()
+        ->setCookie(BigPipeStrategy::NOJS_COOKIE, '1');
     }
   }
 

--- a/tests/behat/features/big_pipe.feature
+++ b/tests/behat/features/big_pipe.feature
@@ -18,12 +18,10 @@ Feature: Check that BigPipeTrait works for or D9
     Given users:
       | name                        | mail                                      | roles         | status |
       | administrator_user          | administrator_user@myexample.com          | administrator | 1      |
-      | authenticated_user          | authenticated_user@myexample.com          |               | 1      |
     And I install a "big_pipe" module
-    And I am logged in as "administrator_user"
     When I visit "/"
     Then cookie "big_pipe_nojs" exists
-    And I am logged in as "authenticated_user"
+    And I am logged in as "administrator_user"
     And I visit "/"
     Then cookie "big_pipe_nojs" exists
 

--- a/tests/behat/features/big_pipe.feature
+++ b/tests/behat/features/big_pipe.feature
@@ -14,7 +14,7 @@ Feature: Check that BigPipeTrait works for or D9
     Then cookie "big_pipe_nojs" does not exist
 
   @api
-  Scenario: Assert that Big Pipe cookie is set when user logs into multiple users in a scenario
+  Scenario: Assert that Big Pipe cookie is preserved across multiple users in a scenario
     Given users:
       | name                        | mail                                      | roles         | status |
       | administrator_user          | administrator_user@myexample.com          | administrator | 1      |
@@ -26,7 +26,7 @@ Feature: Check that BigPipeTrait works for or D9
     Then cookie "big_pipe_nojs" exists
 
   @api @behat-steps-skip:bigPipeBeforeStep
-  Scenario: Assert that Big Pipe cookie is not set when user logs into multiple users when skip tag is used
+  Scenario: Assert that Big Pipe cookie is not preserved across multiple users when skip tag is used
     Given users:
       | name                        | mail                                      | roles         | status |
       | administrator_user          | administrator_user@myexample.com          | administrator | 1      |

--- a/tests/behat/features/big_pipe.feature
+++ b/tests/behat/features/big_pipe.feature
@@ -12,3 +12,30 @@ Feature: Check that BigPipeTrait works for or D9
     Given I install a "big_pipe" module
     When I visit "/"
     Then cookie "big_pipe_nojs" does not exist
+
+  @api
+  Scenario: Assert that Big Pipe cookie is set when user logs into multiple users in a scenario
+    Given users:
+      | name                        | mail                                      | roles         | status |
+      | administrator_user          | administrator_user@myexample.com          | administrator | 1      |
+      | authenticated_user          | authenticated_user@myexample.com          |               | 1      |
+    And I install a "big_pipe" module
+    And I am logged in as "administrator_user"
+    When I visit "/"
+    Then cookie "big_pipe_nojs" exists
+    And I am logged in as "authenticated_user"
+    And I visit "/"
+    Then cookie "big_pipe_nojs" exists
+
+  @api @behat-steps-skip:bigPipeBeforeStep
+  Scenario: Assert that Big Pipe cookie is not set when user logs into multiple users when skip tag is used
+    Given users:
+      | name                        | mail                                      | roles         | status |
+      | administrator_user          | administrator_user@myexample.com          | administrator | 1      |
+    And I install a "big_pipe" module
+    When I visit "/"
+    Then cookie "big_pipe_nojs" exists
+    # Logging in as a new user removes cookies.
+    And I am logged in as "administrator_user"
+    When I visit "/"
+    Then cookie "big_pipe_nojs" does not exist


### PR DESCRIPTION
Issue link: https://github.com/drevops/behat-steps/issues/132

**Background**
Bigpipe trait adds nojs cookie on a BeforeScenario hook but when we log into sessions within a scenario, cookies are cleared with the new session.

**What has changed**
1. Changed BeforeScenario to a check for whether bigpipe is turned on and whether we are using a JS capable driver
1. Added a BeforeStep hook to set the cookie if required