### PR TITLE
Added IframeTrait with iframe switching steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ from the community.
 | [ElementTrait](STEPS.md#elementtrait) | Interact with HTML elements using CSS selectors and DOM attributes. |
 | [FieldTrait](STEPS.md#fieldtrait) | Manipulate form fields and verify widget functionality. |
 | [FileDownloadTrait](STEPS.md#filedownloadtrait) | Test file download functionality with content verification. |
+| [IframeTrait](STEPS.md#iframetrait) | Switch between iframes and the root document. |
 | [JavascriptTrait](STEPS.md#javascripttrait) | Automatically detect JavaScript errors during test execution. |
 | [KeyboardTrait](STEPS.md#keyboardtrait) | Simulate keyboard interactions in Drupal browser testing. |
 | [LinkTrait](STEPS.md#linktrait) | Verify link elements with attribute and content assertions. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -9,6 +9,7 @@
 | [ElementTrait](#elementtrait) | Interact with HTML elements using CSS selectors and DOM attributes. |
 | [FieldTrait](#fieldtrait) | Manipulate form fields and verify widget functionality. |
 | [FileDownloadTrait](#filedownloadtrait) | Test file download functionality with content verification. |
+| [IframeTrait](#iframetrait) | Switch between iframes and the root document. |
 | [JavascriptTrait](#javascripttrait) | Automatically detect JavaScript errors during test execution. |
 | [KeyboardTrait](#keyboardtrait) | Simulate keyboard interactions in Drupal browser testing. |
 | [LinkTrait](#linktrait) | Verify link elements with attribute and content assertions. |
@@ -1025,6 +1026,44 @@ Then the downloaded file should be a zip archive not containing the following fi
   | confidential |
   | private      |
   | draft        |
+
+```
+
+</details>
+
+## IframeTrait
+
+[Source](src/IframeTrait.php), [Example](tests/behat/features/iframe.feature)
+
+>  Switch between iframes and the root document.
+>  - Switch to iframes by CSS selector, including unnamed iframes.
+>  - Switch back to the root (top-level) document.
+
+
+<details>
+  <summary><code>@When I switch to iframe with locator :locator</code></summary>
+
+<br/>
+Switch to an iframe identified by CSS selector
+<br/><br/>
+
+```gherkin
+When I switch to iframe with locator "iframe.payment-form"
+When I switch to iframe with locator "#recaptcha iframe"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I switch to the root document</code></summary>
+
+<br/>
+Switch back to the root (top-level) document from an iframe
+<br/><br/>
+
+```gherkin
+When I switch to the root document
 
 ```
 

--- a/src/IframeTrait.php
+++ b/src/IframeTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps;
+
+use Behat\Step\When;
+use Behat\Mink\Exception\ElementNotFoundException;
+
+/**
+ * Switch between iframes and the root document.
+ *
+ * - Switch to iframes by CSS selector, including unnamed iframes.
+ * - Switch back to the root (top-level) document.
+ */
+trait IframeTrait {
+
+  /**
+   * Switch to an iframe identified by CSS selector.
+   *
+   * Handles unnamed iframes by auto-assigning a name via JavaScript.
+   *
+   * @code
+   * When I switch to iframe with locator "iframe.payment-form"
+   * When I switch to iframe with locator "#recaptcha iframe"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[When('I switch to iframe with locator :locator')]
+  public function iframeSwitchTo(string $locator): void {
+    $iframe = $this->getSession()->getPage()->find('css', $locator);
+
+    if ($iframe === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'iframe', 'css', $locator);
+    }
+
+    $iframe_name = $iframe->getAttribute('name');
+
+    if (empty($iframe_name)) {
+      $this->getSession()->executeScript(
+        "(function(){
+          var iframes = document.querySelectorAll('iframe');
+          for (var i = 0; i < iframes.length; i++) {
+            if (!iframes[i].name) {
+              iframes[i].name = 'behat_iframe_' + (i + 1);
+            }
+          }
+        })()"
+      );
+
+      $iframe = $this->getSession()->getPage()->find('css', $locator);
+
+      if ($iframe === NULL) {
+        throw new ElementNotFoundException($this->getSession()->getDriver(), 'iframe', 'css', $locator);
+      }
+
+      $iframe_name = $iframe->getAttribute('name');
+    }
+
+    $this->getSession()->getDriver()->switchToIFrame($iframe_name);
+  }
+
+  /**
+   * Switch back to the root (top-level) document from an iframe.
+   *
+   * @code
+   * When I switch to the root document
+   * @endcode
+   */
+  #[When('I switch to the root document')]
+  public function iframeSwitchToRootDocument(): void {
+    $this->getSession()->getDriver()->switchToIFrame();
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -31,6 +31,7 @@ use DrevOps\BehatSteps\Drupal\UserTrait;
 use DrevOps\BehatSteps\Drupal\WatchdogTrait;
 use DrevOps\BehatSteps\ElementTrait;
 use DrevOps\BehatSteps\FieldTrait;
+use DrevOps\BehatSteps\IframeTrait;
 use DrevOps\BehatSteps\FileDownloadTrait;
 use DrevOps\BehatSteps\JavascriptTrait;
 use DrevOps\BehatSteps\KeyboardTrait;
@@ -60,6 +61,7 @@ class FeatureContext extends DrupalContext {
   use EmailTrait;
   use FieldTrait;
   use FileDownloadTrait;
+  use IframeTrait;
   use FileTrait;
   use JavascriptTrait;
   use KeyboardTrait;

--- a/tests/behat/features/iframe.feature
+++ b/tests/behat/features/iframe.feature
@@ -1,0 +1,37 @@
+Feature: Check that IframeTrait works
+  As Behat Steps library developer
+  I want to provide tools to switch between iframes
+  So that users can test content inside iframes
+
+  @javascript @phpserver
+  Scenario: Assert "When I switch to iframe with locator :locator" works for named iframe
+    Given I am an anonymous user
+    When I visit "/sites/default/files/iframes.html"
+    And I switch to iframe with locator ".named-iframe"
+    Then I should see "Content inside named iframe"
+    When I switch to the root document
+    Then I should see "Content in the root document"
+
+  @javascript @phpserver
+  Scenario: Assert "When I switch to iframe with locator :locator" works for unnamed iframe
+    Given I am an anonymous user
+    When I visit "/sites/default/files/iframes.html"
+    And I switch to iframe with locator ".unnamed-iframe"
+    Then I should see "Content inside unnamed iframe"
+    When I switch to the root document
+    Then I should see "Content in the root document"
+
+  @trait:IframeTrait
+  Scenario: Assert that "When I switch to iframe with locator :locator" fails when iframe does not exist
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/iframes.html"
+      And I switch to iframe with locator ".nonexistent-iframe"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Iframe matching css ".nonexistent-iframe" not found.
+      """

--- a/tests/behat/fixtures/iframes.html
+++ b/tests/behat/fixtures/iframes.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Iframe Testing Page</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 1000px; margin: 20px auto; padding: 20px; }
+    .section { margin: 30px 0; padding: 20px; border: 2px solid #ccc; border-radius: 8px; }
+    h2 { color: #333; border-bottom: 2px solid #666; padding-bottom: 10px; }
+    iframe { border: 1px solid #999; margin: 10px 0; }
+  </style>
+</head>
+<body>
+  <h1>Iframe Testing Page</h1>
+
+  <div class="section">
+    <h2>Named Iframe</h2>
+    <iframe name="named-frame" class="named-iframe" width="400" height="100" srcdoc="<html><body><p id='named-content'>Content inside named iframe</p></body></html>"></iframe>
+  </div>
+
+  <div class="section">
+    <h2>Unnamed Iframe</h2>
+    <iframe class="unnamed-iframe" width="400" height="100" srcdoc="<html><body><p id='unnamed-content'>Content inside unnamed iframe</p></body></html>"></iframe>
+  </div>
+
+  <p id="root-content">Content in the root document</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Added a new `IframeTrait` that provides steps for switching between iframes and the root document. Handles both named and unnamed iframes by auto-assigning names via JavaScript when needed, working around Mink/Selenium limitations.

## Changes

**New trait: `src/IframeTrait.php`:**
- `When I switch to iframe with locator :locator` — switches to an iframe by CSS selector. Auto-assigns names to unnamed iframes via JavaScript.
- `When I switch to the root document` — switches back to the top-level document.
- Uses `ElementNotFoundException` for proper error handling.

**Test infrastructure:**
- Created `iframes.html` fixture with named and unnamed iframes using `srcdoc`.
- Created `iframe.feature` with positive tests for both named/unnamed iframes and a negative test for non-existent iframes.
- Added `IframeTrait` to `FeatureContext.php`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iframe navigation support to the test framework with methods to switch between iframes and root document context.
  * Automatic handling for both named and unnamed iframes.

* **Tests**
  * Added test scenarios validating iframe switching, content verification, and error handling.
  * Added HTML fixture with sample iframes for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->