### PR TITLE
[#416] Added `When I visit the :vocabulary_machine_name term delete page with the name :term_name`

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -2486,42 +2486,42 @@ Given the following "fruits" vocabulary terms do not exist:
 </details>
 
 <details>
-  <summary><code>@When I visit the :vocabulary_machine_name vocabulary :term_name term page</code></summary>
+  <summary><code>@When I visit the :vocabulary_machine_name term page with the name :term_name</code></summary>
 
 <br/>
 Visit specified vocabulary term page
 <br/><br/>
 
 ```gherkin
-When I visit the "fruits" vocabulary "Apple" term page
+When I visit the "fruits" term page with the name "Apple"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@When I edit the :vocabulary_machine_name vocabulary :term_name term page</code></summary>
+  <summary><code>@When I visit the :vocabulary_machine_name term edit page with the name :term_name</code></summary>
 
 <br/>
-Edit specified vocabulary term page
+Visit specified vocabulary term edit page
 <br/><br/>
 
 ```gherkin
-When I edit the "fruits" vocabulary "Apple" term page
+When I visit the "fruits" term edit page with the name "Apple"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@When I delete the :vocabulary_machine_name vocabulary :term_name term page</code></summary>
+  <summary><code>@When I visit the :vocabulary_machine_name term delete page with the name :term_name</code></summary>
 
 <br/>
-Remove taxonomy term
+Visit specified vocabulary term delete page
 <br/><br/>
 
 ```gherkin
-When I delete the "tags" vocabulary "[TEST] Remove" term page
+When I visit the "tags" term delete page with the name "[TEST] Remove"
 
 ```
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -2514,6 +2514,20 @@ When I edit the "fruits" vocabulary "Apple" term page
 </details>
 
 <details>
+  <summary><code>@When I delete the :vocabulary_machine_name vocabulary :term_name term page</code></summary>
+
+<br/>
+Remove taxonomy term
+<br/><br/>
+
+```gherkin
+When I delete the "tags" vocabulary "[TEST] Remove" term page
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the vocabulary :machine_name with the name :name should exist</code></summary>
 
 <br/>

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -162,27 +162,7 @@ trait TaxonomyTrait {
    * @When I visit the :vocabulary_machine_name term page with the name :term_name
    */
   public function taxonomyVisitTermPageWithName(string $vocabulary_machine_name, string $term_name): void {
-    $vocab = Vocabulary::load($vocabulary_machine_name);
-
-    if (!$vocab) {
-      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
-    }
-
-    $tids = $this->taxonomyLoadMultiple($vocabulary_machine_name, [
-      'name' => $term_name,
-    ]);
-
-    if (empty($tids)) {
-      throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
-    }
-
-    // Use the term created last.
-    ksort($tids);
-    $tid = end($tids);
-
-    $path = $this->locatePath('/taxonomy/term/' . $tid);
-
-    $this->getSession()->visit($path);
+    $this->taxonomyVisitActionPageWithName($vocabulary_machine_name, $term_name);
   }
 
   /**
@@ -195,26 +175,7 @@ trait TaxonomyTrait {
    * @When I visit the :vocabulary_machine_name term edit page with the name :term_name
    */
   public function taxonomyVisitTermEditPageWithName(string $vocabulary_machine_name, string $term_name): void {
-    $vocab = Vocabulary::load($vocabulary_machine_name);
-
-    if (!$vocab) {
-      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
-    }
-
-    $tids = $this->taxonomyLoadMultiple($vocabulary_machine_name, [
-      'name' => $term_name,
-    ]);
-
-    if (empty($tids)) {
-      throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
-    }
-
-    ksort($tids);
-    $tid = end($tids);
-
-    $path = $this->locatePath('/taxonomy/term/' . $tid . '/edit');
-
-    $this->getSession()->visit($path);
+    $this->taxonomyVisitActionPageWithName($vocabulary_machine_name, $term_name, '/edit');
   }
 
   /**
@@ -227,6 +188,20 @@ trait TaxonomyTrait {
    * @When I visit the :vocabulary_machine_name term delete page with the name :term_name
    */
   public function taxonomyVisitTermDeletePageWithName(string $vocabulary_machine_name, string $term_name): void {
+    $this->taxonomyVisitActionPageWithName($vocabulary_machine_name, $term_name, '/delete');
+  }
+
+  /**
+   * Visit the action page of the term with a specified name.
+   *
+   * @param string $vocabulary_machine_name
+   *   The term vocabulary machine name.
+   * @param string $term_name
+   *   The name of the term.
+   * @param string $action_subpath
+   *   The operation to perform, e.g., '/delete', '/edit', etc.
+   */
+  protected function taxonomyVisitActionPageWithName(string $vocabulary_machine_name, string $term_name, string $action_subpath = ''): void {
     $vocab = Vocabulary::load($vocabulary_machine_name);
 
     if (!$vocab) {
@@ -244,7 +219,7 @@ trait TaxonomyTrait {
     ksort($tids);
     $tid = end($tids);
 
-    $path = $this->locatePath('/taxonomy/term/' . $tid . '/delete');
+    $path = $this->locatePath('/taxonomy/term/' . $tid . $action_subpath);
 
     $this->getSession()->visit($path);
   }

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -156,10 +156,10 @@ trait TaxonomyTrait {
    * Visit specified vocabulary term page.
    *
    * @code
-   * When I visit the "fruits" vocabulary "Apple" term page
+   * When I visit the "fruits" term page with the name "Apple"
    * @endcode
    *
-   * @When I visit the :vocabulary_machine_name vocabulary :term_name term page
+   * @When I visit the :vocabulary_machine_name term page with the name :term_name
    */
   public function taxonomyVisitTermPageWithName(string $vocabulary_machine_name, string $term_name): void {
     $vocab = Vocabulary::load($vocabulary_machine_name);
@@ -186,15 +186,15 @@ trait TaxonomyTrait {
   }
 
   /**
-   * Edit specified vocabulary term page.
+   * Visit specified vocabulary term edit page.
    *
    * @code
-   * When I edit the "fruits" vocabulary "Apple" term page
+   * When I visit the "fruits" term edit page with the name "Apple"
    * @endcode
    *
-   * @When I edit the :vocabulary_machine_name vocabulary :term_name term page
+   * @When I visit the :vocabulary_machine_name term edit page with the name :term_name
    */
-  public function taxonomyEditTermPageWithName(string $vocabulary_machine_name, string $term_name): void {
+  public function taxonomyVisitTermEditPageWithName(string $vocabulary_machine_name, string $term_name): void {
     $vocab = Vocabulary::load($vocabulary_machine_name);
 
     if (!$vocab) {
@@ -213,6 +213,38 @@ trait TaxonomyTrait {
     $tid = end($tids);
 
     $path = $this->locatePath('/taxonomy/term/' . $tid . '/edit');
+
+    $this->getSession()->visit($path);
+  }
+
+  /**
+   * Visit specified vocabulary term delete page.
+   *
+   * @code
+   * When I visit the "tags" term delete page with the name "[TEST] Remove"
+   * @endcode
+   *
+   * @When I visit the :vocabulary_machine_name term delete page with the name :term_name
+   */
+  public function taxonomyVisitTermDeletePageWithName(string $vocabulary_machine_name, string $term_name): void {
+    $vocab = Vocabulary::load($vocabulary_machine_name);
+
+    if (!$vocab) {
+      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
+    }
+
+    $tids = $this->taxonomyLoadMultiple($vocabulary_machine_name, [
+      'name' => $term_name,
+    ]);
+
+    if (empty($tids)) {
+      throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
+    }
+
+    ksort($tids);
+    $tid = end($tids);
+
+    $path = $this->locatePath('/taxonomy/term/' . $tid . '/delete');
 
     $this->getSession()->visit($path);
   }
@@ -240,42 +272,6 @@ trait TaxonomyTrait {
     }
 
     return $query->execute();
-  }
-
-  /**
-   * Remove taxonomy term.
-   *
-   * @code
-   * When I delete the "tags" vocabulary "[TEST] Remove" term page
-   * @endcode
-   *
-   * @When I delete the :vocabulary_machine_name vocabulary :term_name term page
-   */
-  public function taxonomyDeleteTerm(string $vocabulary_machine_name, string $term_name): void {
-    $vocabulary = Vocabulary::load($vocabulary_machine_name);
-    if (!$vocabulary) {
-      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
-    }
-
-    $tids = $this->taxonomyLoadMultiple($vocabulary_machine_name, [
-      'name' => $term_name,
-    ]);
-
-    if (empty($tids)) {
-      throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
-    }
-
-    // Use the term created last.
-    ksort($tids);
-    $tid = end($tids);
-    $term = \Drupal::entityTypeManager()
-      ->getStorage('taxonomy_term')
-      ->load($tid);
-
-    if (!$term) {
-      throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
-    }
-    $term->delete();
   }
 
 }

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -242,4 +242,29 @@ trait TaxonomyTrait {
     return $query->execute();
   }
 
+  /**
+   * Remove taxonomy term.
+   *
+   * @code
+   * When I delete the "tags" vocabulary "[TEST] Remove" term page
+   * @endcode
+   *
+   * @When I delete the :vocabulary_machine_name vocabulary :term_name term page
+   */
+  public function taxonomyDeleteTerm(string $vocabulary_machine_name, string $term_name): void {
+    $terms = \Drupal::entityTypeManager()
+      ->getStorage('taxonomy_term')
+      ->loadByProperties([
+        'name' => $term_name,
+        'vid' => $vocabulary_machine_name,
+      ]);
+
+    $term = reset($terms);
+
+    if (!$term) {
+      throw new \Exception("The term '$term_name' in vocabulary '$vocabulary_machine_name' was not found.");
+    }
+    $term->delete();
+  }
+
 }

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -267,7 +267,7 @@ trait TaxonomyTrait {
     $term = reset($terms);
 
     if (!$term) {
-      throw new \Exception(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
+      throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
     }
     $term->delete();
   }

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -252,6 +252,11 @@ trait TaxonomyTrait {
    * @When I delete the :vocabulary_machine_name vocabulary :term_name term page
    */
   public function taxonomyDeleteTerm(string $vocabulary_machine_name, string $term_name): void {
+    $vocabulary = Vocabulary::load($vocabulary_machine_name);
+    if (!$vocabulary) {
+      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
+    }
+
     $terms = \Drupal::entityTypeManager()
       ->getStorage('taxonomy_term')
       ->loadByProperties([
@@ -262,7 +267,7 @@ trait TaxonomyTrait {
     $term = reset($terms);
 
     if (!$term) {
-      throw new \Exception("The term '$term_name' in vocabulary '$vocabulary_machine_name' was not found.");
+      throw new \Exception(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
     }
     $term->delete();
   }

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -257,14 +257,20 @@ trait TaxonomyTrait {
       throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
     }
 
-    $terms = \Drupal::entityTypeManager()
-      ->getStorage('taxonomy_term')
-      ->loadByProperties([
-        'name' => $term_name,
-        'vid' => $vocabulary_machine_name,
-      ]);
+    $tids = $this->taxonomyLoadMultiple($vocabulary_machine_name, [
+      'name' => $term_name,
+    ]);
 
-    $term = reset($terms);
+    if (empty($tids)) {
+      throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
+    }
+
+    // Use the term created last.
+    ksort($tids);
+    $tid = end($tids);
+    $term = \Drupal::entityTypeManager()
+      ->getStorage('taxonomy_term')
+      ->load($tid);
 
     if (!$term) {
       throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));

--- a/tests/behat/features/drupal_taxonomy.feature
+++ b/tests/behat/features/drupal_taxonomy.feature
@@ -154,19 +154,19 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api
-  Scenario: Assert "When I visit the :vocabulary_machine_name vocabulary :term_name term page" works
+  Scenario: Assert "When I visit the :vocabulary_machine_name term page with the name :term_name" works
     Given I am logged in as a user with the "administrator" role
-    When I visit the "tags" vocabulary "Tag1" term page
+    When I visit the "tags" term page with the name "Tag1"
     Then the response should contain "200"
     And I should see "Tag1"
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name vocabulary :term_name term page" fails with non-existing vocabulary
+  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term page with the name :term_name" fails with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I visit the "nonexisting" vocabulary "Tag1" term page
+      When I visit the "nonexisting" term page with the name "Tag1"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -175,12 +175,12 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name vocabulary :term_name term page" fails with non-existing term
+  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term page with the name :term_name" fails with non-existing term
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I visit the "tags" vocabulary "Nonexisting" term page
+      When I visit the "tags" term page with the name "Nonexisting"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -189,19 +189,19 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api
-  Scenario: Assert "When I edit the :vocabulary_machine_name vocabulary :term_name term page" works
+  Scenario: Assert "When I visit the :vocabulary_machine_name term edit page with the name :term_name" works
     Given I am logged in as a user with the "administrator" role
-    When I edit the "tags" vocabulary "Tag1" term page
+    When I visit the "tags" term edit page with the name "Tag1"
     Then the response should contain "200"
     And I should see "Tag1"
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I edit the :vocabulary_machine_name vocabulary :term_name term page" fails with non-existing vocabulary
+  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term edit page with the name :term_name" fails with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I edit the "nonexisting" vocabulary "Tag1" term page
+      When I visit the "nonexisting" term edit page with the name "Tag1"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -210,12 +210,12 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I edit the :vocabulary_machine_name vocabulary :term_name term page" fails with non-existing term
+  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term edit page with the name :term_name" fails with non-existing term
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I edit the "tags" vocabulary "Nonexisting" term page
+      When I visit the "tags" term edit page with the name "Nonexisting"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -224,20 +224,23 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api
-  Scenario: Assert "When I delete the :vocabulary_machine_name vocabulary :term_name term page" works
-    Given "tags" terms:
+  Scenario: Assert "When I visit the :vocabulary_machine_name term delete page with the name :term_name" works
+    Given I am logged in as a user with the "administrator" role
+    And "tags" terms:
       | name           |
       | [TEST] Remove  |
-    When I delete the "tags" vocabulary "[TEST] Remove" term page
-    Then the taxonomy term "[TEST] Remove" from the vocabulary "tags" should not exist
+    When I visit the "tags" term delete page with the name "[TEST] Remove"
+    Then the response should contain "200"
+    And I should see "Are you sure you want to delete"
+    And I should see "[TEST] Remove"
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I delete the :vocabulary_machine_name vocabulary :term_name term page" fails with non-existing vocabulary
+  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term delete page with the name :term_name" fails with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I delete the "nonexisting" vocabulary "Tag1" term page
+      When I visit the "nonexisting" term delete page with the name "Tag1"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -246,12 +249,12 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I delete the :vocabulary_machine_name vocabulary :term_name term page" fails with non-existing term
+  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term delete page with the name :term_name" fails with non-existing term
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I delete the "tags" vocabulary "Nonexisting" term page
+      When I visit the "tags" term delete page with the name "Nonexisting"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:

--- a/tests/behat/features/drupal_taxonomy.feature
+++ b/tests/behat/features/drupal_taxonomy.feature
@@ -1,3 +1,4 @@
+@taxonomy
 Feature: Check that TaxonomyTrait works
   As Behat Steps library developer
   I want to provide tools to manage taxonomy terms programmatically
@@ -226,13 +227,9 @@ Feature: Check that TaxonomyTrait works
   @api
   Scenario: Assert "When I visit the :vocabulary_machine_name term delete page with the name :term_name" works
     Given I am logged in as a user with the "administrator" role
-    And "tags" terms:
-      | name           |
-      | [TEST] Remove  |
-    When I visit the "tags" term delete page with the name "[TEST] Remove"
+    When I visit the "tags" term delete page with the name "Tag1"
     Then the response should contain "200"
-    And I should see "Are you sure you want to delete"
-    And I should see "[TEST] Remove"
+    And I should see "Tag1"
 
   @api @trait:Drupal\TaxonomyTrait
   Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term delete page with the name :term_name" fails with non-existing vocabulary

--- a/tests/behat/features/drupal_taxonomy.feature
+++ b/tests/behat/features/drupal_taxonomy.feature
@@ -222,3 +222,11 @@ Feature: Check that TaxonomyTrait works
       """
       Unable to find the term "Nonexisting" in the vocabulary "tags".
       """
+
+  @api
+  Scenario: Assert "When I delete the :vocabulary_machine_name vocabulary :term_name term page" works
+    Given "tags" terms:
+      | name           |
+      | [TEST] Remove  |
+    When I delete the "tags" vocabulary "[TEST] Remove" term page
+    Then the taxonomy term "[TEST] Remove" from the vocabulary "tags" should not exist

--- a/tests/behat/features/drupal_taxonomy.feature
+++ b/tests/behat/features/drupal_taxonomy.feature
@@ -230,3 +230,31 @@ Feature: Check that TaxonomyTrait works
       | [TEST] Remove  |
     When I delete the "tags" vocabulary "[TEST] Remove" term page
     Then the taxonomy term "[TEST] Remove" from the vocabulary "tags" should not exist
+
+  @api @trait:Drupal\TaxonomyTrait
+  Scenario: Assert negative assertion for "When I delete the :vocabulary_machine_name vocabulary :term_name term page" fails with non-existing vocabulary
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      When I delete the "nonexisting" vocabulary "Tag1" term page
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      The vocabulary "nonexisting" does not exist.
+      """
+
+  @api @trait:Drupal\TaxonomyTrait
+  Scenario: Assert negative assertion for "When I delete the :vocabulary_machine_name vocabulary :term_name term page" fails with non-existing term
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      When I delete the "tags" vocabulary "Nonexisting" term page
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Unable to find the term "Nonexisting" in the vocabulary "tags".
+      """


### PR DESCRIPTION
Closes #416


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated step descriptions for visiting and editing taxonomy term pages for improved clarity.
  - Added documentation for a new step to visit the delete page of a taxonomy term.

- **Tests**
  - Standardized step phrasing in taxonomy-related test scenarios.
  - Added new test scenarios for visiting the delete page of taxonomy terms, including both successful and failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->