### PR TITLE
Removed periods from the scenarios in tests.

### DIFF
--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -4,7 +4,7 @@ Feature: Check that ContentTrait works
   So that users can test content functionality reliably
 
   @api
-  Scenario: Assert "@Given the content type :content_type does not exist" works as expected.
+  Scenario: Assert "@Given the content type :content_type does not exist" works as expected
     Given I am logged in as a user with the "administrator" role
     When I visit "/admin/structure/types/add"
     And I fill in "Name" with "test_content_type"
@@ -17,14 +17,14 @@ Feature: Check that ContentTrait works
     Then I should not see "test_content_type"
 
   @api
-  Scenario: Assert "@Given the content type :content_type does not exist" works as expected on non-existing content type.
+  Scenario: Assert "@Given the content type :content_type does not exist" works as expected on non-existing content type
     Given the content type "test_content_type" does not exist
     And I am logged in as a user with the "administrator" role
     When I visit "/admin/structure/types"
     Then I should not see "test_content_type"
 
   @api
-  Scenario: Assert "@Given the following :content_type content does not exist:" works as expected.
+  Scenario: Assert "@Given the following :content_type content does not exist:" works as expected
     Given page content:
       | title              |
       | [TEST] Page title1 |
@@ -44,7 +44,7 @@ Feature: Check that ContentTrait works
     Then I should get a 404 HTTP response
 
   @api
-  Scenario: Assert "When I visit the :content_type content page with the title :title" works as expected.
+  Scenario: Assert "When I visit the :content_type content page with the title :title" works as expected
     Given page content:
       | title             |
       | [TEST] Page title |
@@ -53,7 +53,7 @@ Feature: Check that ContentTrait works
     Then I should see "[TEST] Page title"
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I visit the :content_type content page with the title :title" works as expected for non-existing content type.
+  Scenario: Assert negative "When I visit the :content_type content page with the title :title" works as expected for non-existing content type
     Given some behat configuration
     And scenario steps:
       """
@@ -67,7 +67,7 @@ Feature: Check that ContentTrait works
       """
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I visit the :content_type content page with the title :title" works as expected for non-existing content.
+  Scenario: Assert negative "When I visit the :content_type content page with the title :title" works as expected for non-existing content
     Given some behat configuration
     And scenario steps:
       """
@@ -81,7 +81,7 @@ Feature: Check that ContentTrait works
       """
 
   @api
-  Scenario: Assert "When I visit the :content_type content edit page with the title :title" works as expected.
+  Scenario: Assert "When I visit the :content_type content edit page with the title :title" works as expected
     Given page content:
       | title             |
       | [TEST] Page title |
@@ -90,7 +90,7 @@ Feature: Check that ContentTrait works
     Then I should see "[TEST] Page title"
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I visit the :content_type content edit page with the title :title" works as expected for non-existing content type.
+  Scenario: Assert negative "When I visit the :content_type content edit page with the title :title" works as expected for non-existing content type
     Given some behat configuration
     And scenario steps:
       """
@@ -104,7 +104,7 @@ Feature: Check that ContentTrait works
       """
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I visit the :content_type content edit page with the title :title" works as expected for non-existing content.
+  Scenario: Assert negative "When I visit the :content_type content edit page with the title :title" works as expected for non-existing content
     Given some behat configuration
     And scenario steps:
       """
@@ -118,7 +118,7 @@ Feature: Check that ContentTrait works
       """
 
   @api
-  Scenario: Assert "When I visit the :content_type content delete page with the title :title" works as expected.
+  Scenario: Assert "When I visit the :content_type content delete page with the title :title" works as expected
     Given page content:
       | title             |
       | [TEST] Page title |
@@ -127,7 +127,7 @@ Feature: Check that ContentTrait works
     Then I should see "[TEST] Page title"
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I visit the :content_type content delete page with the title :title" works as expected for non-existing content type.
+  Scenario: Assert negative "When I visit the :content_type content delete page with the title :title" works as expected for non-existing content type
     Given some behat configuration
     And scenario steps:
       """
@@ -141,7 +141,7 @@ Feature: Check that ContentTrait works
       """
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I visit the :content_type content delete page with the title :title" works as expected for non-existing content.
+  Scenario: Assert negative "When I visit the :content_type content delete page with the title :title" works as expected for non-existing content
     Given some behat configuration
     And scenario steps:
       """
@@ -155,7 +155,7 @@ Feature: Check that ContentTrait works
       """
 
   @api
