### PR TITLE
Renamed MetatagTrait methods, added 'metatagAssertNoHtml' step.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -1276,7 +1276,55 @@ Then the link "Return to site content" should not be an absolute link
 
 >  Assert `<meta>` tags in page markup.
 >  - Assert presence and content of meta tags with proper attribute handling.
+>  - Verify meta tag content is free of HTML markup.
 
+
+<details>
+  <summary><code>@Then the meta tag should exist with the following attributes:</code></summary>
+
+<br/>
+Assert that a meta tag with specific attributes and values exists
+<br/><br/>
+
+```gherkin
+Then the meta tag should exist with the following attributes:
+  | name    | description          |
+  | content | My page description  |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the meta tag should not exist with the following attributes:</code></summary>
+
+<br/>
+Assert that a meta tag with specific attributes and values does not exist
+<br/><br/>
+
+```gherkin
+Then the meta tag should not exist with the following attributes:
+  | name    | nonexistent          |
+  | content | Some content         |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the :metaName meta tag should not contain any HTML tags</code></summary>
+
+<br/>
+Assert a meta tag does not contain HTML tags
+<br/><br/>
+
+```gherkin
+Then the "og:description" meta tag should not contain any HTML tags
+Then the "description" meta tag should not contain any HTML tags
+
+```
+
+</details>
 
 ## PathTrait
 

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -11,14 +11,21 @@ use Behat\Gherkin\Node\TableNode;
  * Assert `<meta>` tags in page markup.
  *
  * - Assert presence and content of meta tags with proper attribute handling.
