### PR TITLE
Added 'I hover over the element' step to ElementTrait.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -325,6 +325,21 @@ When I scroll to the element "#footer"
 </details>
 
 <details>
+  <summary><code>@When I hover over the element :selector</code></summary>
+
+<br/>
+Hover over an element identified by CSS selector
+<br/><br/>
+
+```gherkin
+When I hover over the element ".menu-item"
+When I hover over the element "#tooltip-trigger"
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the element :selector1 should appear after the element :selector2</code></summary>
 
 <br/>

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -288,6 +288,25 @@ trait ElementTrait {
   }
 
   /**
+   * Hover over an element identified by CSS selector.
+   *
+   * @code
+   * When I hover over the element ".menu-item"
+   * When I hover over the element "#tooltip-trigger"
+   * @endcode
+   */
+  #[When('I hover over the element :selector')]
+  public function elementHover(string $selector): void {
+    $element = $this->getSession()->getPage()->find('css', $selector);
+
+    if ($element === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    $element->mouseOver();
+  }
+
+  /**
    * Assert that element with specified CSS is visible on page.
    *
    * @code

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -445,6 +445,29 @@ Feature: Check that ElementTrait works
       Text was not found: "NonExistentText123".
       """
 
+  @javascript
+  Scenario: Assert "When I hover over the element :selector" works as expected
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements.html"
+    Then the element "#hover-reveal" should not be displayed
+    When I hover over the element "#hover-target"
+    Then the element "#hover-reveal" should be displayed
+
+  @trait:ElementTrait
+  Scenario: Assert that "When I hover over the element :selector" fails when element does not exist
+    Given some behat configuration
+    And scenario steps tagged with "@javascript":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements.html"
+      And I hover over the element "#nonexistent-element"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css "#nonexistent-element" not found.
+      """
+
   @javascript @phpserver
   Scenario: Assert click on element works
     Given I am on the phpserver test page

--- a/tests/behat/fixtures/elements.html
+++ b/tests/behat/fixtures/elements.html
@@ -66,6 +66,20 @@
     <a href="/path3">Link 3</a>
   </div>
 
+  <!-- Section: Hover Testing -->
+  <div class="section">
+    <h2>Hover Testing</h2>
+    <div id="hover-target" style="padding: 20px; background: #eee;">
+      Hover over me
+      <div id="hover-reveal" style="display: none;">Revealed on hover</div>
+    </div>
+    <script>
+      document.getElementById('hover-target').addEventListener('mouseover', function() {
+        document.getElementById('hover-reveal').style.display = 'block';
+      });
+    </script>
+  </div>
+
   <!-- Section: Text Ordering -->
   <div class="section">
     <h2>Text Ordering</h2>


### PR DESCRIPTION
## Summary

Added `elementHover()` step to `ElementTrait` that triggers a mouse-over event on a CSS-selected element using Mink's native `mouseOver()` method. This fills the gap between existing click, scroll, and JS event trigger steps.

## Changes

**ElementTrait:**
- Added `When I hover over the element :selector` step with `elementHover()` method.
- Uses `ElementNotFoundException` consistent with other ElementTrait methods (`elementClick`, `elementScrollTo`).

**Test fixtures:**
- Added hover-reveal section to `elements.html` fixture with a hidden child element that becomes visible on parent hover via JavaScript event listener.

**BDD tests:**
- Added positive scenario: verify hover reveals hidden element.
- Added negative scenario via `@trait:ElementTrait`: verify error when hovering non-existent element.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hover interaction testing capability to validate UI elements that respond to mouse-over events.

* **Tests**
  * Added test scenarios validating hover-triggered visibility state changes.
  * Added test fixtures with elements demonstrating hover interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->