### PR TITLE
[#572] Added content 'should not exist' assertion to ContentTrait.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -2398,6 +2398,20 @@ When I change the moderation state of the "article" content with the title "Test
 
 </details>
 
+<details>
+  <summary><code>@Then :content_type content with the title :title should not exist</code></summary>
+
+<br/>
+Assert that content with a specified title does not exist
+<br/><br/>
+
+```gherkin
+Then "page" content with the title "[TEST] Page title" should not exist
+
+```
+
+</details>
+
 ## Drupal\DraggableviewsTrait
 
 [Source](src/Drupal/DraggableviewsTrait.php), [Example](tests/behat/features/drupal_draggableviews.feature)

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps\Drupal;
 
 use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Step\When;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ExpectationException;
 use DrevOps\BehatSteps\HelperTrait;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
@@ -57,6 +59,24 @@ trait ContentTrait {
       $controller = \Drupal::entityTypeManager()->getStorage('node');
       $entities = $controller->loadMultiple($nids);
       $controller->delete($entities);
+    }
+  }
+
+  /**
+   * Assert that content with a specified title does not exist.
+   *
+   * @code
+   * Then "page" content with the title "[TEST] Page title" should not exist
+   * @endcode
+   */
+  #[Then(':content_type content with the title :title should not exist')]
+  public function contentAssertNotExistsWithTitle(string $content_type, string $title): void {
+    $nids = $this->contentLoadMultiple($content_type, [
+      'title' => $title,
+    ]);
+
+    if (!empty($nids)) {
+      throw new ExpectationException(sprintf('"%s" content with the title "%s" exists (nid: %s), but it should not.', $content_type, $title, implode(', ', $nids)), $this->getSession()->getDriver());
     }
   }
 

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -43,6 +43,26 @@ Feature: Check that ContentTrait works
     When I go to "content/test-page-title2"
     Then I should get a 404 HTTP response
 
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "Then :content_type content with the title :title should not exist" fails when content exists
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      Given page content:
+        | title              |
+        | [TEST] Page title  |
+      Then "page" content with the title "[TEST] Page title" should not exist
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      "page" content with the title "[TEST] Page title" exists
+      """
+
+  @api
+  Scenario: Assert "Then :content_type content with the title :title should not exist" passes when content does not exist
+    Then "page" content with the title "[TEST] Non-existing page" should not exist
+
   @api
   Scenario: Assert "When I visit the :content_type content page with the title :title" works as expected
     Given page content:

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -54,9 +54,9 @@ Feature: Check that ContentTrait works
       Then "page" content with the title "[TEST] Page title" should not exist
       """
     When I run "behat --no-colors"
-    Then it should fail with an exception:
+    Then it should fail with an error:
       """
-      "page" content with the title "[TEST] Page title" exists
+      "page" content with the title "[TEST] Page title" exists (nid:
       """
 
   @api


### PR DESCRIPTION
Closes #572

## Summary

Added a `contentAssertNotExistsWithTitle()` step to `ContentTrait` that asserts a given content type with a specified title does not exist in the system. This fills a gap in the trait: the existing `contentDelete()` step removes content, but there was no way to assert absence without performing a deletion. The new step throws an `ExpectationException` with the NID(s) in the error message if any matching content is found.

## Changes

**`src/Drupal/ContentTrait.php`**
- Added `use Behat\Step\Then;` and `use Behat\Mink\Exception\ExpectationException;` imports.
- Added `contentAssertNotExistsWithTitle(string $content_type, string $title)` method with `#[Then]` attribute for the step `":content_type content with the title :title should not exist"`.

**`tests/behat/features/drupal_content.feature`**
- Added `@trait:Drupal\ContentTrait` scenario that verifies the step fails (with the expected exception message) when matching content exists.
- Added `@api` scenario that verifies the step passes when no matching content exists.

**`STEPS.md`**
- Regenerated to include the new `@Then :content_type content with the title :title should not exist` step entry.

## Before / After

```
Before:
┌─────────────────────────────────────────────────────────────────┐
│ ContentTrait                                                    │
│                                                                 │
│  Given: contentDelete()       — deletes content (no assertion)  │
│  When:  contentVisit*()       — page navigation steps           │
│  When:  contentChangeModeration*() — state transitions          │
│                                                                 │
│  [No assertion for content absence]                             │
└─────────────────────────────────────────────────────────────────┘

After:
┌─────────────────────────────────────────────────────────────────┐
│ ContentTrait                                                    │
│                                                                 │
│  Given: contentDelete()       — deletes content (no assertion)  │
│  Then:  contentAssertNotExistsWithTitle()  ← NEW                │
│         Throws ExpectationException if content found,           │
│         including NID(s) in the error message                   │
│  When:  contentVisit*()       — page navigation steps           │
│  When:  contentChangeModeration*() — state transitions          │
└─────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary

## Overview
Adds a negative assertion step to ContentTrait: Then :content_type content with the title :title should not exist, implemented by contentAssertNotExistsWithTitle(). The step asserts no node of the given type with the given title exists and throws an ExpectationException including matching NID(s) if any are found. Tests and documentation were updated accordingly.

## Changes Made

### Source (`src/Drupal/ContentTrait.php`)
- Added imports: Behat\Step\Then, Behat\Mink\Exception\ExpectationException.
- Implemented public function contentAssertNotExistsWithTitle(string $content_type, string $title): void with attribute #[Then(':content_type content with the title :title should not exist')].
- Uses existing contentLoadMultiple($content_type, ['title' => $title]) to find matching nids.
- Throws ExpectationException with a message that includes the matching NID(s) when matches are found.

### Tests (`tests/behat/features/drupal_content.feature`)
- Added a trait scenario that seeds a page node and verifies the negative step fails; the expected failure message includes the substring '(nid:' so the test asserts the exception output contains the NID indicator.
- Added an @api scenario verifying the step passes when no matching content exists.

### Documentation (`STEPS.md`)
- Regenerated to include the new step entry under Drupal\ContentTrait.

## Compliance with CONTRIBUTING.md Step Definition Rules
I inspected CONTRIBUTING.md and the changed files. No violations found:
- Tuple format used (no regex).
- Descriptive placeholders: content_type, title.
- Uses "with" for property identification.
- Step starts with the entity being asserted (:content_type content ...).
- Uses "Then" and "should not" for an assertion.
- Method name follows conventions: ContentTrait → contentAssertNotExistsWithTitle (contains Assert, uses NotExists for singular subject).

## Notes
- The implementation uses ExpectationException (Behat/Mink) rather than the RuntimeException suggested in the issue; this aligns with other Behat assertion patterns.
- Tests verify the error message contains the '(nid:' substring; they do not assert exact NID values but do ensure NID(s) are included in the message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->