### PR TITLE
Added 'I fill in the field' CSS selector step to FieldTrait.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -641,6 +641,21 @@ When I choose the radio button "edit-field-choice-option-a"
 </details>
 
 <details>
+  <summary><code>@When I fill in the field :selector with :value</code></summary>
+
+<br/>
+Fill in a field identified by CSS selector
+<br/><br/>
+
+```gherkin
+When I fill in the field ".field--name-body textarea" with "Hello world"
+When I fill in the field "#edit-field-custom-0-value" with "Test value"
+
+```
+
+</details>
+
+<details>
   <summary><code>@When I fill in the datetime field :label with date :date and time :time</code></summary>
 
 <br/>

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -655,6 +655,28 @@ JS;
   }
 
   /**
+   * Fill in a field identified by CSS selector.
+   *
+   * Use this when the field cannot be reliably located by label, id, or name
+   * (e.g., dynamically generated fields in Paragraphs or Layout Builder).
+   *
+   * @code
+   * When I fill in the field ".field--name-body textarea" with "Hello world"
+   * When I fill in the field "#edit-field-custom-0-value" with "Test value"
+   * @endcode
+   */
+  #[When('I fill in the field :selector with :value')]
+  public function fieldFillField(string $selector, string $value): void {
+    $field = $this->getSession()->getPage()->find('css', $selector);
+
+    if ($field === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'field', 'css', $selector);
+    }
+
+    $field->setValue($value);
+  }
+
+  /**
    * Disable browser validation for the form for validating errors.
    *
    * The form selector is registered and validation disabling will be

--- a/tests/behat/features/field.feature
+++ b/tests/behat/features/field.feature
@@ -17,6 +17,25 @@ Feature: Check that FieldTrait works
     And I fill in "field1" with "0"
     Then the field "field1" should not be empty
 
+  Scenario: Assert "When I fill in the field :selector with :value" works with CSS selector
+    When I visit "/sites/default/files/fields.html"
+    And I fill in the field "#field1" with "CSS filled value"
+    Then the field "field1" should not be empty
+
+  @trait:FieldTrait
+  Scenario: Assert that "When I fill in the field :selector with :value" fails when element does not exist
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I visit "/sites/default/files/fields.html"
+      And I fill in the field "#nonexistent-field" with "some value"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Field matching css "#nonexistent-field" not found.
+      """
+
   @trait:FieldTrait
   Scenario: Assert negative "the :field field should be empty" for field with "0"
     Given some behat configuration


### PR DESCRIPTION
## Summary

Added `fieldFillField()` step to `FieldTrait` that fills a form field identified by CSS selector. This is for cases where fields cannot be reliably located by label, id, or name — common with Paragraphs, Layout Builder, or inline entity forms that generate dynamic attributes.

## Changes

**FieldTrait:**
- Added `When I fill in the field :selector with :value` step with `fieldFillField()` method.
- Uses CSS selector to find the field via `find('css', $selector)`.
- Uses `ElementNotFoundException` for proper error handling.

**BDD tests:**
- Added positive scenario: fill field by CSS selector `#field1` and verify it's not empty.
- Added negative scenario via `@trait:FieldTrait`: verify error when targeting non-existent CSS selector.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Behat step enabling CSS selector-based form field filling for flexible field targeting.

* **Tests**
  * Added test scenarios validating the new field-filling step, including verification of proper error handling when target elements don't exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->