### PR TITLE
[#435] Fixed `mediaCreate()` not deleting existing media before creating new.

### DIFF
--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -73,6 +73,9 @@ trait MediaTrait {
    * @Given the following media :media_type exist:
    */
   public function mediaCreate(string $media_type, TableNode $nodesTable): void {
+    // Delete entities before creating them.
+    $this->mediaDelete($media_type, $nodesTable);
+
     foreach ($nodesTable->getHash() as $node_hash) {
       $node = (object) $node_hash;
       $node->bundle = $media_type;

--- a/tests/behat/features/drupal_media.feature
+++ b/tests/behat/features/drupal_media.feature
@@ -72,3 +72,28 @@ Feature: Check that MediaTrait works
       """
       Unable to find document media "Non-existent media"
       """
+
+  @api
+  Scenario: Assert that mediaCreate() deletes existing media before creating
+    Given the following managed files:
+      | path              |
+      | example_image.png |
+
+    # Create initial media
+    And the following media "image" exist:
+      | name                | field_media_image |
+      | Duplicate test item | example_image.png |
+
+    And I am logged in as a user with the "administrator" role
+    And I visit "/admin/content/media"
+    Then I should see the text "Duplicate test item"
+
+    # Create media again with the same name - should replace the first one
+    When the following media "image" exist:
+      | name                | field_media_image |
+      | Duplicate test item | example_image.png |
+
+    And I visit "/admin/content/media"
+    Then I should see the text "Duplicate test item"
+    # Verify only one media item exists by checking there's exactly one row in the table
+    And I should see 1 ".view-media td:contains('Duplicate test item')" elements


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media creation now automatically removes existing media items before creating new ones, preventing duplicate entries when recreating media with the same name or image.

* **Tests**
  * Added end-to-end test scenario validating that duplicate media prevention works correctly during the creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->