### PR TITLE
[#212] Fixed `When I go to my profile edit page`.

### DIFF
--- a/src/UserTrait.php
+++ b/src/UserTrait.php
@@ -28,17 +28,19 @@ trait UserTrait {
   /**
    * Visit edit page of the current user.
    *
-   * @When I go to my edit profile page
+   * @When I go to my profile edit page
    */
   public function userVisitOwnProfile(): void {
-    /** @var \Drupal\user\UserInterface $user */
     $user = $this->getUserManager()->getCurrentUser();
 
-    if (!$user instanceof UserInterface) {
+    if ($user instanceof \stdClass) {
+      $id = $user->uid;
+    }
+    else {
       throw new \RuntimeException('Require user to login before visiting profile page.');
     }
 
-    $this->userVisitProfile($user->getAccountName());
+    $this->visitPath("/user/$id/edit");
   }
 
   /**

--- a/tests/behat/features/user.feature
+++ b/tests/behat/features/user.feature
@@ -20,6 +20,12 @@ Feature: Check that UserTrait works for or D9
     Then I should get a 200 HTTP response
 
   @api
+  Scenario: Assert "When I go to my profile edit page"
+    Given I am logged in as a user with the "administrator" role
+    When I go to my profile edit page
+    Then I should get a 200 HTTP response
+
+  @api
   Scenario: Assert "Given no users:" by name
     Given I am logged in as a user with the "administrator" role
     When I visit user "authenticated_user" profile


### PR DESCRIPTION
closes #212 

BC 💥 
`When I go to my edit profile page` -> `When I go to my profile edit page`