### PR TITLE
[#431] Added support for the vertical column format in entity creation steps.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -1976,6 +1976,23 @@ Given the following "basic" content blocks exist:
 </details>
 
 <details>
+  <summary><code>@Given the following :type content blocks with fields:</code></summary>
+
+<br/>
+Create content blocks with vertical field format
+<br/><br/>
+
+```gherkin
+Given the following basic content blocks with fields:
+  | info   | [TEST] Block 1        | [TEST] Block 2        |
+  | body   | First block content   | Second block content  |
+  | status | 1                     | 1                     |
+
+```
+
+</details>
+
+<details>
   <summary><code>@When I edit the :type content block with the description :description</code></summary>
 
 <br/>
@@ -2039,6 +2056,23 @@ Given the following "article" content does not exist:
   | title                |
   | Test article         |
   | Another test article |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the following :type content with fields:</code></summary>
+
+<br/>
+Create content with vertical field format
+<br/><br/>
+
+```gherkin
+Given the following page content with fields:
+  | title  | [TEST] Page 1        | [TEST] Page 2        |
+  | body   | First page content   | Second page content  |
+  | status | 1                    | 1                    |
 
 ```
 
@@ -2751,6 +2785,22 @@ Given "video" media:
 </details>
 
 <details>
+  <summary><code>@Given the following :bundle media with fields:</code></summary>
+
+<br/>
+Create media entities with vertical field format
+<br/><br/>
+
+```gherkin
+Given the following image media with fields:
+  | name              | [TEST] Image 1       | [TEST] Image 2       |
+  | field_media_image | image1.jpg           | image2.jpg           |
+
+```
+
+</details>
+
+<details>
   <summary><code>@Given the following media :media_type do not exist:</code></summary>
 
 <br/>
@@ -3098,6 +3148,22 @@ When I run search indexing for 1 item
 
 
 <details>
+  <summary><code>@Given the following :vocabulary terms with fields:</code></summary>
+
+<br/>
+Create taxonomy terms with vertical field format
+<br/><br/>
+
+```gherkin
+Given the following tags terms with fields:
+  | name        | [TEST] Behat    | [TEST] Testing  |
+  | description | Testing tag     | QA tag          |
+
+```
+
+</details>
+
+<details>
   <summary><code>@Given the following :vocabulary_machine_name vocabulary terms do not exist:</code></summary>
 
 <br/>
@@ -3252,6 +3318,23 @@ Given the following users do not exist:
   | mail             |
   | john@example.com |
   | jane@example.com |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the following users with fields:</code></summary>
+
+<br/>
+Create users with vertical field format
+<br/><br/>
+
+```gherkin
+Given the following users with fields:
+  | name  | [TEST] user1         | [TEST] user2         |
+  | mail  | user1@example.com    | user2@example.com    |
+  | roles | editor               | author               |
 
 ```
 

--- a/docs.php
+++ b/docs.php
@@ -42,7 +42,7 @@ function main(array $options = []): void {
   require_once $base_path . '/tests/behat/bootstrap/FeatureContextTrait.php';
   require_once $base_path . '/tests/behat/bootstrap/FeatureContext.php';
 
-  $info = extract_info(FeatureContext::class, [FeatureContextTrait::class], $base_path);
+  $info = extract_info(FeatureContext::class, [FeatureContextTrait::class, 'HelperTrait'], $base_path);
 
   $errors = validate($info);
 

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -6,6 +6,7 @@ namespace DrevOps\BehatSteps\Drupal;
 
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use DrevOps\BehatSteps\HelperTrait;
 use Drupal\block_content\BlockContentTypeInterface;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\Core\Entity\EntityStorageException;
@@ -20,6 +21,8 @@ use Drupal\Core\Entity\EntityStorageException;
  * Skip processing with tag: `@behat-steps-skip:contentBlockAfterScenario`
  */
 trait ContentBlockTrait {
+
+  use HelperTrait;
 
   /**
    * Array of created block_content entities.
@@ -160,6 +163,34 @@ trait ContentBlockTrait {
   public function contentBlockCreate(string $type, TableNode $content_block_table): void {
     foreach ($content_block_table->getHash() as $hash) {
       $this->contentBlockCreateSingle($type, $hash);
+    }
+  }
+
+  /**
+   * Create content blocks with vertical field format.
+   *
+   * Supports both single and multiple entity creation using vertical table
+   * format where fields are listed in rows instead of columns.
+   *
+   * @param string $type
+   *   The content block type machine name.
+   * @param \Behat\Gherkin\Node\TableNode $table
+   *   Vertical format table with field names in first column.
+   *
+   * @Given the following :type content blocks with fields:
+   *
+   * @code
+   * Given the following basic content blocks with fields:
+   *   | info   | [TEST] Block 1        | [TEST] Block 2        |
+   *   | body   | First block content   | Second block content  |
+   *   | status | 1                     | 1                     |
+   * @endcode
+   */
+  public function contentBlockCreateWithFields(string $type, TableNode $table): void {
+    $entities = $this->helperTransposeVerticalTable($table);
+
+    foreach ($entities as $entity_data) {
+      $this->contentBlockCreateSingle($type, $entity_data);
     }
   }
 

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps;
+
+use Behat\Gherkin\Node\TableNode;
+
+/**
+ * Internal helper methods for Behat step definitions.
+ *
+ * This trait provides common helper methods that can be used across multiple
+ * Behat step definition traits. Include this trait in any trait that needs
+ * access to shared helper functionality.
+ *
+ * This is an internal trait and should not be used directly in step definitions.
+ */
+trait HelperTrait {
+
+  /**
+   * Transpose a vertical table format (field/value columns) to entity arrays.
+   *
+   * Supports both single and multiple entity creation:
+   *
+   * Single entity (2 columns):
+   *   | name  | John  |
+   *   | age   | 30    |
+   *
+   * Multiple entities (3+ columns):
+   *   | name  | John      | Jane      |
+   *   | age   | 30        | 25        |
+   *
+   * Returns:
+   *   Single entity: [['name' => 'John', 'age' => '30']]
+   *   Multiple entities: [['name' => 'John', 'age' => '30'], ['name' => 'Jane', 'age' => '25']]
+   *
+   * @param \Behat\Gherkin\Node\TableNode $table
+   *   The vertical format table.
+   *
+   * @return array<int, array<string, string>>
+   *   Array of entity data arrays. Each entity is an associative array.
+   *
+   * @throws \RuntimeException
+   *   If table doesn't have at least 2 columns or has no rows.
+   */
+  protected function helperTransposeVerticalTable(TableNode $table): array {
+    $rows = $table->getRows();
+
+    // Validate table has at least 2 columns (field + at least one value column).
+    $first_row = $rows[0];
+    if (count($first_row) < 2) {
+      throw new \RuntimeException('Vertical table must have at least 2 columns (field name and value).');
+    }
+
+    // Validate no duplicate field names.
+    $field_names = array_column($rows, 0);
+    $duplicate_fields = array_filter(array_count_values($field_names), fn(int $count): bool => $count > 1);
+
+    if (!empty($duplicate_fields)) {
+      throw new \RuntimeException(sprintf('Duplicate field names found: %s', implode(', ', array_keys($duplicate_fields))));
+    }
+
+    // Validate all field names are non-empty.
+    foreach ($field_names as $field_name) {
+      if (trim((string) $field_name) === '') {
+        throw new \RuntimeException('Field names cannot be empty.');
+      }
+    }
+
+    // Determine number of entities based on number of columns.
+    $num_entities = count($first_row) - 1;
+
+    // Initialize result array for each entity.
+    $entities = array_fill(0, $num_entities, []);
+
+    // Transpose the data.
+    foreach ($rows as $row) {
+      $field_name = array_shift($row);
+
+      // Assign each value to corresponding entity.
+      // Note: Gherkin's TableNode automatically pads missing cells with empty
+      // strings, so we don't need to validate row length.
+      foreach ($row as $index => $value) {
+        $entities[$index][$field_name] = $value;
+      }
+    }
+
+    return $entities;
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -34,6 +34,7 @@ use DrevOps\BehatSteps\FileDownloadTrait;
 use DrevOps\BehatSteps\JavascriptTrait;
 use DrevOps\BehatSteps\KeyboardTrait;
 use DrevOps\BehatSteps\LinkTrait;
+use DrevOps\BehatSteps\HelperTrait;
 use DrevOps\BehatSteps\PathTrait;
 use DrevOps\BehatSteps\ResponseTrait;
 use DrevOps\BehatSteps\ResponsiveTrait;
@@ -75,6 +76,7 @@ class FeatureContext extends DrupalContext {
   use TaxonomyTrait;
   use TestmodeTrait;
   use UserTrait;
+  use HelperTrait;
   use WaitTrait;
   use WatchdogTrait;
   use XmlTrait;

--- a/tests/behat/bootstrap/FeatureContextTrait.php
+++ b/tests/behat/bootstrap/FeatureContextTrait.php
@@ -10,6 +10,7 @@
 
 declare(strict_types=1);
 
+use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Hook\Scope\AfterFeatureScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
@@ -428,6 +429,26 @@ trait FeatureContextTrait {
    */
   public function goToPhpServerTestPage(): void {
     $this->getSession()->visit('http://cli:8888/relative.html');
+  }
+
+  /**
+   * Test helperTransposeVerticalTable method.
+   *
+   * @When I call helperTransposeVerticalTable with:
+   */
+  public function testCallHelperTransposeVerticalTable(TableNode $table): void {
+    $result = $this->helperTransposeVerticalTable($table);
+
+    if (empty($result)) {
+      throw new \Exception('helperTransposeVerticalTable returned empty result.');
+    }
+
+    // Validate result structure.
+    foreach ($result as $entity) {
+      if (!is_array($entity)) {
+        throw new \Exception('helperTransposeVerticalTable returned invalid entity data.');
+      }
+    }
   }
 
 }

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -275,3 +275,25 @@ Feature: Check that ContentTrait works
       """
       Unable to find "article" content with title "[TEST] No existing title".
       """
+
+  @api
+  Scenario: Create single node with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following page content with fields:
+      | title  | [TEST] Vertical Page    |
+      | body   | Vertical format content |
+      | status | 1                       |
+    When I go to "/admin/content"
+    Then I should see "[TEST] Vertical Page"
+
+  @api
+  Scenario: Create multiple nodes with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following page content with fields:
+      | title  | [TEST] V-Page 1    | [TEST] V-Page 2     | [TEST] V-Page 3    |
+      | body   | First page content | Second page content | Third page content |
+      | status | 1                  | 1                   | 1                  |
+    When I go to "/admin/content"
+    Then I should see "[TEST] V-Page 1"
+    And I should see "[TEST] V-Page 2"
+    And I should see "[TEST] V-Page 3"

--- a/tests/behat/features/drupal_content_block.feature
+++ b/tests/behat/features/drupal_content_block.feature
@@ -172,8 +172,8 @@ Feature: Check that ContentBlockTrait works
   @api @behat-steps-skip:contentBlockAfterScenario
   Scenario: Content blocks are not automatically cleaned up when skip tag is used
     Given the following "basic" content blocks exist:
-      | info                       | body                | status |
-      | [TEST] Skip Cleanup Block  | Skip cleanup test   | 1      |
+      | info                      | body              | status |
+      | [TEST] Skip Cleanup Block | Skip cleanup test | 1      |
     And I am logged in as a user with the "administrator" role
     When I visit "/admin/content/block"
     Then I should see "[TEST] Skip Cleanup Block"
@@ -181,3 +181,27 @@ Feature: Check that ContentBlockTrait works
     # Manual cleanup
     When the following "basic" content blocks do not exist:
       | [TEST] Skip Cleanup Block |
+
+  @api
+  Scenario: Create single content block with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following basic content blocks with fields:
+      | info   | [TEST] Vertical Block        |
+      | body   | Created with vertical format |
+      | status | 1                            |
+    When I go to "admin/content/block"
+    Then I should see "[TEST] Vertical Block"
+    When I edit the "basic" content block with the description "[TEST] Vertical Block"
+    Then the "Body" field should contain "Created with vertical format"
+
+  @api
+  Scenario: Create multiple content blocks with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following basic content blocks with fields:
+      | info   | [TEST] Vertical Block 1 | [TEST] Vertical Block 2 | [TEST] Vertical Block 3 |
+      | body   | First vertical block    | Second vertical block   | Third vertical block    |
+      | status | 1                       | 1                       | 1                       |
+    When I go to "admin/content/block"
+    Then I should see "[TEST] Vertical Block 1"
+    And I should see "[TEST] Vertical Block 2"
+    And I should see "[TEST] Vertical Block 3"

--- a/tests/behat/features/drupal_eck.feature
+++ b/tests/behat/features/drupal_eck.feature
@@ -58,8 +58,8 @@ Feature: Check that EckTrait works
   @api @behat-steps-skip:eckAfterScenario
   Scenario: ECK entities are not automatically cleaned up when skip tag is used
     Given the following eck "test_bundle" "test_entity_type" entities exist:
-      | title                    | field_test_text      |
-      | [TEST] Skip Cleanup ECK  | Skip cleanup test    |
+      | title                   | field_test_text   |
+      | [TEST] Skip Cleanup ECK | Skip cleanup test |
     And I am logged in as a user with the "administrator" role
     When I visit eck "test_bundle" "test_entity_type" entity with the title "[TEST] Skip Cleanup ECK"
     Then I should see "[TEST] Skip Cleanup ECK"
@@ -72,9 +72,9 @@ Feature: Check that EckTrait works
   @api
   Scenario: ECK entities are automatically cleaned up after scenario
     Given the following eck "test_bundle" "test_entity_type" entities exist:
-      | title                      | field_test_text        |
-      | [TEST] Auto Cleanup ECK 1  | Auto cleanup test 1    |
-      | [TEST] Auto Cleanup ECK 2  | Auto cleanup test 2    |
+      | title                     | field_test_text     |
+      | [TEST] Auto Cleanup ECK 1 | Auto cleanup test 1 |
+      | [TEST] Auto Cleanup ECK 2 | Auto cleanup test 2 |
     And I am logged in as a user with the "administrator" role
     When I visit eck "test_bundle" "test_entity_type" entity with the title "[TEST] Auto Cleanup ECK 1"
     Then I should see "[TEST] Auto Cleanup ECK 1"

--- a/tests/behat/features/drupal_media.feature
+++ b/tests/behat/features/drupal_media.feature
@@ -97,3 +97,47 @@ Feature: Check that MediaTrait works
     Then I should see the text "Duplicate test item"
     # Verify only one media item exists by checking there's exactly one row in the table
     And I should see 1 ".view-media td:contains('Duplicate test item')" elements
+
+  @api
+  Scenario: Create single media with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following managed files:
+      | path              |
+      | example_image.png |
+    And the following image media with fields:
+      | name              | [TEST] Vertical Image |
+      | field_media_image | example_image.png     |
+    When I go to "/admin/content/media"
+    Then I should see "[TEST] Vertical Image"
+
+  @api
+  Scenario: Create multiple media with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following managed files:
+      | path              |
+      | example_image.png |
+    And the following image media with fields:
+      | name              | [TEST] V-Image 1  | [TEST] V-Image 2  | [TEST] V-Image 3  |
+      | field_media_image | example_image.png | example_image.png | example_image.png |
+    When I go to "/admin/content/media"
+    Then I should see "[TEST] V-Image 1"
+    And I should see "[TEST] V-Image 2"
+    And I should see "[TEST] V-Image 3"
+
+  @api
+  Scenario: Assert that mediaCreateWithFields() deletes existing media before creating
+    Given the following managed files:
+      | path              |
+      | example_image.png |
+    And the following image media with fields:
+      | name              | [TEST] Duplicate vertical |
+      | field_media_image | example_image.png         |
+    And I am logged in as a user with the "administrator" role
+    And I visit "/admin/content/media"
+    Then I should see the text "[TEST] Duplicate vertical"
+    When the following image media with fields:
+      | name              | [TEST] Duplicate vertical |
+      | field_media_image | example_image.png         |
+    And I visit "/admin/content/media"
+    Then I should see the text "[TEST] Duplicate vertical"
+    And I should see 1 ".view-media td:contains('[TEST] Duplicate vertical')" elements

--- a/tests/behat/features/drupal_override.feature
+++ b/tests/behat/features/drupal_override.feature
@@ -32,14 +32,14 @@ Feature: Check that OverrideTrait works
   @api
   Scenario: Assert override of createUsers deletes existing users before creation
     Given users:
-      | name                    | mail                          | status |
-      | [TEST] override_user_01 | override_user_01@example.com  | 1      |
+      | name                    | mail                         | status |
+      | [TEST] override_user_01 | override_user_01@example.com | 1      |
     When I am logged in as a user with the "administrator" role
     And I go to "/admin/people"
     Then I should see the text "[TEST] override_user_01"
     # Create the same user again - override should delete first then recreate
     Given users:
-      | name                    | mail                          | status |
-      | [TEST] override_user_01 | override_user_01@example.com  | 1      |
+      | name                    | mail                         | status |
+      | [TEST] override_user_01 | override_user_01@example.com | 1      |
     When I go to "/admin/people"
     Then I should see the text "[TEST] override_user_01"

--- a/tests/behat/features/drupal_taxonomy.feature
+++ b/tests/behat/features/drupal_taxonomy.feature
@@ -258,3 +258,23 @@ Feature: Check that TaxonomyTrait works
       """
       Unable to find the term "Nonexisting" in the vocabulary "tags".
       """
+
+  @api
+  Scenario: Create single taxonomy term with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following tags terms with fields:
+      | name        | [TEST] Vertical Tag  |
+      | description | Vertical format term |
+    When I go to "admin/structure/taxonomy/manage/tags/overview"
+    Then I should see "[TEST] Vertical Tag"
+
+  @api
+  Scenario: Create multiple taxonomy terms with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following tags terms with fields:
+      | name        | [TEST] V-Tag 1      | [TEST] V-Tag 2       | [TEST] V-Tag 3      |
+      | description | First vertical term | Second vertical term | Third vertical term |
+    When I go to "admin/structure/taxonomy/manage/tags/overview"
+    Then I should see "[TEST] V-Tag 1"
+    And I should see "[TEST] V-Tag 2"
+    And I should see "[TEST] V-Tag 3"

--- a/tests/behat/features/drupal_user.feature
+++ b/tests/behat/features/drupal_user.feature
@@ -437,9 +437,9 @@ Feature: Check that UserTrait works
   @api
   Scenario: Assert "Given the following roles:" works with table
     Given the following roles:
-      | name              | permissions                              |
-      | Content Editor    | access content, create article content   |
-      | Content Approver  | access content, edit any article content |
+      | name             | permissions                              |
+      | Content Editor   | access content, create article content   |
+      | Content Approver | access content, edit any article content |
     And I am logged in as a user with the "administrator" role
     And I visit "/admin/people/roles"
     Then I should see "Content Editor"
@@ -448,8 +448,8 @@ Feature: Check that UserTrait works
   @api
   Scenario: Assert "Given the following roles:" works with empty permissions
     Given the following roles:
-      | name            | permissions |
-      | Limited Editor  |             |
+      | name           | permissions |
+      | Limited Editor |             |
     And I am logged in as a user with the "administrator" role
     And I visit "/admin/people/roles"
     Then I should see "Limited Editor"
@@ -468,3 +468,25 @@ Feature: Check that UserTrait works
       """
       Missing required column "name"
       """
+
+  @api
+  Scenario: Create single user with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following users with fields:
+      | name   | [TEST] vertical_user |
+      | mail   | vertical@example.com |
+      | status | 1                    |
+    When I go to "/admin/people"
+    Then I should see "[TEST] vertical_user"
+
+  @api
+  Scenario: Create multiple users with vertical field format
+    Given I am logged in as a user with the "administrator" role
+    And the following users with fields:
+      | name   | [TEST] vuser1      | [TEST] vuser2      | [TEST] vuser3      |
+      | mail   | vuser1@example.com | vuser2@example.com | vuser3@example.com |
+      | status | 1                  | 1                  | 1                  |
+    When I go to "/admin/people"
+    Then I should see "[TEST] vuser1"
+    And I should see "[TEST] vuser2"
+    And I should see "[TEST] vuser3"

--- a/tests/behat/features/helper.feature
+++ b/tests/behat/features/helper.feature
@@ -1,0 +1,133 @@
+Feature: Check that HelperTrait works
+
+  Ensures that the HelperTrait provides reusable helper methods for table
+  manipulation and processing, specifically the transposeVerticalTable() method.
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable works with single entity (2 columns)
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        | name  | John  |
+        | age   | 30    |
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable works with multiple entities (3+ columns)
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        | name  | John      | Jane      |
+        | age   | 30        | 25        |
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable throws exception for less than 2 columns
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        | name  |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Vertical table must have at least 2 columns (field name and value).
+      """
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable throws exception for duplicate field names
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        | name  | John  |
+        | name  | Jane  |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Duplicate field names found: name
+      """
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable throws exception for empty field names
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        |       | John  |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Field names cannot be empty.
+      """
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable handles empty values in rows
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        | name  | John   | Jane   |
+        | age   | 30     |        |
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable throws exception for single column table
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        | |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Vertical table must have at least 2 columns (field name and value).
+      """
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable works with many entities (5+ columns)
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        | name  | John     | Jane     | Bob      | Alice    |
+        | age   | 30       | 25       | 35       | 28       |
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable works with single field
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        | name  | John  |
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @trait:HelperTrait
+  Scenario: Assert transposeVerticalTable works with special characters in values
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      When I call helperTransposeVerticalTable with:
+        | name  | O'Brien                |
+        | email | test@example.com       |
+        | bio   | Line 1\nLine 2         |
+      """
+    When I run "behat --no-colors"
+    Then it should pass

--- a/tests/behat/features/responsive.feature
+++ b/tests/behat/features/responsive.feature
@@ -110,9 +110,9 @@ Feature: Check that ResponsiveTrait works
   @javascript
   Scenario: Custom breakpoints can be registered and used
     Given the following responsive breakpoints:
-      | name        | dimensions |
-      | iphone_12   | 390x844    |
-      | 4k_display  | 3840x2160  |
+      | name       | dimensions |
+      | iphone_12  | 390x844    |
+      | 4k_display | 3840x2160  |
     When I am on "/sites/default/files/clean1.html"
     And I set the viewport to the "iphone_12" breakpoint
     And I set the viewport to the "4k_display" breakpoint


### PR DESCRIPTION
Closes #431

## New Steps Added

Five new "with fields" step variants were added to support **vertical column format** for entity creation:

1. **Content Blocks**: `@Given the following :type content blocks with fields:`
2. **Content (Nodes)**: `@Given the following :type content with fields:`
3. **Media**: `@Given the following :bundle media with fields:`
4. **Taxonomy Terms**: `@Given the following :vocabulary terms with fields:`
5. **Users**: `@Given the following users with fields:`

## The Vertical Format Feature

The key feature is the ability to define entities using a **vertical table format** where:
- **Field names** are in the **first column**
- Each **subsequent column** represents a **separate entity**

### Example - Creating Multiple Nodes:

```gherkin
Given the following page content with fields:
  | title  | [TEST] V-Page 1    | [TEST] V-Page 2     | [TEST] V-Page 3    |
  | body   | First page content | Second page content | Third page content |
  | status | 1                  | 1                   | 1                  |
```