### PR TITLE
[#414] Added ResponsiveTrait.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ from the community.
 | [LinkTrait](STEPS.md#linktrait) | Verify link elements with attribute and content assertions. |
 | [PathTrait](STEPS.md#pathtrait) | Navigate and verify paths with URL validation. |
 | [ResponseTrait](STEPS.md#responsetrait) | Verify HTTP responses with status code and header checks. |
+| [ResponsiveTrait](STEPS.md#responsivetrait) | Test responsive layouts with viewport control. |
 | [WaitTrait](STEPS.md#waittrait) | Wait for a period of time or for AJAX to finish. |
 
 ### Index of Drupal steps

--- a/STEPS.md
+++ b/STEPS.md
@@ -14,6 +14,7 @@
 | [LinkTrait](#linktrait) | Verify link elements with attribute and content assertions. |
 | [PathTrait](#pathtrait) | Navigate and verify paths with URL validation. |
 | [ResponseTrait](#responsetrait) | Verify HTTP responses with status code and header checks. |
+| [ResponsiveTrait](#responsivetrait) | Test responsive layouts with viewport control. |
 | [WaitTrait](#waittrait) | Wait for a period of time or for AJAX to finish. |
 
 ### Index of Drupal steps
@@ -876,16 +877,16 @@ Then the downloaded file should be a zip archive not containing the files partia
 >  ```
 >  @javascript
 >  Scenario: Navigation without JS errors (will fail if errors occur)
->  Given I visit "/home"
->  When I click on "About"
->  Then I should see "About Us"
+>    Given I visit "/home"
+>    When I click on "About"
+>    Then I should see "About Us"
 >  ```
 >  <br/><br/>
 >  Bypassing error detection:
 >  ```
 >  @javascript @js-errors
 >  Scenario: Legacy page with known errors (will not fail)
->  Given I visit "/legacy-page"
+>    Given I visit "/legacy-page"
 >  ```
 
 
@@ -1268,6 +1269,112 @@ Assert a response does not contain a header with a specified name and value
 
 ```gherkin
 Then the response header "Connection" should not contain the value "Keep-Alive"
+
+```
+
+</details>
+
+## ResponsiveTrait
+
+[Source](src/ResponsiveTrait.php), [Example](tests/behat/features/responsive.feature)
+
+>  Test responsive layouts with viewport control.
+>  - Default breakpoints: mobile_portrait, tablet_landscape, desktop, etc.
+>  - Custom breakpoint registration via `responsiveSetBreakpoints()`
+>  - Tag-based viewport control using `@breakpoint:NAME` tag
+>  - Step-based viewport control during scenario execution
+>  - Individual width/height control or combined dimensions.
+>  
+>  Tag-based viewport control:
+>  ```
+>  @javascript @breakpoint:mobile_portrait
+>  Scenario: Mobile navigation test
+>    When I am on the homepage
+>    Then I should see the mobile menu
+>  ```
+>  <br/><br/>
+>  Step-based viewport control:
+>  ```
+>  @javascript
+>  Scenario: Responsive layout test
+>    When I am on the homepage
+>    And I set the viewport to the "tablet_landscape" breakpoint
+>    Then I should see the tablet layout
+>    When I set the viewport to "1920" by "1080"
+>    Then I should see the desktop layout
+>  ```
+>  <br/><br/>
+>  Custom breakpoints:
+>  ```
+>  class FeatureContext extends DrupalContext {
+>    use ResponsiveTrait;
+>  
+>    // @BeforeScenario
+>    public function setupCustomBreakpoints(): void {
+>      $this->responsiveSetBreakpoints([
+>        'iphone_12' => '390x844',
+>        '4k' => '3840x2160',
+>      ]);
+>    }
+>  }
+>  ```
+
+
+<details>
+  <summary><code>@When I set the viewport to the :breakpoint breakpoint</code></summary>
+
+<br/>
+Set the viewport to a specific breakpoint
+<br/><br/>
+
+```gherkin
+When I set the viewport to the "mobile_portrait" breakpoint
+When I set the viewport to the "desktop" breakpoint
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I set the viewport width to :width</code></summary>
+
+<br/>
+Set the viewport width
+<br/><br/>
+
+```gherkin
+When I set the viewport width to "1920"
+When I set the viewport width to "768"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I set the viewport height to :height</code></summary>
+
+<br/>
+Set the viewport height
+<br/><br/>
+
+```gherkin
+When I set the viewport height to "1080"
+When I set the viewport height to "900"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I set the viewport to :width by :height</code></summary>
+
+<br/>
+Set the viewport to specific dimensions
+<br/><br/>
+
+```gherkin
+When I set the viewport to "1920" by "1080"
+When I set the viewport to "375" by "667"
 
 ```
 

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps;
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Mink\Driver\Selenium2Driver;
+
+/**
+ * Test responsive layouts with viewport control.
+ *
+ * - Default breakpoints: mobile_portrait, tablet_landscape, desktop, etc.
+ * - Custom breakpoint registration via `responsiveSetBreakpoints()`
+ * - Tag-based viewport control using `@breakpoint:NAME` tag
+ * - Step-based viewport control during scenario execution
+ * - Individual width/height control or combined dimensions.
+ *
+ * Tag-based viewport control:
+ * @code
+ * @javascript @breakpoint:mobile_portrait
+ * Scenario: Mobile navigation test
+ *   When I am on the homepage
+ *   Then I should see the mobile menu
+ * @endcode
+ *
+ * Step-based viewport control:
+ * @code
+ * @javascript
+ * Scenario: Responsive layout test
+ *   When I am on the homepage
+ *   And I set the viewport to the "tablet_landscape" breakpoint
+ *   Then I should see the tablet layout
+ *   When I set the viewport to "1920" by "1080"
+ *   Then I should see the desktop layout
+ * @endcode
+ *
+ * Custom breakpoints:
+ * @code
+ * class FeatureContext extends DrupalContext {
+ *   use ResponsiveTrait;
+ *
+ *   // @BeforeScenario
+ *   public function setupCustomBreakpoints(): void {
+ *     $this->responsiveSetBreakpoints([
+ *       'iphone_12' => '390x844',
+ *       '4k' => '3840x2160',
+ *     ]);
+ *   }
+ * }
+ * @endcode
+ */
+trait ResponsiveTrait {
+
+  /**
+   * Default breakpoint definitions.
+   *
+   * Format: 'name' => 'WIDTHxHEIGHT'
+   *
+   * @var array<string, string>
+   */
+  protected array $responsiveDefaultBreakpoints = [
+    'mobile_portrait' => '360x640',
+    'mobile_landscape' => '640x360',
+    'tablet_portrait' => '768x1024',
+    'tablet_landscape' => '1024x768',
+    'laptop' => '1280x800',
+    'desktop' => '2560x1440',
+  ];
+
+  /**
+   * Custom breakpoint definitions.
+   *
+   * @var array<string, string>
+   */
+  protected array $responsiveCustomBreakpoints = [];
+
+  /**
+   * Set custom breakpoints.
+   *
+   * Custom breakpoints override default breakpoints with the same name.
+   *
+   * @param array<string, string> $breakpoints
+   *   Array of breakpoints in format ['name' => 'WIDTHxHEIGHT'].
+   *
+   * @throws \RuntimeException
+   *   If breakpoint format is invalid.
+   */
+  public function responsiveSetBreakpoints(array $breakpoints): void {
+    foreach ($breakpoints as $name => $dimensions) {
+      if (!preg_match('/^(\d+)x(\d+)$/i', $dimensions)) {
+        throw new \RuntimeException(sprintf("Invalid breakpoint format for '%s': '%s'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)", $name, $dimensions));
+      }
+      $this->responsiveCustomBreakpoints[$name] = $dimensions;
+    }
+  }
+
+  /**
+   * Process @breakpoint:NAME tag before scenario.
+   *
+   * @BeforeScenario
+   */
+  public function responsiveBeforeScenario(BeforeScenarioScope $scope): void {
+    $tags = $scope->getScenario()->getTags();
+
+    // Collect all breakpoint tags.
+    $breakpoint_tags = [];
+    foreach ($tags as $tag) {
+      if (str_starts_with($tag, 'breakpoint:')) {
+        $breakpoint_tags[] = $tag;
+      }
+    }
+
+    // No breakpoint tags found - nothing to do.
+    if (empty($breakpoint_tags)) {
+      return;
+    }
+
+    // Multiple breakpoint tags - throw exception.
+    if (count($breakpoint_tags) > 1) {
+      throw new \RuntimeException(sprintf('Only one @breakpoint tag is allowed per scenario. Found: @%s', implode(', @', $breakpoint_tags)));
+    }
+
+    // Single breakpoint tag - validate and process.
+    $tag = $breakpoint_tags[0];
+
+    // Validate that @javascript tag is present.
+    if (!in_array('javascript', $tags)) {
+      throw new \RuntimeException(sprintf('@%s tag requires @javascript tag to resize viewport', $tag));
+    }
+
+    $breakpoint_name = substr($tag, strlen('breakpoint:'));
+    $this->responsiveResizeToBreakpoint($breakpoint_name);
+  }
+
+  /**
+   * Set the viewport to a specific breakpoint.
+   *
+   * @code
+   * When I set the viewport to the "mobile_portrait" breakpoint
+   * When I set the viewport to the "desktop" breakpoint
+   * @endcode
+   *
+   * @When I set the viewport to the :breakpoint breakpoint
+   *
+   * @param string $breakpoint
+   *   The breakpoint name.
+   *
+   * @throws \RuntimeException
+   *   If breakpoint doesn't exist.
+   */
+  public function responsiveSetViewportToBreakpoint(string $breakpoint): void {
+    $this->responsiveResizeToBreakpoint($breakpoint);
+  }
+
+  /**
+   * Set the viewport width.
+   *
+   * @code
+   * When I set the viewport width to "1920"
+   * When I set the viewport width to "768"
+   * @endcode
+   *
+   * @When I set the viewport width to :width
+   *
+   * @param string $width
+   *   The width in pixels.
+   */
+  public function responsiveSetViewportWidth(string $width): void {
+    $current_dimensions = $this->responsiveGetCurrentDimensions();
+    $this->responsiveResize((int) $width, $current_dimensions['height']);
+  }
+
+  /**
+   * Set the viewport height.
+   *
+   * @code
+   * When I set the viewport height to "1080"
+   * When I set the viewport height to "900"
+   * @endcode
+   *
+   * @When I set the viewport height to :height
+   *
+   * @param string $height
+   *   The height in pixels.
+   */
+  public function responsiveSetViewportHeight(string $height): void {
+    $current_dimensions = $this->responsiveGetCurrentDimensions();
+    $this->responsiveResize($current_dimensions['width'], (int) $height);
+  }
+
+  /**
+   * Set the viewport to specific dimensions.
+   *
+   * @code
+   * When I set the viewport to "1920" by "1080"
+   * When I set the viewport to "375" by "667"
+   * @endcode
+   *
+   * @When I set the viewport to :width by :height
+   *
+   * @param string $width
+   *   The width in pixels.
+   * @param string $height
+   *   The height in pixels.
+   */
+  public function responsiveSetViewportDimensions(string $width, string $height): void {
+    $this->responsiveResize((int) $width, (int) $height);
+  }
+
+  /**
+   * Resize viewport to a named breakpoint.
+   *
+   * @param string $breakpoint
+   *   The breakpoint name.
+   *
+   * @throws \RuntimeException
+   *   If breakpoint doesn't exist.
+   */
+  protected function responsiveResizeToBreakpoint(string $breakpoint): void {
+    $dimensions = $this->responsiveGetBreakpoint($breakpoint);
+    $parsed = $this->responsiveParseBreakpoint($dimensions);
+    $this->responsiveResize($parsed['width'], $parsed['height']);
+  }
+
+  /**
+   * Get breakpoint dimensions by name.
+   *
+   * @param string $name
+   *   The breakpoint name.
+   *
+   * @return string
+   *   The dimensions in WIDTHxHEIGHT format.
+   *
+   * @throws \RuntimeException
+   *   If breakpoint doesn't exist.
+   */
+  protected function responsiveGetBreakpoint(string $name): string {
+    $all_breakpoints = $this->responsiveGetAllBreakpoints();
+
+    if (!isset($all_breakpoints[$name])) {
+      $available = implode(', ', array_keys($all_breakpoints));
+      throw new \RuntimeException(sprintf("Breakpoint '%s' not found. Available breakpoints: %s", $name, $available));
+    }
+
+    return $all_breakpoints[$name];
+  }
+
+  /**
+   * Get all available breakpoints.
+   *
+   * Custom breakpoints override defaults with the same name.
+   *
+   * @return array<string, string>
+   *   All breakpoints.
+   */
+  protected function responsiveGetAllBreakpoints(): array {
+    return array_merge($this->responsiveDefaultBreakpoints, $this->responsiveCustomBreakpoints);
+  }
+
+  /**
+   * Parse breakpoint dimensions.
+   *
+   * @param string $dimensions
+   *   Dimensions in WIDTHxHEIGHT format.
+   *
+   * @return array<string, int>
+   *   Array with 'width' and 'height' keys.
+   *
+   * @throws \RuntimeException
+   *   If format is invalid.
+   */
+  protected function responsiveParseBreakpoint(string $dimensions): array {
+    if (!preg_match('/^(\d+)x(\d+)$/i', $dimensions, $matches)) {
+      throw new \RuntimeException(sprintf("Invalid breakpoint format: '%s'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)", $dimensions));
+    }
+
+    return [
+      'width' => (int) $matches[1],
+      'height' => (int) $matches[2],
+    ];
+  }
+
+  /**
+   * Get current viewport dimensions.
+   *
+   * @return array<string, int>
+   *   Array with 'width' and 'height' keys.
+   */
+  protected function responsiveGetCurrentDimensions(): array {
+    $driver = $this->getSession()->getDriver();
+
+    // Default dimensions if unable to determine current size.
+    $default_width = 1280;
+    $default_height = 800;
+
+    if (!$driver instanceof Selenium2Driver) {
+      return ['width' => $default_width, 'height' => $default_height];
+    }
+
+    try {
+      $width = $this->getSession()->evaluateScript('return window.innerWidth;');
+      $height = $this->getSession()->evaluateScript('return window.innerHeight;');
+
+      return [
+        'width' => $width ?: $default_width,
+        'height' => $height ?: $default_height,
+      ];
+    }
+    catch (\Exception) {
+      return ['width' => $default_width, 'height' => $default_height];
+    }
+  }
+
+  /**
+   * Resize the browser window.
+   *
+   * @param int $width
+   *   The width in pixels.
+   * @param int $height
+   *   The height in pixels.
+   */
+  protected function responsiveResize(int $width, int $height): void {
+    $driver = $this->getSession()->getDriver();
+
+    if (!$driver instanceof Selenium2Driver) {
+      return;
+    }
+
+    try {
+      // Ensure session is started before resizing.
+      if (!$this->getSession()->isStarted()) {
+        $this->getSession()->start();
+      }
+
+      $this->getSession()->resizeWindow($width, $height, 'current');
+    }
+    catch (\Exception) {
+      // Silently fail if resize not supported.
+    }
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -35,6 +35,7 @@ use DrevOps\BehatSteps\KeyboardTrait;
 use DrevOps\BehatSteps\LinkTrait;
 use DrevOps\BehatSteps\PathTrait;
 use DrevOps\BehatSteps\ResponseTrait;
+use DrevOps\BehatSteps\ResponsiveTrait;
 use DrevOps\BehatSteps\WaitTrait;
 use Drupal\DrupalExtension\Context\DrupalContext;
 
@@ -66,6 +67,7 @@ class FeatureContext extends DrupalContext {
   use ParagraphsTrait;
   use PathTrait;
   use ResponseTrait;
+  use ResponsiveTrait;
   use SearchApiTrait;
   use TaxonomyTrait;
   use TestmodeTrait;

--- a/tests/behat/features/responsive.feature
+++ b/tests/behat/features/responsive.feature
@@ -1,0 +1,109 @@
+@d10
+Feature: Check that ResponsiveTrait works
+  As Behat Steps library developer
+  I want to provide tools to test responsive layouts with viewport control
+  So that users can verify their responsive designs at various breakpoints
+
+  @javascript
+  Scenario: Resize viewport to default breakpoints
+    When I am on "/page.html"
+    And I set the viewport to the "mobile_portrait" breakpoint
+    And I set the viewport to the "mobile_landscape" breakpoint
+    And I set the viewport to the "tablet_portrait" breakpoint
+    And I set the viewport to the "tablet_landscape" breakpoint
+    And I set the viewport to the "laptop" breakpoint
+    And I set the viewport to the "desktop" breakpoint
+
+  @javascript
+  Scenario: Set custom viewport dimensions
+    When I am on "/page.html"
+    And I set the viewport to "1920" by "1080"
+    And I set the viewport to "800" by "600"
+    And I set the viewport to "1366" by "768"
+
+  @javascript
+  Scenario: Set individual viewport width and height
+    When I am on "/page.html"
+    And I set the viewport to "1024" by "768"
+    And I set the viewport width to "1280"
+    And I set the viewport height to "1024"
+
+  @javascript @breakpoint:tablet_landscape
+  Scenario: Tag-based breakpoint control
+    When I am on "/page.html"
+
+  @javascript @breakpoint:mobile_portrait
+  Scenario: Tag-based mobile breakpoint
+    When I am on "/page.html"
+
+  @javascript @breakpoint:desktop
+  Scenario: Tag-based desktop breakpoint
+    When I am on "/page.html"
+
+  @javascript
+  Scenario: Test multiple breakpoints in sequence
+    When I am on "/page.html"
+    And I set the viewport to the "mobile_portrait" breakpoint
+    And I set the viewport to the "tablet_portrait" breakpoint
+    And I set the viewport to the "desktop" breakpoint
+
+  @trait:ResponsiveTrait
+  Scenario: Invalid breakpoint should throw exception
+    Given some behat configuration
+    And scenario steps:
+      """
+      @javascript
+      Scenario: Test invalid breakpoint
+        When I am on "/page.html"
+        And I set the viewport to the "non_existent_breakpoint" breakpoint
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Breakpoint 'non_existent_breakpoint' not found
+      """
+
+  @trait:ResponsiveTrait
+  Scenario: Invalid breakpoint tag should throw exception
+    Given some behat configuration
+    And scenario steps:
+      """
+      @javascript @breakpoint:invalid_breakpoint_tag
+      Scenario: Test invalid breakpoint tag
+        When I am on "/page.html"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Breakpoint 'invalid_breakpoint_tag' not found
+      """
+
+  @trait:ResponsiveTrait
+  Scenario: Missing @javascript tag with @breakpoint should throw exception
+    Given some behat configuration
+    And scenario steps:
+      """
+      @breakpoint:mobile_portrait
+      Scenario: Test missing javascript tag
+        When I am on "/page.html"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      @breakpoint:mobile_portrait tag requires @javascript tag to resize viewport
+      """
+
+  @trait:ResponsiveTrait
+  Scenario: Multiple @breakpoint tags should throw exception
+    Given some behat configuration
+    And scenario steps:
+      """
+      @javascript @breakpoint:mobile_portrait @breakpoint:desktop
+      Scenario: Test multiple breakpoint tags
+        When I am on "/page.html"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Only one @breakpoint tag is allowed per scenario. Found: @breakpoint:mobile_portrait, @breakpoint:desktop
+      """

--- a/tests/phpunit/src/DocsTest.php
+++ b/tests/phpunit/src/DocsTest.php
@@ -1631,6 +1631,102 @@ EOD,
           'description_full' => 'Test trait description.' . PHP_EOL . PHP_EOL . '@code' . PHP_EOL . 'Given I am on the homepage' . PHP_EOL . PHP_EOL . 'When I click "Submit"' . PHP_EOL . 'Then I should see "Success"' . PHP_EOL . '@endcode',
         ],
       ],
+      'with @code block with indented PHP code' => [
+        'TestTrait',
+        <<<'EOD'
+/**
+ * Test trait description.
+ *
+ * @code
+ * class FeatureContext extends DrupalContext {
+ *   use ResponsiveTrait;
+ *
+ *   public function setupCustomBreakpoints(): void {
+ *     $this->responsiveSetBreakpoints([
+ *       'iphone_12' => '390x844',
+ *       '4k' => '3840x2160',
+ *     ]);
+ *   }
+ * }
+ * @endcode
+ */
+EOD,
+        [
+          'description' => 'Test trait description.',
+          'description_full' => 'Test trait description.' . PHP_EOL . PHP_EOL . '@code' . PHP_EOL . 'class FeatureContext extends DrupalContext {' . PHP_EOL . '  use ResponsiveTrait;' . PHP_EOL . PHP_EOL . '  public function setupCustomBreakpoints(): void {' . PHP_EOL . '    $this->responsiveSetBreakpoints([' . PHP_EOL . "      'iphone_12' => '390x844'," . PHP_EOL . "      '4k' => '3840x2160'," . PHP_EOL . '    ]);' . PHP_EOL . '  }' . PHP_EOL . '}' . PHP_EOL . '@endcode',
+        ],
+      ],
+      'with @code block with 4-space indentation' => [
+        'TestTrait',
+        <<<'EOD'
+/**
+ * Test trait description.
+ *
+ * @code
+ * if ($condition) {
+ *     // 4 spaces indentation
+ *     doSomething();
+ *     if ($nested) {
+ *         // 8 spaces indentation
+ *         doNestedThing();
+ *     }
+ * }
+ * @endcode
+ */
+EOD,
+        [
+          'description' => 'Test trait description.',
+          'description_full' => 'Test trait description.' . PHP_EOL . PHP_EOL . '@code' . PHP_EOL . 'if ($condition) {' . PHP_EOL . '    // 4 spaces indentation' . PHP_EOL . '    doSomething();' . PHP_EOL . '    if ($nested) {' . PHP_EOL . '        // 8 spaces indentation' . PHP_EOL . '        doNestedThing();' . PHP_EOL . '    }' . PHP_EOL . '}' . PHP_EOL . '@endcode',
+        ],
+      ],
+      'with @code block with mixed content and indentation' => [
+        'TestTrait',
+        <<<'EOD'
+/**
+ * Test trait description.
+ *
+ * Regular text before code.
+ *
+ * @code
+ * class Example {
+ *   private $value;
+ *
+ *   public function __construct() {
+ *     $this->value = [
+ *       'key1' => 'value1',
+ *       'key2' => 'value2',
+ *     ];
+ *   }
+ * }
+ * @endcode
+ *
+ * Regular text after code.
+ */
+EOD,
+        [
+          'description' => 'Test trait description.',
+          'description_full' => 'Test trait description.' . PHP_EOL . PHP_EOL . 'Regular text before code.' . PHP_EOL . PHP_EOL . '@code' . PHP_EOL . 'class Example {' . PHP_EOL . '  private $value;' . PHP_EOL . PHP_EOL . '  public function __construct() {' . PHP_EOL . '    $this->value = [' . PHP_EOL . "      'key1' => 'value1'," . PHP_EOL . "      'key2' => 'value2'," . PHP_EOL . '    ];' . PHP_EOL . '  }' . PHP_EOL . '}' . PHP_EOL . '@endcode' . PHP_EOL . PHP_EOL . 'Regular text after code.',
+        ],
+      ],
+      'with @code block preserving trailing spaces in code' => [
+        'TestTrait',
+        <<<'EOD'
+/**
+ * Test trait description.
+ *
+ * @code
+ * // Line with trailing content
+ * function test() {
+ *   return true;
+ * }
+ * @endcode
+ */
+EOD,
+        [
+          'description' => 'Test trait description.',
+          'description_full' => 'Test trait description.' . PHP_EOL . PHP_EOL . '@code' . PHP_EOL . '// Line with trailing content' . PHP_EOL . 'function test() {' . PHP_EOL . '  return true;' . PHP_EOL . '}' . PHP_EOL . '@endcode',
+        ],
+      ],
     ];
   }
 

--- a/tests/phpunit/src/ResponsiveTraitTest.php
+++ b/tests/phpunit/src/ResponsiveTraitTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests;
+
+use DrevOps\BehatSteps\ResponsiveTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for ResponsiveTrait.
+ *
+ * phpcs:disable Drupal.Commenting.FunctionComment
+ */
+#[CoversClass(ResponsiveTrait::class)]
+class ResponsiveTraitTest extends UnitTestCase {
+
+  /**
+   * A test implementation of ResponsiveTrait.
+   *
+   * @var \DrevOps\BehatSteps\Tests\ResponsiveTraitTestImplementation
+   */
+  protected $testObject;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->testObject = new ResponsiveTraitTestImplementation();
+  }
+
+  #[DataProvider('dataProviderParseBreakpoint')]
+  public function testParseBreakpoint(string $dimensions, array $expected, ?string $exception = NULL): void {
+    if ($exception) {
+      $this->expectException(\RuntimeException::class);
+      $this->expectExceptionMessage($exception);
+    }
+
+    $result = $this->testObject->testResponsiveParseBreakpoint($dimensions);
+    $this->assertEquals($expected, $result);
+  }
+
+  public static function dataProviderParseBreakpoint(): array {
+    return [
+      'valid mobile portrait' => [
+        '360x640',
+        ['width' => 360, 'height' => 640],
+      ],
+      'valid desktop' => [
+        '1920x1080',
+        ['width' => 1920, 'height' => 1080],
+      ],
+      'valid 4K' => [
+        '3840x2160',
+        ['width' => 3840, 'height' => 2160],
+      ],
+      'valid small dimensions' => [
+        '1x1',
+        ['width' => 1, 'height' => 1],
+      ],
+      'valid large dimensions' => [
+        '9999x9999',
+        ['width' => 9999, 'height' => 9999],
+      ],
+      'case insensitive - uppercase X' => [
+        '1920X1080',
+        ['width' => 1920, 'height' => 1080],
+      ],
+      'invalid - missing height' => [
+        '1920',
+        [],
+        "Invalid breakpoint format: '1920'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid - missing width' => [
+        'x1080',
+        [],
+        "Invalid breakpoint format: 'x1080'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid - non-numeric width' => [
+        'abcx1080',
+        [],
+        "Invalid breakpoint format: 'abcx1080'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid - non-numeric height' => [
+        '1920xabc',
+        [],
+        "Invalid breakpoint format: '1920xabc'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid - empty string' => [
+        '',
+        [],
+        "Invalid breakpoint format: ''. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid - only x' => [
+        'x',
+        [],
+        "Invalid breakpoint format: 'x'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid - with spaces' => [
+        '1920 x 1080',
+        [],
+        "Invalid breakpoint format: '1920 x 1080'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid - negative width' => [
+        '-1920x1080',
+        [],
+        "Invalid breakpoint format: '-1920x1080'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid - negative height' => [
+        '1920x-1080',
+        [],
+        "Invalid breakpoint format: '1920x-1080'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid - float dimensions' => [
+        '1920.5x1080.5',
+        [],
+        "Invalid breakpoint format: '1920.5x1080.5'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+    ];
+  }
+
+  #[DataProvider('dataProviderGetBreakpoint')]
+  public function testGetBreakpoint(array $custom_breakpoints, string $name, string $expected, ?string $exception = NULL): void {
+    if (!empty($custom_breakpoints)) {
+      $this->testObject->responsiveSetBreakpoints($custom_breakpoints);
+    }
+
+    if ($exception) {
+      $this->expectException(\RuntimeException::class);
+      $this->expectExceptionMessageMatches($exception);
+    }
+
+    $result = $this->testObject->testResponsiveGetBreakpoint($name);
+    $this->assertEquals($expected, $result);
+  }
+
+  public static function dataProviderGetBreakpoint(): array {
+    return [
+      'default breakpoint - mobile_portrait' => [
+        [],
+        'mobile_portrait',
+        '360x640',
+      ],
+      'default breakpoint - desktop' => [
+        [],
+        'desktop',
+        '2560x1440',
+      ],
+      'default breakpoint - tablet_landscape' => [
+        [],
+        'tablet_landscape',
+        '1024x768',
+      ],
+      'custom breakpoint' => [
+        ['iphone_12' => '390x844'],
+        'iphone_12',
+        '390x844',
+      ],
+      'custom breakpoint overrides default' => [
+        ['mobile_portrait' => '400x700'],
+        'mobile_portrait',
+        '400x700',
+      ],
+      'multiple custom breakpoints' => [
+        [
+          'iphone_12' => '390x844',
+          '4k' => '3840x2160',
+        ],
+        '4k',
+        '3840x2160',
+      ],
+      'non-existent breakpoint' => [
+        [],
+        'non_existent',
+        '',
+        "/Breakpoint 'non_existent' not found\. Available breakpoints: .*/",
+      ],
+      'non-existent with custom breakpoints' => [
+        ['custom' => '1000x2000'],
+        'invalid',
+        '',
+        "/Breakpoint 'invalid' not found\. Available breakpoints: .*/",
+      ],
+    ];
+  }
+
+  #[DataProvider('dataProviderGetAllBreakpoints')]
+  public function testGetAllBreakpoints(array $custom_breakpoints, array $expected): void {
+    if (!empty($custom_breakpoints)) {
+      $this->testObject->responsiveSetBreakpoints($custom_breakpoints);
+    }
+
+    $result = $this->testObject->testResponsiveGetAllBreakpoints();
+    $this->assertEquals($expected, $result);
+  }
+
+  public static function dataProviderGetAllBreakpoints(): array {
+    $defaults = [
+      'mobile_portrait' => '360x640',
+      'mobile_landscape' => '640x360',
+      'tablet_portrait' => '768x1024',
+      'tablet_landscape' => '1024x768',
+      'laptop' => '1280x800',
+      'desktop' => '2560x1440',
+    ];
+
+    return [
+      'only default breakpoints' => [
+        [],
+        $defaults,
+      ],
+      'with single custom breakpoint' => [
+        ['iphone_12' => '390x844'],
+        array_merge($defaults, ['iphone_12' => '390x844']),
+      ],
+      'with multiple custom breakpoints' => [
+        [
+          'iphone_12' => '390x844',
+          '4k' => '3840x2160',
+          'ultrawide' => '3440x1440',
+        ],
+        array_merge($defaults, [
+          'iphone_12' => '390x844',
+          '4k' => '3840x2160',
+          'ultrawide' => '3440x1440',
+        ]),
+      ],
+      'custom overrides default' => [
+        ['mobile_portrait' => '400x700'],
+        array_merge($defaults, ['mobile_portrait' => '400x700']),
+      ],
+      'custom overrides multiple defaults' => [
+        [
+          'mobile_portrait' => '400x700',
+          'desktop' => '1920x1080',
+        ],
+        array_merge($defaults, [
+          'mobile_portrait' => '400x700',
+          'desktop' => '1920x1080',
+        ]),
+      ],
+    ];
+  }
+
+  #[DataProvider('dataProviderSetBreakpoints')]
+  public function testSetBreakpoints(array $breakpoints, ?string $exception = NULL): void {
+    if ($exception) {
+      $this->expectException(\RuntimeException::class);
+      $this->expectExceptionMessage($exception);
+    }
+
+    $this->testObject->responsiveSetBreakpoints($breakpoints);
+
+    // Verify breakpoints were set correctly.
+    if (!$exception) {
+      if (empty($breakpoints)) {
+        // For empty array, just verify all defaults still exist.
+        $defaults = $this->testObject->testResponsiveGetAllBreakpoints();
+        $this->assertNotEmpty($defaults);
+        $this->assertArrayHasKey('mobile_portrait', $defaults);
+      }
+      else {
+        foreach ($breakpoints as $name => $dimensions) {
+          $result = $this->testObject->testResponsiveGetBreakpoint($name);
+          $this->assertEquals($dimensions, $result);
+        }
+      }
+    }
+  }
+
+  public static function dataProviderSetBreakpoints(): array {
+    return [
+      'single valid breakpoint' => [
+        ['iphone_12' => '390x844'],
+      ],
+      'multiple valid breakpoints' => [
+        [
+          'iphone_12' => '390x844',
+          '4k' => '3840x2160',
+          'ultrawide' => '3440x1440',
+        ],
+      ],
+      'override default breakpoint' => [
+        ['mobile_portrait' => '400x700'],
+      ],
+      'empty array' => [
+        [],
+      ],
+      'invalid format - missing height' => [
+        ['bad_format' => '1920'],
+        "Invalid breakpoint format for 'bad_format': '1920'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'invalid format - non-numeric' => [
+        ['bad_format' => 'widthxheight'],
+        "Invalid breakpoint format for 'bad_format': 'widthxheight'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+      'mixed valid and invalid' => [
+        [
+          'valid' => '1920x1080',
+          'invalid' => '1920',
+        ],
+        "Invalid breakpoint format for 'invalid': '1920'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)",
+      ],
+    ];
+  }
+
+}
+
+/**
+ * Test implementation of ResponsiveTrait.
+ */
+class ResponsiveTraitTestImplementation {
+
+  use ResponsiveTrait;
+
+  /**
+   * Expose protected method for testing.
+   */
+  public function testResponsiveParseBreakpoint(string $dimensions): array {
+    return $this->responsiveParseBreakpoint($dimensions);
+  }
+
+  /**
+   * Expose protected method for testing.
+   */
+  public function testResponsiveGetBreakpoint(string $name): string {
+    return $this->responsiveGetBreakpoint($name);
+  }
+
+  /**
+   * Expose protected method for testing.
+   */
+  public function testResponsiveGetAllBreakpoints(): array {
+    return $this->responsiveGetAllBreakpoints();
+  }
+
+}


### PR DESCRIPTION
Closes #414

## Steps Added

ResponsiveTrait adds **4 Behat step definitions** for viewport control:

1. **`When I set the viewport to the :breakpoint breakpoint`**  
   Sets the viewport to a named breakpoint (e.g., "mobile_portrait", "desktop")

2. **`When I set the viewport width to :width`**  
   Sets only the viewport width in pixels (height remains unchanged)

3. **`When I set the viewport height to :height`**  
   Sets only the viewport height in pixels (width remains unchanged)

4. **`When I set the viewport to :width by :height`**  
   Sets both width and height to specific pixel values

## Tagging Feature

The **`@breakpoint:NAME`** tag provides automatic viewport resizing before a scenario executes: `@breakpoint:mobile_portrait`
