### PR TITLE
[#572] Added content 'should not exist' assertion to 'ContentTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -2398,6 +2398,21 @@ When I change the moderation state of the "article" content with the title "Test
 
 </details>
 
+<details>
+  <summary><code>@Then :content_type content with the title :title should not exist</code></summary>
+
+<br/>
+Assert content with specified type and title does not exist
+<br/><br/>
+
+```gherkin
+Then "page" content with the title "Test page" should not exist
+Then "article" content with the title "Test article" should not exist
+
+```
+
+</details>
+
 ## Drupal\DraggableviewsTrait
 
 [Source](src/Drupal/DraggableviewsTrait.php), [Example](tests/behat/features/drupal_draggableviews.feature)

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps\Drupal;
 
 use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Step\When;
 use Behat\Gherkin\Node\TableNode;
 use DrevOps\BehatSteps\HelperTrait;
@@ -227,6 +228,23 @@ trait ContentTrait {
 
     $node->set('moderation_state', $new_state);
     $node->save();
+  }
+
+  /**
+   * Assert content with specified type and title does not exist.
+   *
+   * @code
+   * Then "page" content with the title "Test page" should not exist
+   * Then "article" content with the title "Test article" should not exist
+   * @endcode
+   */
+  #[Then(':content_type content with the title :title should not exist')]
+  public function contentAssertNotExistsWithTitle(string $content_type, string $title): void {
+    $nids = $this->contentLoadMultiple($content_type, ['title' => $title]);
+
+    if (!empty($nids)) {
+      throw new \RuntimeException(sprintf('Content of type "%s" with title "%s" should not exist, but found with NID: %s', $content_type, $title, implode(', ', $nids)));
+    }
   }
 
   /**

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -8,6 +8,7 @@ use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ExpectationException;
 use DrevOps\BehatSteps\HelperTrait;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
@@ -243,7 +244,7 @@ trait ContentTrait {
     $nids = $this->contentLoadMultiple($content_type, ['title' => $title]);
 
     if (!empty($nids)) {
-      throw new \RuntimeException(sprintf('Content of type "%s" with title "%s" should not exist, but found with NID: %s', $content_type, $title, implode(', ', $nids)));
+      throw new ExpectationException(sprintf('"%s" content with the title "%s" should not exist, but it does (nid: %s).', $content_type, $title, implode(', ', $nids)), $this->getSession()->getDriver());
     }
   }
 

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -314,7 +314,7 @@ Feature: Check that ContentTrait works
       Then "page" content with the title "[TEST] Exists page" should not exist
       """
     When I run "behat --no-colors"
-    Then it should fail with an exception:
+    Then it should fail with an error:
       """
-      Content of type "page" with title "[TEST] Exists page" should not exist, but found with NID:
+      "page" content with the title "[TEST] Exists page" should not exist, but it does (nid:
       """

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -297,3 +297,24 @@ Feature: Check that ContentTrait works
     Then I should see "[TEST] V-Page 1"
     And I should see "[TEST] V-Page 2"
     And I should see "[TEST] V-Page 3"
+
+  @api
+  Scenario: Assert "Then :content_type content with the title :title should not exist" works as expected
+    Given I am logged in as a user with the "administrator" role
+    Then "page" content with the title "[TEST] Non-existing page" should not exist
+
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "Then :content_type content with the title :title should not exist" works as expected when content exists
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given page content:
+        | title              |
+        | [TEST] Exists page |
+      Then "page" content with the title "[TEST] Exists page" should not exist
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Content of type "page" with title "[TEST] Exists page" should not exist, but found with NID:
+      """


### PR DESCRIPTION
Closes #572

## Summary

Added a new `contentAssertNotExistsWithTitle()` step to `ContentTrait` that asserts no content of a given type and title exists. When content is found, a `RuntimeException` is thrown with the NID(s) included in the error message. The implementation uses the existing `contentLoadMultiple()` helper for consistency with the rest of the trait.

## Changes

**`src/Drupal/ContentTrait.php`**
- Added `use Behat\Step\Then;` import
- Added `contentAssertNotExistsWithTitle(string $content_type, string $title)` method with `#[Then(':content_type content with the title :title should not exist')]` attribute

**`tests/behat/features/drupal_content.feature`**
- Added positive `@api` scenario: asserts the step passes when content truly does not exist
- Added negative `@trait:Drupal\ContentTrait` scenario: verifies the step throws a `RuntimeException` with NID when content is found

## Before / After

```
Before:
ContentTrait
├── contentRemoveContentType()
├── contentDelete()
├── contentCreateWithFields()
├── contentVisitViewWithTitle()
├── contentVisitEditPageWithTitle()
├── contentVisitDeletePageWithTitle()
├── contentVisitScheduledTransitionsPageWithTitle()
├── contentVisitRevisionsPageWithTitle()
├── contentChangeModerationStateWithTitle()
└── contentLoadMultiple()        ← helper (no "not exists" assertion)

After:
ContentTrait
├── contentRemoveContentType()
├── contentDelete()
├── contentCreateWithFields()
├── contentVisitViewWithTitle()
├── contentVisitEditPageWithTitle()
├── contentVisitDeletePageWithTitle()
├── contentVisitScheduledTransitionsPageWithTitle()
├── contentVisitRevisionsPageWithTitle()
├── contentChangeModerationStateWithTitle()
├── contentAssertNotExistsWithTitle()  ← NEW: Then "page" content ... should not exist
└── contentLoadMultiple()
```
