### PR TITLE
Fixed code coverage for tests ran in subprocesses.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -144,7 +144,9 @@ commands:
 
   test-bdd-coverage:
     usage: Run BDD tests with coverage.
-    cmd: ahoy cli "cd /app/build && php -dpcov.enabled=1 -dpcov.directory=/app/src vendor/bin/behat -c /app/behat.yml --strict --colors $@"
+    cmd: |
+      ahoy cli "cd /app/build && php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat -c /app/behat.yml --strict --colors $@"
+      ahoy cli "php /app/scripts/merge-coverage.php"
 
   debug:
     usage: Enable PHP Xdebug.

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,4 +20,5 @@
 /phpunit.xml         export-ignore
 /rector.php          export-ignore
 /renovate.json       export-ignore
+/scripts             export-ignore
 /tests               export-ignore

--- a/behat.yml
+++ b/behat.yml
@@ -87,7 +87,5 @@ default:
         text:
           showColors: true
           showOnlySummary: true
-        html:
-          target: '%paths.base%/.logs/coverage/behat/.coverage-html'
-        cobertura:
-          target: '%paths.base%/.logs/coverage/behat/cobertura.xml'
+        php:
+          target: '%paths.base%/.logs/coverage/behat/phpcov.php'

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,6 +23,7 @@
     <config name="testVersion" value="8.2"/>
 
     <file>docs.php</file>
+    <file>scripts</file>
     <file>src</file>
     <file>tests/behat/bootstrap</file>
     <file>tests/behat/fixtures/d10/web/modules/custom</file>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
 
   paths:
     - docs.php
+    - scripts
     - src
     - tests/behat/bootstrap
     - tests/behat/fixtures/d10/web/modules/custom

