### PR TITLE
Added 'I go back' step to PathTrait.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -1303,6 +1303,20 @@ Given the basic authentication with the username "myusername" and the password "
 </details>
 
 <details>
+  <summary><code>@When I go back</code></summary>
+
+<br/>
+Navigate back in browser history
+<br/><br/>
+
+```gherkin
+When I go back
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the path should be :path</code></summary>
 
 <br/>

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -6,6 +6,7 @@ namespace DrevOps\BehatSteps;
 
 use Behat\Step\Then;
 use Behat\Step\Given;
+use Behat\Step\When;
 use Behat\Mink\Exception\ExpectationException;
 
 /**
@@ -195,6 +196,18 @@ trait PathTrait {
   #[Given('the basic authentication with the username :username and the password :password')]
   public function pathSetBasicAuth(string $username, string $password): void {
     $this->getSession()->setBasicAuth($username, $password);
+  }
+
+  /**
+   * Navigate back in browser history.
+   *
+   * @code
+   * When I go back
+   * @endcode
+   */
+  #[When('I go back')]
+  public function pathGoBack(): void {
+    $this->getSession()->back();
   }
 
 }

--- a/tests/behat/features/path.feature
+++ b/tests/behat/features/path.feature
@@ -205,6 +205,14 @@ Feature: Check that PathTrait works
     Then current url should not have the "nonexistent" parameter with the "value" value
 
   @api
+  Scenario: Assert "When I go back" navigates to the previous page
+    Given I am an anonymous user
+    When I go to "/user/login"
+    And I go to "/user/password"
+    And I go back
+    Then the path should be "/user/login"
+
+  @api
   Scenario: Assert "When the basic authentication with the username :username and the password :password"
     Given users:
       | name       | mail               | pass       |


### PR DESCRIPTION
## Summary
- Added `When I go back` step to `PathTrait` that navigates the browser back in history via `$this->getSession()->back()`.
- Method: `pathGoBack()` — follows existing trait naming convention.
- Added BDD test that navigates to two pages and verifies back navigation returns to the first.

## Test plan
- [ ] Run `ahoy test-bdd tests/behat/features/path.feature` to verify the new step works.
- [ ] Verify STEPS.md is updated after `ahoy update-docs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new step allowing tests to trigger browser "back" navigation to return to the previous page.

* **Tests**
  * Added a scenario validating the back navigation step and confirming the previous page is restored.

* **Documentation**
  * Added documentation and a Gherkin example describing the new back navigation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->