### PR TITLE
[#402] Fixed path trait failing on `<front>`.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -1040,6 +1040,7 @@ Assert that the current page is a specified path
 
 ```gherkin
 Then the path should be "/about-us"
+Then the path should be "/"
 Then the path should be "<front>"
 
 ```
@@ -1055,6 +1056,7 @@ Assert that the current page is not a specified path
 
 ```gherkin
 Then the path should not be "/about-us"
+Then the path should not be "/"
 Then the path should not be "<front>"
 
 ```

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -19,6 +19,7 @@ trait PathTrait {
    *
    * @code
    * Then the path should be "/about-us"
+   * Then the path should be "/"
    * Then the path should be "<front>"
    * @endcode
    *
@@ -37,9 +38,10 @@ trait PathTrait {
       throw new \Exception('Current path is not a valid URL');
     }
 
-    $current_path = $current_path === '' ? '<front>' : $current_path;
+    $normalized_current_path = ($current_path === '' || $current_path === '/') ? '<front>' : $current_path;
+    $normalized_path = ($path === '/' || $path === '<front>') ? '<front>' : $path;
 
-    if (ltrim((string) $current_path, '/') !== ltrim($path, '/')) {
+    if (ltrim((string) $normalized_current_path, '/') !== ltrim($normalized_path, '/')) {
       throw new \Exception(sprintf('Current path is "%s", but expected is "%s"', $current_path, $path));
     }
   }
@@ -51,6 +53,7 @@ trait PathTrait {
    *
    * @code
    * Then the path should not be "/about-us"
+   * Then the path should not be "/"
    * Then the path should not be "<front>"
    * @endcode
    *
@@ -69,10 +72,11 @@ trait PathTrait {
       throw new \Exception('Current path is not a valid URL');
     }
 
-    $current_path = $current_path === '/' ? '<front>' : $current_path;
+    $normalized_current_path = ($current_path === '' || $current_path === '/') ? '<front>' : $current_path;
+    $normalized_path = ($path === '/' || $path === '<front>') ? '<front>' : $path;
 
-    if (ltrim((string) $current_path, '/') === ltrim($path, '/')) {
-      throw new \Exception(sprintf('Current path should not be "%s"', $current_path));
+    if (ltrim((string) $normalized_current_path, '/') === ltrim($normalized_path, '/')) {
+      throw new \Exception(sprintf('Current path should not be "%s"', $path));
     }
 
     return TRUE;

--- a/tests/behat/features/path.feature
+++ b/tests/behat/features/path.feature
@@ -4,31 +4,32 @@ Feature: Check that PathTrait works
   So that I can verify proper URL paths in my application
 
   @api
-  Scenario: User is at the path without prefixed slash.
+  Scenario Outline: Assert that the path is the same as the given path
     Given I am an anonymous user
-    When I go to "user/login"
-    Then the path should be "user/login"
+    When I go to "<src>"
+    Then the path should be "<dst>"
+    Examples:
+      | src         | dst         |
+      | /           | /           |
+      | /           | <front>     |
+      | <front>     | /           |
+      | <front>     | <front>     |
+      | /user/login | /user/login |
+      | user/login  | user/login  |
 
   @api
-  Scenario: User is at the path with prefixed slash
+  Scenario Outline: Assert that the path is not the same as the given path
     Given I am an anonymous user
-    When I go to "/user/login"
-    Then the path should be "/user/login"
-
-  @api
-  Scenario: User is at the '<front>' path.
-    Given I am an anonymous user
-    When I go to "/"
-    Then the path should be "/"
-
-  @api
-  Scenario: Current page is not specified path.
-    Given I am an anonymous user
-    When I go to "/user/login"
-    Then the path should be "/user/login"
-
-    When I go to "/"
-    Then the path should not be "/user/login"
+    When I go to "<src>"
+    Then the path should not be "<dst>"
+    Examples:
+      | src     | dst     |
+      | /       | /user   |
+      | /user   | /       |
+      | user    | /       |
+      | <front> | /user   |
+      | /user   | <front> |
+      | user    | <front> |
 
   @trait:PathTrait
   Scenario: Assert that negative assertion for "Then the path should be :path" fails
@@ -46,6 +47,36 @@ Feature: Check that PathTrait works
       """
 
   @trait:PathTrait
+  Scenario: Assert that negative assertion for "Then the path should be :path" fails for "<front>"
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I go to "/user/login"
+      Then the path should be "<front>"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Current path is "/user/login", but expected is "<front>"
+      """
+
+  @trait:PathTrait
+  Scenario: Assert that negative assertion for "Then the path should be :path" fails for "/"
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I go to "/user/login"
+      Then the path should be "/"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Current path is "/user/login", but expected is "/"
+      """
+
+  @trait:PathTrait
   Scenario: Assert that negative assertion for "Then the path should not be :path" fails
     Given some behat configuration
     And scenario steps:
@@ -58,6 +89,36 @@ Feature: Check that PathTrait works
     Then it should fail with an error:
       """
       Current path should not be "/user/login"
+      """
+
+  @trait:PathTrait
+  Scenario: Assert that negative assertion for "Then the path should not be :path" fails for "/"
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I go to "/"
+      Then the path should not be "/"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Current path should not be "/"
+      """
+
+  @trait:PathTrait
+  Scenario: Assert that negative assertion for "Then the path should not be :path" fails for "<front>"
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I go to "/"
+      Then the path should not be "<front>"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Current path should not be "<front>"
       """
 
   @api


### PR DESCRIPTION
closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the root path ("/") and "<front>" so they are treated as equivalent in path assertions.
  - Updated error messages to display the original input path for clearer feedback.

- **Tests**
  - Enhanced and expanded test coverage for path assertions, including new scenarios for both matching and non-matching cases with "/", "<front>", and related edge cases.

- **Documentation**
  - Updated examples to include the root path ("/") as a valid option for path assertion steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->