+ * - Verify meta tag content is free of HTML markup.
  */
 trait MetatagTrait {
 
   /**
    * Assert that a meta tag with specific attributes and values exists.
+   *
+   * @code
+   * Then the meta tag should exist with the following attributes:
+   *   | name    | description          |
+   *   | content | My page description  |
+   * @endcode
    */
   #[Then('the meta tag should exist with the following attributes:')]
-  public function assertMetaTagWithAttributesExists(TableNode $table): void {
+  public function metatagAssertWithAttributesExists(TableNode $table): void {
     $elements = $this->getSession()->getPage()->findAll('css', 'meta');
 
     $attributes = [];
@@ -51,9 +58,15 @@ trait MetatagTrait {
 
   /**
    * Assert that a meta tag with specific attributes and values does not exist.
+   *
+   * @code
+   * Then the meta tag should not exist with the following attributes:
+   *   | name    | nonexistent          |
+   *   | content | Some content         |
+   * @endcode
    */
   #[Then('the meta tag should not exist with the following attributes:')]
-  public function assertMetaTagWithAttributesNotExists(TableNode $table): void {
+  public function metatagAssertWithAttributesNotExists(TableNode $table): void {
     $meta_tags = $this->getSession()->getPage()->findAll('css', 'meta');
 
     $attributes = [];
@@ -73,6 +86,38 @@ trait MetatagTrait {
       if ($all_attributes_matched) {
         throw new \Exception('Meta tag with specified attributes should not exist: ' . json_encode($attributes) . '.');
       }
+    }
+  }
+
+  /**
+   * Assert a meta tag does not contain HTML tags.
+   *
+   * Looks up the meta tag by either "name" or "property" attribute and checks
+   * that the "content" attribute value is free of HTML markup.
+   *
+   * @code
+   * Then the "og:description" meta tag should not contain any HTML tags
+   * Then the "description" meta tag should not contain any HTML tags
+   * @endcode
+   */
+  #[Then('the :metaName meta tag should not contain any HTML tags')]
+  public function metatagAssertNoHtml(string $meta_name): void {
+    $page = $this->getSession()->getPage();
+
+    $meta_tag = $page->find('xpath', sprintf(
+      "//meta[@name='%s' or @property='%s']",
+      $meta_name,
+      $meta_name
+    ));
+
+    if ($meta_tag === NULL) {
+      throw new \Exception(sprintf('Meta tag with name or property "%s" not found.', $meta_name));
+    }
+
+    $content = (string) $meta_tag->getAttribute('content');
+
+    if ($content !== strip_tags($content)) {
+      throw new \Exception(sprintf('The "%s" meta tag contains HTML tags: %s', $meta_name, $content));
     }
   }
 

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -6,6 +6,7 @@ namespace DrevOps\BehatSteps;
 
 use Behat\Step\Then;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Selector\Xpath\Escaper;
 
 /**
  * Assert `<meta>` tags in page markup.
@@ -103,12 +104,9 @@ trait MetatagTrait {
   #[Then('the :metaName meta tag should not contain any HTML tags')]
   public function metatagAssertNoHtml(string $meta_name): void {
     $page = $this->getSession()->getPage();
+    $escaped_name = (new Escaper())->escapeLiteral($meta_name);
 
-    $meta_tag = $page->find('xpath', sprintf(
-      "//meta[@name='%s' or @property='%s']",
-      $meta_name,
-      $meta_name
-    ));
+    $meta_tag = $page->find('xpath', "//meta[@name=$escaped_name or @property=$escaped_name]");
 
     if ($meta_tag === NULL) {
       throw new \Exception(sprintf('Meta tag with name or property "%s" not found.', $meta_name));

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -106,7 +106,7 @@ trait MetatagTrait {
     $page = $this->getSession()->getPage();
     $escaped_name = (new Escaper())->escapeLiteral($meta_name);
 
-    $meta_tag = $page->find('xpath', "//meta[@name=$escaped_name or @property=$escaped_name]");
+    $meta_tag = $page->find('xpath', sprintf('//meta[@name=%s or @property=%s]', $escaped_name, $escaped_name));
 
     if ($meta_tag === NULL) {
       throw new \Exception(sprintf('Meta tag with name or property "%s" not found.', $meta_name));

--- a/tests/behat/features/metatag.feature
+++ b/tests/behat/features/metatag.feature
@@ -64,7 +64,6 @@ Feature: Check that MetatagTrait works
     Given some behat configuration
     And scenario steps:
       """
-      Given I am an anonymous user
       When I visit "/sites/default/files/metatags.html"
       Then the "og:description" meta tag should not contain any HTML tags
       """
@@ -79,7 +78,6 @@ Feature: Check that MetatagTrait works
     Given some behat configuration
     And scenario steps:
       """
-      Given I am an anonymous user
       When I visit "/sites/default/files/metatags.html"
       Then the "nonexistent" meta tag should not contain any HTML tags
       """

--- a/tests/behat/features/metatag.feature
+++ b/tests/behat/features/metatag.feature
@@ -48,3 +48,43 @@ Feature: Check that MetatagTrait works
       """
       Meta tag with specified attributes should not exist: {"name":"MobileOptimized","content":"width"}
       """
+
+  Scenario: Assert "Then the :metaName meta tag should not contain any HTML tags" works for clean meta tag
+    Given I am an anonymous user
+    When I visit "/sites/default/files/metatags.html"
+    Then the "description" meta tag should not contain any HTML tags
+
+  Scenario: Assert "Then the :metaName meta tag should not contain any HTML tags" works for clean OG meta tag
+    Given I am an anonymous user
+    When I visit "/sites/default/files/metatags.html"
+    Then the "og:title" meta tag should not contain any HTML tags
+
+  @trait:MetatagTrait
+  Scenario: Assert that "Then the :metaName meta tag should not contain any HTML tags" fails when meta tag contains HTML
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/metatags.html"
+      Then the "og:description" meta tag should not contain any HTML tags
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The "og:description" meta tag contains HTML tags:
+      """
+
+  @trait:MetatagTrait
+  Scenario: Assert that "Then the :metaName meta tag should not contain any HTML tags" fails when meta tag does not exist
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/metatags.html"
+      Then the "nonexistent" meta tag should not contain any HTML tags
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Meta tag with name or property "nonexistent" not found.
+      """

--- a/tests/behat/fixtures/metatags.html
+++ b/tests/behat/fixtures/metatags.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Meta Tag Testing Page</title>
+  <meta name="description" content="This is a clean description without HTML">
+  <meta name="keywords" content="test, behat, metatags">
+  <meta property="og:description" content="<p>This description has HTML tags</p>">
+  <meta property="og:title" content="Clean OG Title">
+</head>
+<body>
+  <h1>Meta Tag Testing Page</h1>
+  <p>This page contains various meta tags for testing purposes.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Renamed existing MetatagTrait methods to follow the project's trait-prefixed naming convention (`traitNameAssert*()` instead of `assertTraitName*()`). Added a new `metatagAssertNoHtml()` step that asserts a meta tag's content is free of HTML markup, checking both `name` and `property` attributes to cover standard and OpenGraph meta tags.

## Changes

**MetatagTrait method rename:**
- `assertMetaTagWithAttributesExists()` → `metatagAssertWithAttributesExists()`
- `assertMetaTagWithAttributesNotExists()` → `metatagAssertWithAttributesNotExists()`
- Step text unchanged — no consumer impact.

**New step: `metatagAssertNoHtml()`:**
- Step: `Then the :metaName meta tag should not contain any HTML tags`
- Looks up meta tag by `name` or `property` attribute.
- Compares content against `strip_tags()` to detect HTML.

**Test fixtures and scenarios:**
- Added `metatags.html` fixture with clean and HTML-containing meta tags.
- Added positive, negative (HTML detected), and not-found test scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new assertion to check that a named meta tag's content does not contain HTML markup.
* **Tests**
  * Added scenarios covering the new meta-tag-no-HTML assertion, including success and failure cases.
  * Added an HTML fixture with sample meta tags for testing.
* **Documentation**
  * Updated step documentation with examples and usage for the new meta tag assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->