-  Scenario: Assert "When I visit the :content_type content scheduled transitions page with the title :title" works as expected.
+  Scenario: Assert "When I visit the :content_type content scheduled transitions page with the title :title" works as expected
     Given page content:
       | title             |
       | [TEST] Page title |
@@ -164,7 +164,7 @@ Feature: Check that ContentTrait works
     Then I should see "[TEST] Page title"
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I visit the :content_type content scheduled transitions page with the title :title" works as expected for non-existing content type.
+  Scenario: Assert negative "When I visit the :content_type content scheduled transitions page with the title :title" works as expected for non-existing content type
     Given some behat configuration
     And scenario steps:
       """
@@ -178,7 +178,7 @@ Feature: Check that ContentTrait works
       """
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I visit the :content_type content scheduled transitions page with the title :title" works as expected for non-existing content.
+  Scenario: Assert negative "When I visit the :content_type content scheduled transitions page with the title :title" works as expected for non-existing content
     Given some behat configuration
     And scenario steps:
       """
@@ -192,7 +192,7 @@ Feature: Check that ContentTrait works
       """
 
   @api
-  Scenario: Assert "When I change the moderation state of the :content_type content with the title :title to the :new_state state" works as expected.
+  Scenario: Assert "When I change the moderation state of the :content_type content with the title :title to the :new_state state" works as expected
     Given page content:
       | title             | moderation_state |
       | [TEST] Page title | draft            |
@@ -204,7 +204,7 @@ Feature: Check that ContentTrait works
     Then the response status code should be 200
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I change the moderation state of the :content_type content with the title :title to the :new_state state" works as expected for non-existing content type.
+  Scenario: Assert negative "When I change the moderation state of the :content_type content with the title :title to the :new_state state" works as expected for non-existing content type
     Given some behat configuration
     And scenario steps:
       """
@@ -218,7 +218,7 @@ Feature: Check that ContentTrait works
       """
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I change the moderation state of the :content_type content with the title :title to the :new_state state" works as expected for non-existing content.
+  Scenario: Assert negative "When I change the moderation state of the :content_type content with the title :title to the :new_state state" works as expected for non-existing content
     Given some behat configuration
     And scenario steps:
       """
@@ -232,7 +232,7 @@ Feature: Check that ContentTrait works
       """
 
   @trait:Drupal\ContentTrait
-  Scenario: Assert negative "When I change the moderation state of the :content_type content with the title :title to the :new_state state" works as expected for a node without moderation state enabled.
+  Scenario: Assert negative "When I change the moderation state of the :content_type content with the title :title to the :new_state state" works as expected for a node without moderation state enabled
     Given some behat configuration
     And scenario steps:
       """

--- a/tests/behat/features/drupal_eck.feature
+++ b/tests/behat/features/drupal_eck.feature
@@ -15,14 +15,14 @@ Feature: Check that EckTrait works
       | [TEST] ECK test1 | Test text field | T2                   |
 
   @api
-  Scenario: Assert "I visit eck :bundle :entity_type entity with the title :title" works as expected.
+  Scenario: Assert "I visit eck :bundle :entity_type entity with the title :title" works as expected
     Given I am logged in as a user with the "administrator" role
     When I visit eck "test_bundle" "test_entity_type" entity with the title "[TEST] ECK test1"
     Then I should see "[TEST] ECK test1"
     And I should see "T2"
 
   @api @trait:Drupal\EckTrait
-  Scenario: Assert navigate "I visit eck :bundle :entity_type entity with the title :title" works as expected.
+  Scenario: Assert navigate "I visit eck :bundle :entity_type entity with the title :title" works as expected
     Given some behat configuration
     And scenario steps:
       """
