### PR TITLE
Email Trait idempotency fixes.

### DIFF
--- a/src/EmailTrait.php
+++ b/src/EmailTrait.php
@@ -43,6 +43,10 @@ trait EmailTrait {
       return;
     }
 
+    if (!$scope->getScenario()->hasTag('email')) {
+      return;
+    }
+
     if ($scope->getScenario()->hasTag('debug')) {
       $this->emailDebug = TRUE;
     }
@@ -106,11 +110,10 @@ trait EmailTrait {
   public function emailDisableTestEmailSystem(): void {
     foreach ($this->emailTypes as $type) {
       $original_test_system = self::emailGetMailSystemOriginal($type);
-      self::emailDeleteMailSystemOriginal();
       // Restore the original system to after the scenario.
       self::emailSetMailSystemDefault($type, $original_test_system);
     }
-
+    self::emailDeleteMailSystemOriginal();
     self::emailClearTestEmailSystemQueue(TRUE);
   }
 


### PR DESCRIPTION
The email trait doesn't check for the email tag before initialising in emailBeforeScenarioEnableTestEmailSystem. Depending on how scenarios are written and ordered, this will most likely result in the Drupal installation still having the test_mail_collector configured post run.

In addition, emailDisableTestEmailSystem invokes emailDeleteMailSystemOriginal inside the foreach instead of afterwards, preventing the correct restoration of config for second and subsequent email types.
