### PR TITLE
Fixed methods prefixes.

### DIFF
--- a/src/BlockContentTrait.php
+++ b/src/BlockContentTrait.php
@@ -179,8 +179,8 @@ trait BlockContentTrait {
    * @endcode
    */
   public function blockContentCreate(string $type, TableNode $block_content_table): void {
-    foreach ($block_content_table->getHash() as $blockContentHash) {
-      $this->createBlockContent($type, $blockContentHash);
+    foreach ($block_content_table->getHash() as $hash) {
+      $this->blockContentCreateSingle($type, $hash);
     }
   }
 
@@ -209,7 +209,7 @@ trait BlockContentTrait {
    *
    * @SuppressWarnings(PHPMD.StaticAccess)
    */
-  protected function createBlockContent(string $type, array $values): BlockContent {
+  protected function blockContentCreateSingle(string $type, array $values): BlockContent {
     $block_content = (object) $values;
     $block_content->type = $type;
     $this->parseEntityFields('block_content', $block_content);

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -96,7 +96,7 @@ trait FieldTrait {
    * @When I fill color in :field with :value
    * @When I fill in the color field :field with the value :value
    */
-  public function fillColorField(string $field, ?string $value = NULL): mixed {
+  public function fieldFillColor(string $field, ?string $value = NULL): mixed {
     $js = <<<JS
         (function() {
             var element = document.querySelector('{$field}');
@@ -116,7 +116,7 @@ JS;
    *
    * @Then the color field :field should have the value :value
    */
-  public function assertColorFieldHasValue(string $field, string $value): void {
+  public function fieldAssertColorFieldHasValue(string $field, string $value): void {
     $js = <<<JS
         (function() {
             var element = document.querySelector('{$field}');
@@ -141,9 +141,9 @@ JS;
    *
    * @When I fill in the WYSIWYG field :field with the :value
    */
-  public function wysiwygFillField(string $field, string $value): void {
-    $field = $this->wysiwygFixStepArgument($field);
-    $value = $this->wysiwygFixStepArgument($value);
+  public function fieldFillWysiwyg(string $field, string $value): void {
+    $field = $this->fieldFixStepArgument($field);
+    $value = $this->fieldFixStepArgument($value);
 
     $page = $this->getSession()->getPage();
     $element = $page->findField($field);
@@ -199,7 +199,7 @@ JS;
   /**
    * Returns fixed step argument (with \\" replaced back to ").
    */
-  protected function wysiwygFixStepArgument(string $argument): string {
+  protected function fieldFixStepArgument(string $argument): string {
     return str_replace('\\"', '"', $argument);
   }
 

--- a/src/JsTrait.php
+++ b/src/JsTrait.php
@@ -121,7 +121,7 @@ trait JsTrait {
    *
    * @When I scroll to the element :selector
    */
-  public function iScrollToElement(string $selector): void {
+  public function jsScrollToElement(string $selector): void {
     $this->getSession()->executeScript("
       var element = document.querySelector('" . $selector . "');
       element.scrollIntoView( true );
@@ -133,7 +133,7 @@ trait JsTrait {
    *
    * @Then the element :selector should be at the top of the viewport
    */
-  public function assertElementAtTopOfViewport(string $selector): void {
+  public function jsAssertElementAtTopOfViewport(string $selector): void {
     $script = <<<JS
         (function() {
             var element = document.querySelector('{$selector}');

--- a/src/LinkTrait.php
+++ b/src/LinkTrait.php
@@ -168,7 +168,7 @@ trait LinkTrait {
    *
    * @Then the link :link should be an absolute link
    */
-  public function assertLinkAbsolute(string $text): void {
+  public function linkAssertLinkAbsolute(string $text): void {
     $link = $this->getSession()->getPage()->findLink($text);
     if (!$link) {
       throw new \Exception(sprintf('The link "%s" is not found', $text));
@@ -188,7 +188,7 @@ trait LinkTrait {
    *
    * @Then the link :link should not be an absolute link
    */
-  public function assertLinkNotAbsolute(string $text): void {
+  public function linkAssertLinkNotAbsolute(string $text): void {
     $link = $this->getSession()->getPage()->findLink($text);
     if (!$link) {
       throw new \Exception(sprintf('The link "%s" is not found', $text));

--- a/steps.md
+++ b/steps.md
@@ -617,6 +617,21 @@ When I visit eck "contact" "contact_type" entity with the title "Test contact"
 
 [Source](src/FieldTrait.php), [Example](tests/behat/features/field.feature)
 
+#### Fills value for color field
+
+```gherkin
+@When I fill color in :field with :value
+```
+```gherkin
+@When I fill in the color field :field with the value :value
+```
+
+#### Set value for WYSIWYG field
+
+```gherkin
+@When I fill in the WYSIWYG field :field with the :value
+```
+
 #### Assert that field exists on the page using id,name,label or value
 
 ```gherkin
@@ -650,6 +665,12 @@ Then the field "Body" should be "disabled"
 Then the field "field_body" should be "disabled"
 Then the field "Tags" should be "enabled"
 Then the field "field_tags" should be "not enabled"
+```
+
+#### Asserts that a color field has a value
+
+```gherkin
+@Then the color field :field should have the value :value
 ```
 
 ### FileDownloadTrait
@@ -807,6 +828,18 @@ When I click on the element ".button"
 @When I trigger the JS event :event on the element :selector
 ```
 
+#### Scroll to an element with ID
+
+```gherkin
+@When I scroll to the element :selector
+```
+
+#### Assert the element :selector should be at the top of the viewport
+
+```gherkin
+@Then the element :selector should be at the top of the viewport
+```
+
 ### KeyboardTrait
 
 [Source](src/KeyboardTrait.php), [Example](tests/behat/features/keyboard.feature)
@@ -891,6 +924,26 @@ Then the link with the title "Return to site content" should exist
 Example:
 ```gherkin
 Then the link with the title "Some non-existing title" should not exist
+```
+
+#### Assert that the link with a text is absolute
+
+```gherkin
+@Then the link :link should be an absolute link
+```
+Example:
+```gherkin
+Then the link "Drupal" should be an absolute link
+```
+
+#### Assert that the link is not an absolute
+
+```gherkin
+@Then the link :link should not be an absolute link
+```
+Example:
+```gherkin
+Then the link "Return to site content" should not be an absolute link
 ```
 
 ### MediaTrait


### PR DESCRIPTION
Fixed method prefixes to start with the trait name. We use this to namespace methods in order to avoid collisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated method names across various features for improved consistency and clarity. No changes to end-user functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->