@@ -36,13 +36,13 @@ Feature: Check that EckTrait works
       """
 
   @api
-  Scenario: Assert "When I edit eck :bundle :entity_type entity with the title :title" works as expected.
+  Scenario: Assert "When I edit eck :bundle :entity_type entity with the title :title" works as expected
     Given I am logged in as a user with the "administrator" role
     When I edit eck "test_bundle" "test_entity_type" entity with the title "[TEST] ECK test1"
     Then I should see "Edit test bundle [TEST] ECK test1"
 
   @api @trait:Drupal\EckTrait
-  Scenario: Assert negative "When I edit eck :bundle :entity_type entity with the title :title" works as expected.
+  Scenario: Assert negative "When I edit eck :bundle :entity_type entity with the title :title" works as expected
     Given some behat configuration
     And scenario steps:
       """

--- a/tests/behat/features/drupal_email.feature
+++ b/tests/behat/features/drupal_email.feature
@@ -162,7 +162,7 @@ Feature: Check that EmailTrait works
       """
 
   @api @email
-  Scenario: As a developer, I want to know that test email system is activated as before and after scenario steps.
+  Scenario: As a developer, I want to know that test email system is activated as before and after scenario steps
     Given I send test email to "test@example.com" with
       """
       Line one of the test email content
@@ -180,7 +180,7 @@ Feature: Check that EmailTrait works
       """
 
   @api @email
-  Scenario: As a developer, I want to know that test email system queue clearing step is working.
+  Scenario: As a developer, I want to know that test email system queue clearing step is working
     Given I enable the test email system
     And I send test email to "test@example.com" with
       """
@@ -240,7 +240,7 @@ Feature: Check that EmailTrait works
     Then I should be on "https://example.com/reset-password"
 
   @api @email
-  Scenario: As a developer, I want to know that no emails assertions works as expected.
+  Scenario: As a developer, I want to know that no emails assertions works as expected
     Given no emails should have been sent
     When I send test email to "test@example.com" with
       """
@@ -308,7 +308,7 @@ Feature: Check that EmailTrait works
     And the file "example.pdf" should be attached to the email with the subject containing "with Attachment"
 
   @trait:Drupal\EmailTrait
-  Scenario: Assert that an email was sent to an address.
+  Scenario: Assert that an email was sent to an address
     Given some behat configuration
     And scenario steps tagged with "@api @email":
       """

--- a/tests/behat/features/drupal_media.feature
+++ b/tests/behat/features/drupal_media.feature
@@ -60,7 +60,7 @@ Feature: Check that MediaTrait works
     Then I should not see "test_media_type"
 
   @api @trait:Drupal\MediaTrait
-  Scenario: Assert that negative assertion for "When I edit the media :media_type with the name :name" fails with an error.
+  Scenario: Assert that negative assertion for "When I edit the media :media_type with the name :name" fails with an error
     Given some behat configuration
     And scenario steps:
       """

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -234,7 +234,7 @@ Feature: Check that ElementTrait works
     Then I should see the button "You canceled!"
 
   @javascript @phpserver
-  Scenario: Assert scroll to an element with selector.
+  Scenario: Assert scroll to an element with selector
     Given I am on the phpserver test page
     When I scroll to the element "#main-inner"
     Then the element "#main-inner" should be at the top of the viewport

--- a/tests/behat/features/field.feature
+++ b/tests/behat/features/field.feature
@@ -40,14 +40,14 @@ Feature: Check that FieldTrait works
       | Field 3        | disabled            |
 
   @api @javascript
-  Scenario: Assert fills in form color field with specified id|name|label|value.
+  Scenario: Assert fills in form color field with specified id|name|label|value
     When I visit "/sites/default/files/relative.html"
     Then the color field "#edit-color-input" should have the value "#000000"
     When I fill in the color field "#edit-color-input" with the value "#ffffff"
     Then the color field "#edit-color-input" should have the value "#ffffff"
 
   @api @javascript
-  Scenario: Assert fills in form color field with specified id|name|label|value using an alternate step definition.
+  Scenario: Assert fills in form color field with specified id|name|label|value using an alternate step definition
     When I visit "/sites/default/files/relative.html"
     Then the color field "#edit-color-input" should have the value "#000000"
     When I fill in the color field "#edit-color-input" with the value "#ffffff"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Removed trailing periods from scenario titles in multiple Behat feature files for improved consistency and readability. No changes were made to scenario steps or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->