### PR TITLE
[#433] Added support to enable and disable Drupal modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ from the community.
 | [Drupal\MediaTrait](STEPS.md#drupalmediatrait) | Manage Drupal media entities with type-specific field handling. |
 | [Drupal\MenuTrait](STEPS.md#drupalmenutrait) | Manage Drupal menu systems and menu link rendering. |
 | [Drupal\MetatagTrait](STEPS.md#drupalmetatagtrait) | Assert `<meta>` tags in page markup. |
+| [Drupal\ModuleTrait](STEPS.md#drupalmoduletrait) | Enable and disable Drupal modules with automatic state restoration. |
 | [Drupal\OverrideTrait](STEPS.md#drupaloverridetrait) | Override Drupal Extension behaviors. |
 | [Drupal\ParagraphsTrait](STEPS.md#drupalparagraphstrait) | Manage Drupal paragraphs entities with structured field data. |
 | [Drupal\SearchApiTrait](STEPS.md#drupalsearchapitrait) | Assert Drupal Search API with index and query operations. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -33,6 +33,7 @@
 | [Drupal\MediaTrait](#drupalmediatrait) | Manage Drupal media entities with type-specific field handling. |
 | [Drupal\MenuTrait](#drupalmenutrait) | Manage Drupal menu systems and menu link rendering. |
 | [Drupal\MetatagTrait](#drupalmetatagtrait) | Assert `<meta>` tags in page markup. |
+| [Drupal\ModuleTrait](#drupalmoduletrait) | Enable and disable Drupal modules with automatic state restoration. |
 | [Drupal\OverrideTrait](#drupaloverridetrait) | Override Drupal Extension behaviors. |
 | [Drupal\ParagraphsTrait](#drupalparagraphstrait) | Manage Drupal paragraphs entities with structured field data. |
 | [Drupal\SearchApiTrait](#drupalsearchapitrait) | Assert Drupal Search API with index and query operations. |
@@ -2847,6 +2848,142 @@ Given the following menu links exist in the menu "Main navigation":
 >  Assert `<meta>` tags in page markup.
 >  - Assert presence and content of meta tags with proper attribute handling.
 
+
+## Drupal\ModuleTrait
+
+[Source](src/Drupal/ModuleTrait.php), [Example](tests/behat/features/drupal_module.feature)
+
+>  Enable and disable Drupal modules with automatic state restoration.
+>  <br/><br/>
+>  Supports automatic module management via scenario tags.
+>  <br/><br/>
+>  Skip processing with tags: `@behat-steps-skip:moduleBeforeScenario` and
+>  `@behat-steps-skip:moduleAfterScenario`.
+>  <br/><br/>
+>  Special tags:
+>  - `@module:module_name` - enable module for scenario
+>  - `@module:!module_name` - disable module for scenario
+
+
+<details>
+  <summary><code>@Given the :module module is enabled</code></summary>
+
+<br/>
+Enable a module
+<br/><br/>
+
+```gherkin
+Given the "ctools" module is enabled
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the :module module is disabled</code></summary>
+
+<br/>
+Disable a module
+<br/><br/>
+
+```gherkin
+Given the "shield" module is disabled
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the following modules are enabled:</code></summary>
+
+<br/>
+Enable multiple modules
+<br/><br/>
+
+```gherkin
+Given the following modules are enabled:
+  | ctools |
+  | views  |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the following modules are disabled:</code></summary>
+
+<br/>
+Disable multiple modules
+<br/><br/>
+
+```gherkin
+Given the following modules are disabled:
+  | shield           |
+  | stage_file_proxy |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the :module module should be enabled</code></summary>
+
+<br/>
+Assert that a module is enabled
+<br/><br/>
+
+```gherkin
+Then the "ctools" module should be enabled
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the :module module should be disabled</code></summary>
+
+<br/>
+Assert that a module is disabled
+<br/><br/>
+
+```gherkin
+Then the "shield" module should be disabled
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the following modules should be enabled:</code></summary>
+
+<br/>
+Assert that multiple modules are enabled
+<br/><br/>
+
+```gherkin
+Then the following modules should be enabled:
+  | ctools |
+  | views  |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the following modules should be disabled:</code></summary>
+
+<br/>
+Assert that multiple modules are disabled
+<br/><br/>
+
+```gherkin
+Then the following modules should be disabled:
+  | shield           |
+  | stage_file_proxy |
+
+```
+
+</details>
 
 ## Drupal\OverrideTrait
 

--- a/src/Drupal/ModuleTrait.php
+++ b/src/Drupal/ModuleTrait.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Drupal;
+
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+
+/**
+ * Enable and disable Drupal modules with automatic state restoration.
+ *
+ * Supports automatic module management via scenario tags.
+ *
+ * Skip processing with tags: `@behat-steps-skip:moduleBeforeScenario` and
+ * `@behat-steps-skip:moduleAfterScenario`.
+ *
+ * Special tags:
+ * - `@module:module_name` - enable module for scenario
+ * - `@module:!module_name` - disable module for scenario
+ */
+trait ModuleTrait {
+
+  /**
+   * Stores original module states for restoration.
+   *
+   * @var array<string, bool>
+   */
+  protected array $moduleOriginalStates = [];
+
+  /**
+   * Enable/disable modules before scenario based on tags.
+   *
+   * @BeforeScenario
+   */
+  public function moduleBeforeScenario(BeforeScenarioScope $scope): void {
+    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+
+    $tags = $scope->getScenario()->getTags();
+    foreach ($tags as $tag) {
+      if (str_starts_with($tag, 'module:')) {
+        $module_spec = substr($tag, 7);
+        $should_disable = str_starts_with($module_spec, '!');
+        $module_name = $should_disable ? substr($module_spec, 1) : $module_spec;
+
+        // Store original state.
+        $this->moduleStoreOriginalState($module_name);
+
+        // Enable or disable module as specified.
+        if ($should_disable) {
+          if ($this->moduleIsEnabled($module_name)) {
+            $this->moduleDisable($module_name);
+          }
+        }
+        elseif (!$this->moduleIsEnabled($module_name)) {
+          $this->moduleEnable($module_name);
+        }
+      }
+    }
+  }
+
+  /**
+   * Restore module states after scenario.
+   *
+   * @AfterScenario
+   */
+  public function moduleAfterScenario(AfterScenarioScope $scope): void {
+    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+
+    foreach ($this->moduleOriginalStates as $module_name => $original_state) {
+      $current_state = $this->moduleIsEnabled($module_name);
+
+      if ($original_state !== $current_state) {
+        if ($original_state) {
+          $this->moduleEnable($module_name);
+        }
+        else {
+          $this->moduleDisable($module_name);
+        }
+      }
+    }
+
+    // Clear state tracking.
+    $this->moduleOriginalStates = [];
+  }
+
+  /**
+   * Enable a module.
+   *
+   * @code
+   * Given the "ctools" module is enabled
+   * @endcode
+   *
+   * @Given the :module module is enabled
+   */
+  public function moduleEnsureEnabled(string $module): void {
+    $this->moduleStoreOriginalState($module);
+    if (!$this->moduleIsEnabled($module)) {
+      $this->moduleEnable($module);
+    }
+  }
+
+  /**
+   * Disable a module.
+   *
+   * @code
+   * Given the "shield" module is disabled
+   * @endcode
+   *
+   * @Given the :module module is disabled
+   */
+  public function moduleEnsureDisabled(string $module): void {
+    $this->moduleStoreOriginalState($module);
+    if ($this->moduleIsEnabled($module)) {
+      $this->moduleDisable($module);
+    }
+  }
+
+  /**
+   * Enable multiple modules.
+   *
+   * @code
+   * Given the following modules are enabled:
+   *   | ctools |
+   *   | views  |
+   * @endcode
+   *
+   * @Given the following modules are enabled:
+   */
+  public function moduleEnsureEnabledMultiple(TableNode $modules_table): void {
+    foreach ($modules_table->getColumn(0) as $module) {
+      $this->moduleStoreOriginalState($module);
+      if (!$this->moduleIsEnabled($module)) {
+        $this->moduleEnable($module);
+      }
+    }
+  }
+
+  /**
+   * Disable multiple modules.
+   *
+   * @code
+   * Given the following modules are disabled:
+   *   | shield           |
+   *   | stage_file_proxy |
+   * @endcode
+   *
+   * @Given the following modules are disabled:
+   */
+  public function moduleEnsureDisabledMultiple(TableNode $modules_table): void {
+    foreach ($modules_table->getColumn(0) as $module) {
+      $this->moduleStoreOriginalState($module);
+      if ($this->moduleIsEnabled($module)) {
+        $this->moduleDisable($module);
+      }
+    }
+  }
+
+  /**
+   * Assert that a module is enabled.
+   *
+   * @code
+   * Then the "ctools" module should be enabled
+   * @endcode
+   *
+   * @Then the :module module should be enabled
+   */
+  public function moduleAssertEnabled(string $module): void {
+    if (!$this->moduleIsEnabled($module)) {
+      throw new \Exception(sprintf('The module "%s" is not enabled, but it should be.', $module));
+    }
+  }
+
+  /**
+   * Assert that a module is disabled.
+   *
+   * @code
+   * Then the "shield" module should be disabled
+   * @endcode
+   *
+   * @Then the :module module should be disabled
+   */
+  public function moduleAssertDisabled(string $module): void {
+    if ($this->moduleIsEnabled($module)) {
+      throw new \Exception(sprintf('The module "%s" is enabled, but it should not be.', $module));
+    }
+  }
+
+  /**
+   * Assert that multiple modules are enabled.
+   *
+   * @code
+   * Then the following modules should be enabled:
+   *   | ctools |
+   *   | views  |
+   * @endcode
+   *
+   * @Then the following modules should be enabled:
+   */
+  public function moduleAssertEnabledMultiple(TableNode $modules_table): void {
+    foreach ($modules_table->getColumn(0) as $module) {
+      if (!$this->moduleIsEnabled($module)) {
+        throw new \Exception(sprintf('The module "%s" is not enabled, but it should be.', $module));
+      }
+    }
+  }
+
+  /**
+   * Assert that multiple modules are disabled.
+   *
+   * @code
+   * Then the following modules should be disabled:
+   *   | shield           |
+   *   | stage_file_proxy |
+   * @endcode
+   *
+   * @Then the following modules should be disabled:
+   */
+  public function moduleAssertDisabledMultiple(TableNode $modules_table): void {
+    foreach ($modules_table->getColumn(0) as $module) {
+      if ($this->moduleIsEnabled($module)) {
+        throw new \Exception(sprintf('The module "%s" is enabled, but it should not be.', $module));
+      }
+    }
+  }
+
+  /**
+   * Check if a module is enabled.
+   *
+   * @param string $module
+   *   The module machine name.
+   *
+   * @return bool
+   *   TRUE if the module is enabled, FALSE otherwise.
+   */
+  protected function moduleIsEnabled(string $module): bool {
+    return \Drupal::moduleHandler()->moduleExists($module);
+  }
+
+  /**
+   * Enable a module.
+   *
+   * @param string $module
+   *   The module machine name.
+   */
+  protected function moduleEnable(string $module): void {
+    if ($this->moduleIsEnabled($module)) {
+      return;
+    }
+
+    if (!$this->moduleIsPresent($module)) {
+      throw new \RuntimeException(sprintf('Cannot enable module "%s": module is not installed.', $module));
+    }
+
+    try {
+      \Drupal::service('module_installer')->install([$module]);
+      drupal_flush_all_caches();
+    }
+    catch (\Exception $e) {
+      throw new \RuntimeException(sprintf('Failed to enable module "%s": %s', $module, $e->getMessage()), $e->getCode(), $e);
+    }
+  }
+
+  /**
+   * Disable a module.
+   *
+   * @param string $module
+   *   The module machine name.
+   */
+  protected function moduleDisable(string $module): void {
+    if (!$this->moduleIsEnabled($module)) {
+      return;
+    }
+
+    try {
+      \Drupal::service('module_installer')->uninstall([$module]);
+      drupal_flush_all_caches();
+    }
+    catch (\Exception $e) {
+      throw new \RuntimeException(sprintf('Failed to disable module "%s": %s', $module, $e->getMessage()), $e->getCode(), $e);
+    }
+  }
+
+  /**
+   * Check if a module's code is present.
+   *
+   * @param string $module
+   *   The module machine name.
+   *
+   * @return bool
+   *   TRUE if the module's code is present, FALSE otherwise.
+   */
+  protected function moduleIsPresent(string $module): bool {
+    $module_list = \Drupal::service('extension.list.module')->getList();
+    return isset($module_list[$module]);
+  }
+
+  /**
+   * Store original module state if not already stored.
+   *
+   * @param string $module
+   *   The module name.
+   */
+  protected function moduleStoreOriginalState(string $module): void {
+    if (!array_key_exists($module, $this->moduleOriginalStates)) {
+      $this->moduleOriginalStates[$module] = $this->moduleIsEnabled($module);
+    }
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -20,6 +20,7 @@ use DrevOps\BehatSteps\Drupal\FileTrait;
 use DrevOps\BehatSteps\Drupal\MediaTrait;
 use DrevOps\BehatSteps\Drupal\MenuTrait;
 use DrevOps\BehatSteps\Drupal\MetatagTrait;
+use DrevOps\BehatSteps\Drupal\ModuleTrait;
 use DrevOps\BehatSteps\Drupal\OverrideTrait;
 use DrevOps\BehatSteps\Drupal\ParagraphsTrait;
 use DrevOps\BehatSteps\Drupal\SearchApiTrait;
@@ -64,6 +65,7 @@ class FeatureContext extends DrupalContext {
   use MediaTrait;
   use MenuTrait;
   use MetatagTrait;
+  use ModuleTrait;
   use OverrideTrait;
   use ParagraphsTrait;
   use PathTrait;

--- a/tests/behat/features/drupal_module.feature
+++ b/tests/behat/features/drupal_module.feature
@@ -1,0 +1,183 @@
+Feature: Check that ModuleTrait works
+  As Behat Steps library developer
+  I want to provide tools to manage Drupal modules programmatically
+  So that users can enable/disable modules during tests and restore state automatically
+
+  @api
+  Scenario: Assert "Given the :module module is enabled" enables a module
+    Given I am logged in as a user with the "administrator" role
+    And the "help" module is disabled
+    When the "help" module is enabled
+    Then the "help" module should be enabled
+
+  @api
+  Scenario: Assert "Given the :module module is disabled" disables a module
+    Given I am logged in as a user with the "administrator" role
+    And the "help" module is enabled
+    When the "help" module is disabled
+    Then the "help" module should be disabled
+
+  @api
+  Scenario: Assert "Then the :module module should be enabled" assertion works
+    Given I am logged in as a user with the "administrator" role
+    And the "help" module is enabled
+    Then the "help" module should be enabled
+
+  @api
+  Scenario: Assert "Then the :module module should be disabled" assertion works
+    Given I am logged in as a user with the "administrator" role
+    And the "help" module is disabled
+    Then the "help" module should be disabled
+
+  @api
+  Scenario: Assert "Given the following modules are enabled:" enables multiple modules
+    Given I am logged in as a user with the "administrator" role
+    And the following modules are disabled:
+      | help |
+      | ban  |
+    When the following modules are enabled:
+      | help |
+      | ban  |
+    Then the following modules should be enabled:
+      | help |
+      | ban  |
+
+  @api
+  Scenario: Assert "Given the following modules are disabled:" disables multiple modules
+    Given I am logged in as a user with the "administrator" role
+    And the following modules are enabled:
+      | help |
+      | ban  |
+    When the following modules are disabled:
+      | help |
+      | ban  |
+    Then the following modules should be disabled:
+      | help |
+      | ban  |
+
+  @api @trait:Drupal\ModuleTrait
+  Scenario: Assert negative assertion for "Then the :module module should be enabled" works with disabled module
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the "help" module is disabled
+      Then the "help" module should be enabled
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The module "help" is not enabled, but it should be.
+      """
+
+  @api @trait:Drupal\ModuleTrait
+  Scenario: Assert negative assertion for "Then the :module module should be disabled" works with enabled module
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the "help" module is enabled
+      Then the "help" module should be disabled
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The module "help" is enabled, but it should not be.
+      """
+
+  @api @module:help
+  Scenario: Assert @module:module_name tag enables module automatically
+    Given I am logged in as a user with the "administrator" role
+    Then the "help" module should be enabled
+
+  @api @module:!help
+  Scenario: Assert @module:!module_name tag disables module automatically
+    Given I am logged in as a user with the "administrator" role
+    Then the "help" module should be disabled
+
+  @api @module:help @module:ban
+  Scenario: Assert multiple @module tags enable multiple modules
+    Given I am logged in as a user with the "administrator" role
+    Then the "help" module should be enabled
+    And the "ban" module should be enabled
+
+  @api @module:help @module:ban @module:!history
+  Scenario: Assert mixed @module tags with enable and disable work together
+    Given I am logged in as a user with the "administrator" role
+    Then the "help" module should be enabled
+    And the "ban" module should be enabled
+    And the "history" module should be disabled
+
+  # Skip automatic state restoration because this scenario intentionally sets up
+  # initial state for the next scenarios to test tag-based restoration.
+  # Without the skip tag, the Given step would store the original state and
+  # restore it at the end, interfering with the cross-scenario test flow.
+  @api @behat-steps-skip:moduleAfterScenario
+  Scenario: Assert module state is restored after scenario changes
+    Given I am logged in as a user with the "administrator" role
+    # First, ensure help is disabled
+    And the "help" module is disabled
+    Then the "help" module should be disabled
+
+  @api @module:help
+  Scenario: Assert module state restoration works after tag-based enable
+    Given I am logged in as a user with the "administrator" role
+    # This scenario should enable help via tag, but after this scenario
+    # the previous state should be restored in the next scenario
+    Then the "help" module should be enabled
+
+  @api
+  Scenario: Verify module state was restored after previous scenario with tag
+    Given I am logged in as a user with the "administrator" role
+    # This verifies that help module was restored to disabled state
+    # after the previous scenario that used @module:help tag
+    Then the "help" module should be disabled
+
+  @api
+  Scenario: Setup initial state for Given step restoration test
+    Given I am logged in as a user with the "administrator" role
+    # Ensure ban is disabled as the initial state
+    And the "ban" module is disabled
+    Then the "ban" module should be disabled
+
+  @api
+  Scenario: Assert module state changes via Given step
+    Given I am logged in as a user with the "administrator" role
+    # Enable ban module using Given step (not tag)
+    And the "ban" module is enabled
+    Then the "ban" module should be enabled
+
+  @api
+  Scenario: Verify module state was restored after Given step modification
+    Given I am logged in as a user with the "administrator" role
+    # This verifies that ban module was restored to disabled state
+    # after the previous scenario modified it using Given step
+    Then the "ban" module should be disabled
+
+  @api
+  Scenario: Assert enabling already-enabled module is idempotent
+    Given I am logged in as a user with the "administrator" role
+    And the "help" module is enabled
+    When the "help" module is enabled
+    Then the "help" module should be enabled
+
+  @api
+  Scenario: Assert disabling already-disabled module is idempotent
+    Given I am logged in as a user with the "administrator" role
+    And the "help" module is disabled
+    When the "help" module is disabled
+    Then the "help" module should be disabled
+
+  @api @trait:Drupal\ModuleTrait
+  Scenario: Assert enabling non-existent module throws error
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the "nonexistent_module_xyz" module is enabled
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Cannot enable module "nonexistent_module_xyz": module is not installed.
+      """

--- a/tests/behat/features/field.feature
+++ b/tests/behat/features/field.feature
@@ -443,8 +443,8 @@ Feature: Check that FieldTrait works
   @api @datetime
   Scenario: Fill date-only field using date part step
     Given page content:
-      | title                        |
-      | [TEST] Date part test page   |
+      | title                      |
+      | [TEST] Date part test page |
     And I am logged in as a user with the "administrator" role
     When I visit the "page" content edit page with the title "[TEST] Date part test page"
     And I fill in the date part of the datetime field "Event date only" with "2024-04-05"
@@ -454,8 +454,8 @@ Feature: Check that FieldTrait works
   @api @datetime
   Scenario: Fill daterange field with start and end dates
     Given page content:
-      | title                        |
-      | [TEST] Daterange test page   |
+      | title                      |
+      | [TEST] Daterange test page |
     And I am logged in as a user with the "administrator" role
     When I visit the "page" content edit page with the title "[TEST] Daterange test page"
     And I fill in the start datetime field "Event period" with date "2024-06-01" and time "09:00:00"


### PR DESCRIPTION
Closes #433


This PR adds **8 Behat steps** for managing Drupal modules:

**Single Module Operations:**
1. `Given the :module module is enabled` - Enables a module
2. `Given the :module module is disabled` - Disables a module
3. `Then the :module module should be enabled` - Asserts a module is enabled
4. `Then the :module module should be disabled` - Asserts a module is disabled

**Multiple Module Operations:**
5. `Given the following modules are enabled:` - Enables multiple modules from a table
6. `Given the following modules are disabled:` - Disables multiple modules from a table
7. `Then the following modules should be enabled:` - Asserts multiple modules are enabled
8. `Then the following modules should be disabled:` - Asserts multiple modules are disabled

## Tagging Feature

The tagging feature allows you to **automatically enable/disable modules** for specific scenarios using scenario tags:

**Tag Syntax:**
- `@module:module_name` - Automatically enables the module for the scenario
- `@module:!module_name` - Automatically disables the module for the scenario

**Examples:**
```gherkin
@api @module:help
Scenario: Test with help module enabled
  # help module is automatically enabled before this scenario

@api @module:!shield
Scenario: Test with shield module disabled
  # shield module is automatically disabled before this scenario

@api @module:ctools @module:views @module:!shield
Scenario: Test with multiple module states
  # ctools and views are enabled, shield is disabled
```