--- a/rector.php
+++ b/rector.php
@@ -38,6 +38,7 @@ use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 return RectorConfig::configure()
   ->withPaths([
     '/app/docs.php',
+    '/app/scripts',
     '/app/src',
     '/app/tests/behat/bootstrap',
     '/app/tests/behat/fixtures/d10/web/modules/custom',

--- a/scripts/merge-coverage.php
+++ b/scripts/merge-coverage.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * @file
+ * Merge coverage files from subprocess Behat runs into the main coverage file.
+ *
+ * Usage:
+ * php merge-coverage.php [coverage_root_path].
+ *
+ * Where coverage_root_path is the optional path to the coverage root directory.
+ * Defaults to '/app/.logs/coverage'.
+ *
+ * This will also generate Cobertura and HTML reports from the merged coverage
+ * data.
+ */
+
+declare(strict_types=1);
+
+use SebastianBergmann\CodeCoverage\Report\Html\Facade;
+use SebastianBergmann\CodeCoverage\Report\Cobertura;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// Get coverage root path from command line argument or use default.
+define('COVERAGE_ROOT_PATH', $argv[1] ?? '/app/.logs/coverage');
+
+// Source coverage files to be merged.
+define('SOURCE_MAIN_COVERAGE_FILE', COVERAGE_ROOT_PATH . '/behat/phpcov.php');
+define('SOURCE_SUBPROCESS_COVERAGE_DIR', COVERAGE_ROOT_PATH . '/behat_cli/phpcov');
+
+// Output files for merged coverage and reports.
+define('OUTPUT_MERGED_COVERAGE_FILE', COVERAGE_ROOT_PATH . '/behat_cli/phpcov.php');
+define('OUTPUT_COBERTURA_REPORT_FILE', COVERAGE_ROOT_PATH . '/behat_cli/cobertura.xml');
+define('OUTPUT_HTML_REPORT_DIR', COVERAGE_ROOT_PATH . '/behat_cli/.coverage-html');
+
+if (!file_exists(SOURCE_MAIN_COVERAGE_FILE)) {
+  echo sprintf('Main coverage file not found: %s%s', SOURCE_MAIN_COVERAGE_FILE, PHP_EOL);
+  exit(1);
+}
+
+// Load main coverage.
+try {
+  $main_coverage = @include SOURCE_MAIN_COVERAGE_FILE;
+}
+catch (\Throwable $e) {
+  echo "Error loading main Behat coverage file: " . $e->getMessage() . "\n";
+  echo "Skipping coverage merge.\n";
+  exit(0);
+}
+
+if (!$main_coverage instanceof CodeCoverage) {
+  echo "Invalid main Behat coverage file format or unserialization failed.\n";
+  echo "This may be due to version incompatibility. Skipping coverage merge.\n";
+  exit(0);
+}
+
+// Find all subprocess coverage files.
+$subprocess_files = [];
+if (is_dir(SOURCE_SUBPROCESS_COVERAGE_DIR)) {
+  $subprocess_files = glob(SOURCE_SUBPROCESS_COVERAGE_DIR . '/*.php');
+}
+
+if (empty($subprocess_files)) {
+  echo "No subprocess coverage files found, skipping merge.\n";
+  exit(0);
+}
+
+echo "Merging " . count($subprocess_files) . " subprocess coverage files...\n";
+
+foreach ($subprocess_files as $file) {
+  try {
+    $subprocess_coverage = include $file;
+    if ($subprocess_coverage instanceof CodeCoverage) {
+      $main_coverage->merge($subprocess_coverage);
+      echo "  Merged: " . basename($file) . "\n";
+    }
+  }
+  catch (\Exception $e) {
+    echo "  Error merging " . basename($file) . ": " . $e->getMessage() . "\n";
+  }
+}
+
+// Save merged coverage.
+$output_dir = dirname(OUTPUT_MERGED_COVERAGE_FILE);
+if (!is_dir($output_dir)) {
+  mkdir($output_dir, 0755, TRUE);
+}
+
+file_put_contents(OUTPUT_MERGED_COVERAGE_FILE, '<?php' . PHP_EOL . 'return \\unserialize(' . var_export(serialize($main_coverage), TRUE) . ');' . PHP_EOL);
+
+echo sprintf('Coverage merged and saved to: %s%s', OUTPUT_MERGED_COVERAGE_FILE, PHP_EOL);
+
+// Generate Cobertura report.
+$cobertura_report = new Cobertura();
+file_put_contents(OUTPUT_COBERTURA_REPORT_FILE, $cobertura_report->process($main_coverage));
+echo sprintf('Cobertura report generated: %s%s', OUTPUT_COBERTURA_REPORT_FILE, PHP_EOL);
+
+// Generate HTML report.
+$html_report = new Facade();
+$html_report->process($main_coverage, OUTPUT_HTML_REPORT_DIR);
+echo sprintf('HTML report generated: %s%s', OUTPUT_HTML_REPORT_DIR, PHP_EOL);

--- a/tests/behat/bootstrap/BehatCliContext.php
+++ b/tests/behat/bootstrap/BehatCliContext.php
@@ -271,7 +271,7 @@ EOL;
 
     // Forward pcov settings if enabled.
     if (static::behatCliIsCoverageEnabled()) {
-      $php .= ' -dpcov.enabled=1 -dpcov.directory=' . ini_get('pcov.directory');
+      $php .= ' -d pcov.enabled=1 -d pcov.directory=' . ini_get('pcov.directory');
     }
 
     $cmd = sprintf(

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -293,7 +293,9 @@ default:
 EOL;
 
     if (static::behatCliIsCoverageEnabled()) {
-      $coverage_content = <<<'EOL'
+      // Generate unique coverage filename for this subprocess to avoid conflicts.
+      $coverage_id = md5($this->workingDir);
+      $coverage_content = <<<EOL
 
     DVDoug\Behat\CodeCoverage\Extension:
       filter:
@@ -304,10 +306,8 @@ EOL;
         text:
           showColors: true
           showOnlySummary: true
-        html:
-          target: /app/.logs/coverage/behat_cli/.coverage-html
-        cobertura:
-          target: /app/.logs/coverage/behat_cli/cobertura.xml
+        php:
+          target: /app/.logs/coverage/behat_cli/phpcov/{$coverage_id}.php
 EOL;
       $content .= $coverage_content;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for parallel Behat runs by generating unique per-process coverage files.
  * Added an automatic merge step that consolidates subprocess coverage into a single report and emits PHP, HTML, and Cobertura outputs.

* **Chores**
  * Enabled coverage-related flags during test runs and added a post-test merge step.
  * Included project scripts in static analysis/tooling scans and excluded them from archive exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->