### PR TITLE
Block, Menu, Date traits pipefail

### DIFF
--- a/src/DateTrait.php
+++ b/src/DateTrait.php
@@ -50,8 +50,8 @@ trait DateTrait {
     $rows = [];
     foreach ($table->getRows() as $hash) {
       $row = [];
-      foreach ($hash as $column => $cell) {
-        $row[$column] = self::dateRelativeProcessValue($cell);
+      foreach ($hash as $cell) {
+        $row[] = self::dateRelativeProcessValue($cell);
       }
       $rows[] = $row;
     }

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -141,7 +141,12 @@ trait BlockTrait {
           break;
 
         case 'region':
-          $block->setRegion($value);
+          if (is_string($value)) {
+            $block->setRegion($value);
+          }
+          else {
+            throw new \InvalidArgumentException('Expected region as string.');
+          }
           break;
 
         case 'status':

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -136,12 +136,20 @@ trait MenuTrait {
     foreach ($table->getHash() as $menu_link_hash) {
       $menu_link_hash['menu_name'] = $menu->id();
       // Add uri to correct property.
-      $menu_link_hash['link']['uri'] = $menu_link_hash['uri'];
-      unset($menu_link_hash['uri']);
+      if (isset($menu_link_hash['uri'])) {
+        $menu_link_hash['link'] = [];
+        $menu_link_hash['link']['uri'] = (string) $menu_link_hash['uri'];
+        unset($menu_link_hash['uri']);
+      }
       // Create parent property in format required.
-      if (!empty($menu_link_hash['parent'])) {
+      if (!empty($menu_link_hash['parent']) && is_string($menu_link_hash['parent'])) {
         $parent_link = $this->loadMenuLinkByTitle($menu_link_hash['parent'], $menu_name);
-        $menu_link_hash['parent'] = 'menu_link_content:' . $parent_link->uuid();
+        if ($parent_link instanceof MenuLinkContent) {
+          $menu_link_hash['parent'] = 'menu_link_content:' . $parent_link->uuid();
+        }
+        else {
+          unset($menu_link_hash['parent']);
+        }
       }
       else {
         unset($menu_link_hash['parent']);


### PR DESCRIPTION
Reference: [link](https://app.circleci.com/pipelines/github/drevops/behat-steps/1052/workflows/d7c68fcd-7295-41d9-a8e9-e6d5d6fb57cb/jobs/2151)
```
 ------ ----------------------------------------------------------------------- 
  Line   src/DateTrait.php (in context of class                                 
         DrevOps\BehatSteps\Tests\DateTraitTestImplementation)                  
 ------ ----------------------------------------------------------------------- 
  59     Parameter #1 $table of class Behat\Gherkin\Node\TableNode constructor  
         expects array<int, list<string>>, list<array<int<0, max>, string>>     
         given.                                                                 
         🪪 argument.type                                                       
         💡 array<int<0, max>, string> might not be a list.                     
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   src/DateTrait.php (in context of class FeatureContext)                 
 ------ ----------------------------------------------------------------------- 
  59     Parameter #1 $table of class Behat\Gherkin\Node\TableNode constructor  
         expects array<int, list<string>>, list<array<int<0, max>, string>>     
         given.                                                                 
         🪪 argument.type                                                       
         💡 array<int<0, max>, string> might not be a list.                     
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   src/Drupal/BlockTrait.php (in context of class FeatureContext)         
 ------ ----------------------------------------------------------------------- 
  144    Parameter #1 $region of method Drupal\block\Entity\Block::setRegion()  
         expects string, list<string>|string given.                             
         🪪 argument.type                                                       
 ------ ----------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   src/Drupal/MenuTrait.php (in context of class FeatureContext)        
 ------ --------------------------------------------------------------------- 
  139    Cannot access offset 'uri' on int|string.                            
         🪪 offsetAccess.nonOffsetAccessible                                  
  143    Parameter #1 $title of method FeatureContext::loadMenuLinkByTitle()  
         expects string, array<string, int|string|null>|int<min, -1>|int<1,   
         max>|string given.                                                   
         🪪 argument.type                                                     
 ------ --------------------------------------------------------------------- 

 [ERROR] Found 5 errors     
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling and validation when configuring block regions, ensuring only valid string values are accepted.
  - Enhanced robustness in menu link creation by adding checks for optional or malformed input data, preventing errors with missing or invalid fields.
- **Refactor**
  - Updated internal data handling for date transformation to use indexed arrays, streamlining row processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->