### PR TITLE
[#406] Added DateTime fields support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /.phpunit.cache
 /build
 /composer.lock
+/patches.lock.json
 /docker-compose.override.yml
 /vendor

--- a/PLAN-406-datetime-field-support.md
+++ b/PLAN-406-datetime-field-support.md
@@ -1,0 +1,183 @@
+# Implementation Plan for DateTime Field Handling (Issue #406)
+
+**Issue:** https://github.com/drevops/behat-steps/issues/406
+
+Based on analysis of the codebase and the referenced implementation from Metadrop, here's the comprehensive plan:
+
+## Overview
+Add datetime field handling to support setting date, time, and datetime fields in Drupal forms, following the project's existing patterns and conventions.
+
+## Implementation Details
+
+### 1. **Add datetime field handling methods to `FieldTrait.php`**
+
+**New methods to add:**
+
+- `fieldFillDatetime(string $label, string $date, string $time = ''): void`
+  - Step: `When I fill in the datetime field :label with date :date and time :time`
+  - Step: `When I fill in the datetime field :label with date :date`
+  - Fills both date and optionally time components of a datetime field
+
+- `fieldFillDatetimeDate(string $label, string $date): void`
+  - Step: `When I fill in the date part of the datetime field :label with :date`
+  - Fills only the date component
+
+- `fieldFillDatetimeTime(string $label, string $time): void`
+  - Step: `When I fill in the time part of the datetime field :label with :time`
+  - Fills only the time component
+
+- `fieldFillDatetimeStart(string $label, string $date, string $time = ''): void`
+  - Step: `When I fill in the start datetime field :label with date :date and time :time`
+  - Handles "start" value for date range fields
+
+- `fieldFillDatetimeEnd(string $label, string $date, string $time = ''): void`
+  - Step: `When I fill in the end datetime field :label with date :date and time :time`
+  - Handles "end_value" for date range fields
+
+**Helper method:**
+- `fieldFillDatetimeHelper(string $label, string $part, string $field, string $value): void`
+  - Core implementation that uses XPath to locate datetime field inputs
+  - Parameters:
+    - `$label`: Field label text
+    - `$part`: 'value' (start) or 'end_value' (end)
+    - `$field`: 'date' or 'time'
+    - `$value`: The value to set
+
+**XPath strategy:**
+```php
+// Locate datetime inputs by field label and name attribute
+sprintf(
+  '//label[contains(text(), "%s")]/..//input[contains(@name, "[%s][%s]")]',
+  $label, $part, $field
+)
+```
+
+### 2. **Create datetime field configurations**
+
+**Four fields to create in `build/config/sync/`:**
+
+1. **`field_datetime`**
+   - Type: `datetime`
+   - Storage: Single value
+   - Settings: Date and time
+   - Tests: Regular datetime methods with both date and time
+
+2. **`field_date_only`**
+   - Type: `datetime`
+   - Storage: Single value
+   - Settings: Date only (no time)
+   - Tests: Regular datetime methods with date only
+
+3. **`field_daterange`**
+   - Type: `daterange`
+   - Storage: Start and end values
+   - Settings: Date and time
+   - Tests: Start/end datetime methods with both date and time
+
+4. **`field_daterange_date_only`**
+   - Type: `daterange`
+   - Storage: Start and end values
+   - Settings: Date only (no time)
+   - Tests: Start/end datetime methods with date only
+
+**Configuration files to create:**
+- `field.storage.node.field_datetime.yml`
+- `field.field.node.page.field_datetime.yml`
+- `field.storage.node.field_date_only.yml`
+- `field.field.node.page.field_date_only.yml`
+- `field.storage.node.field_daterange.yml`
+- `field.field.node.page.field_daterange.yml`
+- `field.storage.node.field_daterange_date_only.yml`
+- `field.field.node.page.field_daterange_date_only.yml`
+- Update `core.entity_form_display.node.page.default.yml` - Add form display configuration for all 4 fields
+
+**Implementation steps:**
+1. Create configuration files in `build/config/sync/`
+2. Import configuration using `ahoy drush cim -y`
+3. User will manually move configuration to `tests/behat/fixtures/d10/config/sync/` and `tests/behat/fixtures/d11/config/sync/` later
+
+### 3. **Create Behat test scenarios**
+
+**New feature file: `tests/behat/features/field_datetime.feature`**
+
+**Test scenarios to include:**
+- Fill datetime field with date only
+- Fill datetime field with date and time
+- Fill date part of datetime field
+- Fill time part of datetime field
+- Fill start datetime field (date range)
+- Fill end datetime field (date range)
+- Negative tests for non-existent fields
+- Integration with DateTrait's relative date transformations (e.g., `[relative:-1 day]`)
+- Both `@api` (non-JS) and `@javascript` scenarios
+
+### 4. **Update documentation**
+- Run `ahoy update-docs` to regenerate `STEPS.md` from the new method annotations
+- Verify the documentation is properly formatted with `ahoy lint-docs`
+
+### 5. **Testing and validation**
+- Run `ahoy test-bdd tests/behat/features/field_datetime.feature` for the new tests
+- Run full test suite with `ahoy test-bdd` to ensure no regressions
+- Fix any linting issues with `ahoy lint-fix`
+
+## Technical Considerations
+
+1. **Consistent language:** Following project conventions:
+   - Use descriptive placeholder names (`:label`, `:date`, `:time`)
+   - Methods start with trait name prefix: `fieldFillDatetime*()`
+   - Steps use "When I..." for actions
+   - Use "the datetime field" consistently in step definitions
+
+2. **Integration with existing traits:**
+   - Works with `DateTrait` for `[relative:...]` transformations
+   - Follows patterns from `FieldTrait` for field interaction
+   - Uses standard Mink/Behat APIs
+
+3. **Drupal-specific considerations:**
+   - Datetime fields in Drupal use separate `date` and `time` HTML inputs
+   - Field names contain `[value][date]` and `[value][time]` parts
+   - Date range fields use `[value]` for start and `[end_value]` for end
+
+4. **Error handling:**
+   - Throw descriptive exceptions when fields aren't found
+   - Follow existing error message patterns from other field methods
+
+## Files to Create/Modify
+
+**Modified:**
+- `src/FieldTrait.php` (add new methods)
+- `build/config/sync/core.entity_form_display.node.page.default.yml` (add form display for 4 new fields)
+
+**Created in `build/config/sync/` (to be moved to fixtures later):**
+- `field.storage.node.field_datetime.yml`
+- `field.field.node.page.field_datetime.yml`
+- `field.storage.node.field_date_only.yml`
+- `field.field.node.page.field_date_only.yml`
+- `field.storage.node.field_daterange.yml`
+- `field.field.node.page.field_daterange.yml`
+- `field.storage.node.field_daterange_date_only.yml`
+- `field.field.node.page.field_daterange_date_only.yml`
+
+**Created:**
+- `tests/behat/features/field_datetime.feature`
+
+**Updated (via automation):**
+- `STEPS.md` (via `ahoy update-docs`)
+
+**To be done manually later:**
+- Move configuration files from `build/config/sync/` to `tests/behat/fixtures/d10/config/sync/`
+- Replicate configuration files to `tests/behat/fixtures/d11/config/sync/`
+
+## Success Criteria
+- ✅ All new Behat tests pass
+- ✅ Existing tests continue to pass (no regressions)
+- ✅ Code linting passes
+- ✅ Documentation is updated and properly formatted
+- ✅ Supports date-only, time-only, and datetime fields
+- ✅ Supports date range fields (start/end)
+- ✅ Integrates with relative date transformation
+
+## Notes
+- Reference implementation: https://github.com/Metadrop/behat-contexts/blob/48e079eac0cc96e15b0cf0906b4e03841e47eb76/src/Behat/Context/FormContext.php#L69
+- This implementation should use consistent language and follow DrevOps coding standards
+- All step definitions should follow the tuple format (not regex)

--- a/STEPS.md
+++ b/STEPS.md
@@ -572,6 +572,79 @@ When I uncheck the checkbox "edit-field-terms-0-value"
 </details>
 
 <details>
+  <summary><code>@When I fill in the datetime field :label with date :date and time :time</code></summary>
+
+<br/>
+Fill in datetime field with date and optionally time
+<br/><br/>
+
+```gherkin
+When I fill in the datetime field "Event date" with date "2024-01-15" and time "14:30:00"
+When I fill in the datetime field "Event date" with date "2024-01-15" and time ""
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I fill in the date part of the datetime field :label with :date</code></summary>
+
+<br/>
+Fill in the date part of a datetime field
+<br/><br/>
+
+```gherkin
+When I fill in the date part of the datetime field "Event date" with "2024-01-15"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I fill in the time part of the datetime field :label with :time</code></summary>
+
+<br/>
+Fill in the time part of a datetime field
+<br/><br/>
+
+```gherkin
+When I fill in the time part of the datetime field "Event date" with "14:30:00"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I fill in the start datetime field :label with date :date and time :time</code></summary>
+
+<br/>
+Fill in start datetime field with date and optionally time
+<br/><br/>
+
+```gherkin
+When I fill in the start datetime field "Event period" with date "2024-01-15" and time "14:30:00"
+When I fill in the start datetime field "Event period" with date "2024-01-15" and time ""
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I fill in the end datetime field :label with date :date and time :time</code></summary>
+
+<br/>
+Fill in end datetime field with date and optionally time
+<br/><br/>
+
+```gherkin
+When I fill in the end datetime field "Event period" with date "2024-01-20" and time "18:00:00"
+When I fill in the end datetime field "Event period" with date "2024-01-20" and time ""
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the field :field should be empty</code></summary>
 
 <br/>

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -414,4 +414,142 @@ JS;
     $this->getSession()->executeScript($script);
   }
 
+  /**
+   * Fill in datetime field with date and optionally time.
+   *
+   * Leave time empty if not needed.
+   *
+   * @code
+   * When I fill in the datetime field "Event date" with date "2024-01-15" and time "14:30:00"
+   * When I fill in the datetime field "Event date" with date "2024-01-15" and time ""
+   * @endcode
+   *
+   * @When I fill in the datetime field :label with date :date and time :time
+   */
+  public function fieldFillDatetime(string $label, string $date, string $time): void {
+    $this->fieldFillDatetimeHelper($label, 'value', 'date', $date);
+    if ($time !== '') {
+      $this->fieldFillDatetimeHelper($label, 'value', 'time', $time);
+    }
+  }
+
+  /**
+   * Fill in the date part of a datetime field.
+   *
+   * @code
+   * When I fill in the date part of the datetime field "Event date" with "2024-01-15"
+   * @endcode
+   *
+   * @When I fill in the date part of the datetime field :label with :date
+   */
+  public function fieldFillDatetimeDate(string $label, string $date): void {
+    $this->fieldFillDatetimeHelper($label, 'value', 'date', $date);
+  }
+
+  /**
+   * Fill in the time part of a datetime field.
+   *
+   * @code
+   * When I fill in the time part of the datetime field "Event date" with "14:30:00"
+   * @endcode
+   *
+   * @When I fill in the time part of the datetime field :label with :time
+   */
+  public function fieldFillDatetimeTime(string $label, string $time): void {
+    $this->fieldFillDatetimeHelper($label, 'value', 'time', $time);
+  }
+
+  /**
+   * Fill in start datetime field with date and optionally time.
+   *
+   * For date range fields. Leave time empty if not needed.
+   *
+   * @code
+   * When I fill in the start datetime field "Event period" with date "2024-01-15" and time "14:30:00"
+   * When I fill in the start datetime field "Event period" with date "2024-01-15" and time ""
+   * @endcode
+   *
+   * @When I fill in the start datetime field :label with date :date and time :time
+   */
+  public function fieldFillDatetimeStart(string $label, string $date, string $time): void {
+    $this->fieldFillDatetimeHelper($label, 'value', 'date', $date);
+    if ($time !== '') {
+      $this->fieldFillDatetimeHelper($label, 'value', 'time', $time);
+    }
+  }
+
+  /**
+   * Fill in end datetime field with date and optionally time.
+   *
+   * For date range fields. Leave time empty if not needed.
+   *
+   * @code
+   * When I fill in the end datetime field "Event period" with date "2024-01-20" and time "18:00:00"
+   * When I fill in the end datetime field "Event period" with date "2024-01-20" and time ""
+   * @endcode
+   *
+   * @When I fill in the end datetime field :label with date :date and time :time
+   */
+  public function fieldFillDatetimeEnd(string $label, string $date, string $time): void {
+    $this->fieldFillDatetimeHelper($label, 'end_value', 'date', $date);
+    if ($time !== '') {
+      $this->fieldFillDatetimeHelper($label, 'end_value', 'time', $time);
+    }
+  }
+
+  /**
+   * Helper method to fill datetime field parts.
+   *
+   * @param string $label
+   *   The field label text.
+   * @param string $part
+   *   The field part: 'value' for single/start or 'end_value' for end.
+   * @param string $field
+   *   The field type: 'date' or 'time'.
+   * @param string $value
+   *   The value to set.
+   *
+   * @throws \Exception
+   */
+  protected function fieldFillDatetimeHelper(string $label, string $part, string $field, string $value): void {
+    // Try to find by label element first.
+    $xpath = sprintf(
+      '//label[contains(text(), "%s")]/..//input[contains(@name, "[%s][%s]")]',
+      $label,
+      $part,
+      $field
+    );
+
+    $page = $this->getSession()->getPage();
+    $element = $page->find('xpath', $xpath);
+
+    // If not found, try to find by span (Drupal field label pattern).
+    if ($element === NULL) {
+      $xpath = sprintf(
+        '//span[contains(text(), "%s")]/../..//input[contains(@name, "[%s][%s]")]',
+        $label,
+        $part,
+        $field
+      );
+      $element = $page->find('xpath', $xpath);
+    }
+
+    // If still not found, try a more generic approach.
+    if ($element === NULL) {
+      $xpath = sprintf(
+        '//*[contains(text(), "%s")]/ancestor::div[contains(@class, "field--")]//input[contains(@name, "[%s][%s]")]',
+        $label,
+        $part,
+        $field
+      );
+      $element = $page->find('xpath', $xpath);
+    }
+
+    if ($element === NULL) {
+      throw new \Exception(sprintf('Datetime field "%s" with part "%s" and field "%s" not found.', $label, $part, $field));
+    }
+
+    $element->setValue($value);
+  }
+
 }

--- a/tests/behat/features/field.feature
+++ b/tests/behat/features/field.feature
@@ -405,3 +405,147 @@ Feature: Check that FieldTrait works
     And I press "Save"
      # Server-side validation errors should appear.
     Then I should see "Title field is required"
+
+  @api @datetime
+  Scenario: Fill datetime field with date and time
+    Given page content:
+      | title                     |
+      | [TEST] Datetime test page |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "page" content edit page with the title "[TEST] Datetime test page"
+    And I fill in the datetime field "Event date" with date "2024-01-15" and time "14:30:00"
+    And I press "Save"
+    Then I should see the text "Page [TEST] Datetime test page has been updated."
+
+  @api @datetime
+  Scenario: Fill datetime field using separate date and time steps
+    Given page content:
+      | title                          |
+      | [TEST] Datetime separate steps |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "page" content edit page with the title "[TEST] Datetime separate steps"
+    And I fill in the date part of the datetime field "Event date" with "2024-02-20"
+    And I fill in the time part of the datetime field "Event date" with "15:45:00"
+    And I press "Save"
+    Then I should see the text "Page [TEST] Datetime separate steps has been updated."
+
+  @api @datetime
+  Scenario: Fill date-only field
+    Given page content:
+      | title                      |
+      | [TEST] Date only test page |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "page" content edit page with the title "[TEST] Date only test page"
+    And I fill in the datetime field "Event date only" with date "2024-03-10" and time ""
+    And I press "Save"
+    Then I should see the text "Page [TEST] Date only test page has been updated."
+
+  @api @datetime
+  Scenario: Fill date-only field using date part step
+    Given page content:
+      | title                        |
+      | [TEST] Date part test page   |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "page" content edit page with the title "[TEST] Date part test page"
+    And I fill in the date part of the datetime field "Event date only" with "2024-04-05"
+    And I press "Save"
+    Then I should see the text "Page [TEST] Date part test page has been updated."
+
+  @api @datetime
+  Scenario: Fill daterange field with start and end dates
+    Given page content:
+      | title                        |
+      | [TEST] Daterange test page   |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "page" content edit page with the title "[TEST] Daterange test page"
+    And I fill in the start datetime field "Event period" with date "2024-06-01" and time "09:00:00"
+    And I fill in the end datetime field "Event period" with date "2024-06-05" and time "17:00:00"
+    And I press "Save"
+    Then I should see the text "Page [TEST] Daterange test page has been updated."
+
+  @api @datetime
+  Scenario: Fill daterange date-only field
+    Given page content:
+      | title                                |
+      | [TEST] Daterange date only test page |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "page" content edit page with the title "[TEST] Daterange date only test page"
+    And I fill in the start datetime field "Event period date only" with date "2024-07-10" and time ""
+    And I fill in the end datetime field "Event period date only" with date "2024-07-15" and time ""
+    And I press "Save"
+    Then I should see the text "Page [TEST] Daterange date only test page has been updated."
+
+  @trait:FieldTrait @datetime
+  Scenario: Assert negative "fill in the datetime field" for non-existent field
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      And I go to "node/add/page"
+      And I fill in the datetime field "Non-existent field" with date "2024-01-01" and time "12:00:00"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Datetime field "Non-existent field" with part "value" and field "date" not found.
+      """
+
+  @trait:FieldTrait @datetime
+  Scenario: Assert negative "fill in the date part of the datetime field" for non-existent field
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      And I go to "node/add/page"
+      And I fill in the date part of the datetime field "Non-existent field" with "2024-01-01"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Datetime field "Non-existent field" with part "value" and field "date" not found.
+      """
+
+  @trait:FieldTrait @datetime
+  Scenario: Assert negative "fill in the time part of the datetime field" for non-existent field
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      And I go to "node/add/page"
+      And I fill in the time part of the datetime field "Non-existent field" with "12:00:00"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Datetime field "Non-existent field" with part "value" and field "time" not found.
+      """
+
+  @trait:FieldTrait @datetime
+  Scenario: Assert negative "fill in the start datetime field" for non-existent field
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      And I go to "node/add/page"
+      And I fill in the start datetime field "Non-existent range" with date "2024-01-01" and time ""
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Datetime field "Non-existent range" with part "value" and field "date" not found.
+      """
+
+  @trait:FieldTrait @datetime
+  Scenario: Assert negative "fill in the end datetime field" for non-existent field
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      And I go to "node/add/page"
+      And I fill in the end datetime field "Non-existent range" with date "2024-01-05" and time ""
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Datetime field "Non-existent range" with part "end_value" and field "date" not found.
+      """

--- a/tests/behat/fixtures/d10/config/sync/core.entity_form_display.node.page.default.yml
+++ b/tests/behat/fixtures/d10/config/sync/core.entity_form_display.node.page.default.yml
@@ -4,11 +4,17 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_date_only
+    - field.field.node.page.field_daterange
+    - field.field.node.page.field_daterange_date_only
+    - field.field.node.page.field_datetime
     - field.field.node.page.field_description
     - node.type.page
     - workflows.workflow.editorial
   module:
     - content_moderation
+    - datetime
+    - datetime_range
     - path
     - text
 _core:
@@ -31,6 +37,30 @@ content:
   created:
     type: datetime_timestamp
     weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_date_only:
+    type: datetime_default
+    weight: 122
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_daterange:
+    type: daterange_default
+    weight: 123
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_daterange_date_only:
+    type: daterange_default
+    weight: 124
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_datetime:
+    type: datetime_default
+    weight: 125
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/tests/behat/fixtures/d10/config/sync/core.entity_view_display.node.page.default.yml
+++ b/tests/behat/fixtures/d10/config/sync/core.entity_view_display.node.page.default.yml
@@ -39,4 +39,8 @@ content:
     weight: 101
     region: content
 hidden:
+  field_date_only: true
+  field_daterange: true
+  field_daterange_date_only: true
+  field_datetime: true
   search_api_excerpt: true

--- a/tests/behat/fixtures/d10/config/sync/core.entity_view_display.node.page.search_index.yml
+++ b/tests/behat/fixtures/d10/config/sync/core.entity_view_display.node.page.search_index.yml
@@ -30,6 +30,10 @@ content:
     weight: -20
     region: content
 hidden:
+  field_date_only: true
+  field_daterange: true
+  field_daterange_date_only: true
+  field_datetime: true
   field_description: true
   links: true
   search_api_excerpt: true

--- a/tests/behat/fixtures/d10/config/sync/core.entity_view_display.node.page.search_result.yml
+++ b/tests/behat/fixtures/d10/config/sync/core.entity_view_display.node.page.search_result.yml
@@ -36,5 +36,9 @@ content:
     weight: 101
     region: content
 hidden:
+  field_date_only: true
+  field_daterange: true
+  field_daterange_date_only: true
+  field_datetime: true
   field_description: true
   search_api_excerpt: true

--- a/tests/behat/fixtures/d10/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/tests/behat/fixtures/d10/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -34,5 +34,9 @@ content:
     weight: 101
     region: content
 hidden:
+  field_date_only: true
+  field_daterange: true
+  field_daterange_date_only: true
+  field_datetime: true
   field_description: true
   search_api_excerpt: true

--- a/tests/behat/fixtures/d10/config/sync/core.extension.yml
+++ b/tests/behat/fixtures/d10/config/sync/core.extension.yml
@@ -15,6 +15,7 @@ module:
   contextual: 0
   ctools: 0
   datetime: 0
+  datetime_range: 0
   dblog: 0
   draggableviews: 0
   draggableviews_demo: 0

--- a/tests/behat/fixtures/d10/config/sync/field.field.node.page.field_date_only.yml
+++ b/tests/behat/fixtures/d10/config/sync/field.field.node.page.field_date_only.yml
@@ -1,0 +1,21 @@
+uuid: 12345678-1234-1234-1234-000000000012
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_only
+    - node.type.page
+  module:
+    - datetime
+id: node.page.field_date_only
+field_name: field_date_only
+entity_type: node
+bundle: page
+label: 'Event date only'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/tests/behat/fixtures/d10/config/sync/field.field.node.page.field_daterange.yml
+++ b/tests/behat/fixtures/d10/config/sync/field.field.node.page.field_daterange.yml
@@ -1,0 +1,21 @@
+uuid: 12345678-1234-1234-1234-000000000013
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_daterange
+    - node.type.page
+  module:
+    - datetime_range
+id: node.page.field_daterange
+field_name: field_daterange
+entity_type: node
+bundle: page
+label: 'Event period'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/tests/behat/fixtures/d10/config/sync/field.field.node.page.field_daterange_date_only.yml
+++ b/tests/behat/fixtures/d10/config/sync/field.field.node.page.field_daterange_date_only.yml
@@ -1,0 +1,21 @@
+uuid: 12345678-1234-1234-1234-000000000014
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_daterange_date_only
+    - node.type.page
+  module:
+    - datetime_range
+id: node.page.field_daterange_date_only
+field_name: field_daterange_date_only
+entity_type: node
+bundle: page
+label: 'Event period date only'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/tests/behat/fixtures/d10/config/sync/field.field.node.page.field_datetime.yml
+++ b/tests/behat/fixtures/d10/config/sync/field.field.node.page.field_datetime.yml
@@ -1,0 +1,21 @@
+uuid: 12345678-1234-1234-1234-000000000011
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_datetime
+    - node.type.page
+  module:
+    - datetime
+id: node.page.field_datetime
+field_name: field_datetime
+entity_type: node
+bundle: page
+label: 'Event date'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/tests/behat/fixtures/d10/config/sync/field.storage.node.field_date_only.yml
+++ b/tests/behat/fixtures/d10/config/sync/field.storage.node.field_date_only.yml
@@ -1,0 +1,20 @@
+uuid: 12345678-1234-1234-1234-000000000002
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_date_only
+field_name: field_date_only
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/fixtures/d10/config/sync/field.storage.node.field_daterange.yml
+++ b/tests/behat/fixtures/d10/config/sync/field.storage.node.field_daterange.yml
@@ -1,0 +1,20 @@
+uuid: 12345678-1234-1234-1234-000000000003
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime_range
+    - node
+id: node.field_daterange
+field_name: field_daterange
+entity_type: node
+type: daterange
+settings:
+  datetime_type: datetime
+module: datetime_range
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/fixtures/d10/config/sync/field.storage.node.field_daterange_date_only.yml
+++ b/tests/behat/fixtures/d10/config/sync/field.storage.node.field_daterange_date_only.yml
@@ -1,0 +1,20 @@
+uuid: 12345678-1234-1234-1234-000000000004
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime_range
+    - node
+id: node.field_daterange_date_only
+field_name: field_daterange_date_only
+entity_type: node
+type: daterange
+settings:
+  datetime_type: date
+module: datetime_range
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/fixtures/d10/config/sync/field.storage.node.field_datetime.yml
+++ b/tests/behat/fixtures/d10/config/sync/field.storage.node.field_datetime.yml
@@ -1,0 +1,20 @@
+uuid: 12345678-1234-1234-1234-000000000001
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_datetime
+field_name: field_datetime
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/fixtures/d10/config/sync/search_api.index.default_index.yml
+++ b/tests/behat/fixtures/d10/config/sync/search_api.index.default_index.yml
@@ -145,11 +145,11 @@ processor_settings:
     title: true
     alt: true
     tags:
-      b: 2
-      h1: 5
-      h2: 3
-      h3: 2
-      string: 2
+      b: 2.0
+      h1: 5.0
+      h2: 3.0
+      h3: 2.0
+      string: 2.0
   ignorecase:
     weights:
       preprocess_index: -5

--- a/tests/behat/fixtures/d11/config/sync/core.entity_form_display.node.page.default.yml
+++ b/tests/behat/fixtures/d11/config/sync/core.entity_form_display.node.page.default.yml
@@ -4,11 +4,17 @@ status: true
 dependencies:
   config:
     - field.field.node.page.body
+    - field.field.node.page.field_date_only
+    - field.field.node.page.field_daterange
+    - field.field.node.page.field_daterange_date_only
+    - field.field.node.page.field_datetime
     - field.field.node.page.field_description
     - node.type.page
     - workflows.workflow.editorial
   module:
     - content_moderation
+    - datetime
+    - datetime_range
     - path
     - text
 _core:
@@ -31,6 +37,30 @@ content:
   created:
     type: datetime_timestamp
     weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_date_only:
+    type: datetime_default
+    weight: 122
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_daterange:
+    type: daterange_default
+    weight: 123
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_daterange_date_only:
+    type: daterange_default
+    weight: 124
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_datetime:
+    type: datetime_default
+    weight: 125
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/tests/behat/fixtures/d11/config/sync/core.extension.yml
+++ b/tests/behat/fixtures/d11/config/sync/core.extension.yml
@@ -15,6 +15,7 @@ module:
   contextual: 0
   ctools: 0
   datetime: 0
+  datetime_range: 0
   dblog: 0
   draggableviews: 0
   draggableviews_demo: 0

--- a/tests/behat/fixtures/d11/config/sync/field.field.node.page.field_date_only.yml
+++ b/tests/behat/fixtures/d11/config/sync/field.field.node.page.field_date_only.yml
@@ -1,0 +1,21 @@
+uuid: 12345678-1234-1234-1234-000000000012
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_only
+    - node.type.page
+  module:
+    - datetime
+id: node.page.field_date_only
+field_name: field_date_only
+entity_type: node
+bundle: page
+label: 'Event date only'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/tests/behat/fixtures/d11/config/sync/field.field.node.page.field_daterange.yml
+++ b/tests/behat/fixtures/d11/config/sync/field.field.node.page.field_daterange.yml
@@ -1,0 +1,21 @@
+uuid: 12345678-1234-1234-1234-000000000013
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_daterange
+    - node.type.page
+  module:
+    - datetime_range
+id: node.page.field_daterange
+field_name: field_daterange
+entity_type: node
+bundle: page
+label: 'Event period'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/tests/behat/fixtures/d11/config/sync/field.field.node.page.field_daterange_date_only.yml
+++ b/tests/behat/fixtures/d11/config/sync/field.field.node.page.field_daterange_date_only.yml
@@ -1,0 +1,21 @@
+uuid: 12345678-1234-1234-1234-000000000014
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_daterange_date_only
+    - node.type.page
+  module:
+    - datetime_range
+id: node.page.field_daterange_date_only
+field_name: field_daterange_date_only
+entity_type: node
+bundle: page
+label: 'Event period date only'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/tests/behat/fixtures/d11/config/sync/field.field.node.page.field_datetime.yml
+++ b/tests/behat/fixtures/d11/config/sync/field.field.node.page.field_datetime.yml
@@ -1,0 +1,21 @@
+uuid: 12345678-1234-1234-1234-000000000011
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_datetime
+    - node.type.page
+  module:
+    - datetime
+id: node.page.field_datetime
+field_name: field_datetime
+entity_type: node
+bundle: page
+label: 'Event date'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/tests/behat/fixtures/d11/config/sync/field.storage.node.field_date_only.yml
+++ b/tests/behat/fixtures/d11/config/sync/field.storage.node.field_date_only.yml
@@ -1,0 +1,20 @@
+uuid: 12345678-1234-1234-1234-000000000002
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_date_only
+field_name: field_date_only
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/fixtures/d11/config/sync/field.storage.node.field_daterange.yml
+++ b/tests/behat/fixtures/d11/config/sync/field.storage.node.field_daterange.yml
@@ -1,0 +1,20 @@
+uuid: 12345678-1234-1234-1234-000000000003
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime_range
+    - node
+id: node.field_daterange
+field_name: field_daterange
+entity_type: node
+type: daterange
+settings:
+  datetime_type: datetime
+module: datetime_range
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/fixtures/d11/config/sync/field.storage.node.field_daterange_date_only.yml
+++ b/tests/behat/fixtures/d11/config/sync/field.storage.node.field_daterange_date_only.yml
@@ -1,0 +1,20 @@
+uuid: 12345678-1234-1234-1234-000000000004
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime_range
+    - node
+id: node.field_daterange_date_only
+field_name: field_daterange_date_only
+entity_type: node
+type: daterange
+settings:
+  datetime_type: date
+module: datetime_range
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/fixtures/d11/config/sync/field.storage.node.field_datetime.yml
+++ b/tests/behat/fixtures/d11/config/sync/field.storage.node.field_datetime.yml
@@ -1,0 +1,20 @@
+uuid: 12345678-1234-1234-1234-000000000001
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_datetime
+field_name: field_datetime
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Closes #406

## Summary of Added Steps

This PR adds **5 new Behat step definitions** for handling datetime fields in Drupal:

1. **`@When I fill in the datetime field :label with date :date and time :time`**
   - Fills a datetime field with both date and time (time is optional)
   - Example: `When I fill in the datetime field "Event date" with date "2024-01-15" and time "14:30:00"`

2. **`@When I fill in the date part of the datetime field :label with :date`**
   - Fills only the date portion of a datetime field
   - Example: `When I fill in the date part of the datetime field "Event date" with "2024-01-15"`

3. **`@When I fill in the time part of the datetime field :label with :time`**
   - Fills only the time portion of a datetime field
   - Example: `When I fill in the time part of the datetime field "Event date" with "14:30:00"`

4. **`@When I fill in the start datetime field :label with date :date and time :time`**
   - Fills the start value of a daterange field (time is optional)
   - Example: `When I fill in the start datetime field "Event period" with date "2024-01-15" and time "14:30:00"`

5. **`@When I fill in the end datetime field :label with date :date and time :time`**
   - Fills the end value of a daterange field (time is optional)
   - Example: `When I fill in the end datetime field "Event period" with date "2024-01-20" and time "18:00:00"`
