### PR TITLE
Increased coverage for WatchdogTrait.

### DIFF
--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -27,7 +27,7 @@ trait WatchdogTrait {
   /**
    * Start time for each scenario.
    *
-   * @var int
+   * @var int|null
    */
   protected $watchdogScenarioStartTime;
 
@@ -100,6 +100,11 @@ trait WatchdogTrait {
     }
 
     if (!$database->schema()->tableExists('watchdog')) {
+      throw new \RuntimeException('Watchdog table does not exist. Ensure the dblog module is enabled.');
+    }
+
+    // If watchdogSetScenario was skipped, the start time won't be set.
+    if (!isset($this->watchdogScenarioStartTime)) {
       return;
     }
 

--- a/tests/behat/bootstrap/FeatureContextTrait.php
+++ b/tests/behat/bootstrap/FeatureContextTrait.php
@@ -72,6 +72,18 @@ trait FeatureContextTrait {
   }
 
   /**
+   * Clear watchdog table.
+   *
+   * @Given the watchdog is cleared
+   */
+  public function testClearWatchdogTable(): void {
+    $database = Database::getConnection();
+    if ($database->schema()->tableExists('watchdog')) {
+      $database->truncate('watchdog')->execute();
+    }
+  }
+
+  /**
    * Assert that a user exists.
    *
    * @Then user :name should exist

--- a/tests/behat/features/drupal_watchdog.feature
+++ b/tests/behat/features/drupal_watchdog.feature
@@ -47,3 +47,49 @@ Feature: Check that WatchdogTrait works
   @api @error
   Scenario: Assert that watchdog track errors with level above threshold
     When set watchdog error level "warning"
+
+  @api @watchdog:custom_type
+  Scenario: Assert that @watchdog tag parsing works with custom type
+    # This scenario tests that the @watchdog:custom_type tag is parsed correctly
+    # The watchdog functionality will check for both 'php' and 'custom_type' messages
+    Given the watchdog is cleared
+    When I go to the homepage
+
+  @api @watchdog:type1 @watchdog:type2
+  Scenario: Assert that multiple @watchdog tags are parsed correctly
+    # This scenario tests that multiple @watchdog tags are parsed into message types
+    Given the watchdog is cleared
+    When I go to the homepage
+
+  @trait:Drupal\WatchdogTrait
+  Scenario: Assert that skip tag for watchdogSetScenario hook works
+    Given some behat configuration
+    And scenario steps tagged with "@behat-steps-skip:watchdogSetScenario":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @trait:Drupal\WatchdogTrait
+  Scenario: Assert that skip tag for watchdogAfterScenario hook works
+    Given some behat configuration
+    And scenario steps tagged with "@behat-steps-skip:watchdogAfterScenario":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @trait:Drupal\WatchdogTrait,Drupal\ModuleTrait
+  Scenario: Assert that missing watchdog table throws RuntimeException
+    Given some behat configuration
+    And scenario steps tagged with "@module:!dblog":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Watchdog table does not exist. Ensure the dblog module is enabled.
+      """


### PR DESCRIPTION
Breaking change: a `\RuntimeException` will be thrown if `dblog` is not enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when the database logging module is not enabled.
  * Added null-safety checks for watchdog initialization scenarios.

* **Tests**
  * Extended test coverage for watchdog functionality, including tag parsing, multiple tag handling, and error condition validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->