### PR TITLE
[#573] Added element focus step to 'ElementTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -341,6 +341,21 @@ When I hover over the element "#tooltip-trigger"
 </details>
 
 <details>
+  <summary><code>@When I focus on the element :selector</code></summary>
+
+<br/>
+Focus on an element by CSS selector
+<br/><br/>
+
+```gherkin
+When I focus on the element "#edit-name"
+When I focus on the element ".form-text"
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the element :selector1 should appear after the element :selector2</code></summary>
 
 <br/>

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -314,11 +314,16 @@ trait ElementTrait {
    * When I focus on the element ".form-text"
    * @endcode
    *
-   *
    * @javascript
    */
   #[When('I focus on the element :selector')]
   public function elementFocus(string $selector): void {
+    $element = $this->getSession()->getPage()->find('css', $selector);
+
+    if (!$element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
     $this->elementExecuteJs($selector, '{{ELEMENT}}.focus();');
   }
 

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -307,6 +307,22 @@ trait ElementTrait {
   }
 
   /**
+   * Focus on an element by CSS selector.
+   *
+   * @code
+   * When I focus on the element "#edit-name"
+   * When I focus on the element ".form-text"
+   * @endcode
+   *
+   *
+   * @javascript
+   */
+  #[When('I focus on the element :selector')]
+  public function elementFocus(string $selector): void {
+    $this->elementExecuteJs($selector, '{{ELEMENT}}.focus();');
+  }
+
+  /**
    * Assert that element with specified CSS is visible on page.
    *
    * @code

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -487,7 +487,7 @@ Feature: Check that ElementTrait works
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      Element with selector #nonexistent-element not found.
+      Element with selector "#nonexistent-element" not found.
       """
 
   @javascript @phpserver

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -473,7 +473,7 @@ Feature: Check that ElementTrait works
     Given I am an anonymous user
     When I visit "/sites/default/files/elements.html"
     And I focus on the element "#focus-input"
-    Then the element "#focus-input" with the attribute "id" and the value "focus-input" should exist
+    Then the element "#focus-input" with the attribute "data-focused" and the value "true" should exist
 
   @trait:ElementTrait
   Scenario: Assert that "When I focus on the element :selector" fails when element does not exist

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -468,6 +468,28 @@ Feature: Check that ElementTrait works
       Element matching css "#nonexistent-element" not found.
       """
 
+  @javascript
+  Scenario: Assert "When I focus on the element :selector" works as expected
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements.html"
+    And I focus on the element "#focus-input"
+    Then the element "#focus-input" with the attribute "id" and the value "focus-input" should exist
+
+  @trait:ElementTrait
+  Scenario: Assert that "When I focus on the element :selector" fails when element does not exist
+    Given some behat configuration
+    And scenario steps tagged with "@javascript":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements.html"
+      And I focus on the element "#nonexistent-element"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element with selector #nonexistent-element not found.
+      """
+
   @javascript @phpserver
   Scenario: Assert click on element works
     Given I am on the phpserver test page

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -478,7 +478,7 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert that "When I focus on the element :selector" fails when element does not exist
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
       When I visit "/sites/default/files/elements.html"

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -487,7 +487,7 @@ Feature: Check that ElementTrait works
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      Element with selector "#nonexistent-element" not found.
+      Element matching css "#nonexistent-element" not found.
       """
 
   @javascript @phpserver

--- a/tests/behat/fixtures/elements.html
+++ b/tests/behat/fixtures/elements.html
@@ -66,6 +66,12 @@
     <a href="/path3">Link 3</a>
   </div>
 
+  <!-- Section: Focus Testing -->
+  <div class="section">
+    <h2>Focus Testing</h2>
+    <input id="focus-input" type="text" placeholder="Focus me">
+  </div>
+
   <!-- Section: Hover Testing -->
   <div class="section">
     <h2>Hover Testing</h2>

--- a/tests/behat/fixtures/elements.html
+++ b/tests/behat/fixtures/elements.html
@@ -69,7 +69,7 @@
   <!-- Section: Focus Testing -->
   <div class="section">
     <h2>Focus Testing</h2>
-    <input id="focus-input" type="text" placeholder="Focus me">
+    <input id="focus-input" type="text" placeholder="Focus me" onfocus="this.setAttribute('data-focused', 'true')">
   </div>
 
   <!-- Section: Hover Testing -->


### PR DESCRIPTION
Closes #573

## Summary

Added a `When I focus on the element :selector` step to `ElementTrait` that focuses a DOM element using JavaScript. The step uses the existing `elementExecuteJs()` helper, which handles element lookup, error handling, and JS execution. This fills a gap in the trait — it already had scroll, click, hover, and event-trigger steps but lacked a dedicated focus step.

## Changes

**`src/ElementTrait.php`**
- Added `elementFocus(string $selector)` method with the `#[When('I focus on the element :selector')]` attribute, placed after the existing `elementHover()` method alongside the other interaction steps.

**`tests/behat/features/element.feature`**
- Added a positive `@javascript` scenario that visits `elements.html`, focuses on `#focus-input`, and asserts the element exists.
- Added a negative `@trait:ElementTrait` scenario that verifies the step throws the expected error when the target element is not found.

**`tests/behat/fixtures/elements.html`**
- Added a "Focus Testing" section containing an `<input id="focus-input">` element used by the new test scenario.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds support for focusing on HTML elements via a new Behat step definition to the `ElementTrait`.

## Changes

**src/ElementTrait.php**
- Added `elementFocus(string $selector): void` method with step attribute `#[When('I focus on the element :selector')]`
- Locates the target element via CSS selector and throws `ElementNotFoundException` if not found
- Executes JavaScript focus operation using the existing `elementExecuteJs()` helper: `{{ELEMENT}}.focus();`

**tests/behat/features/element.feature**
- Added positive scenario (tagged `@javascript`) that focuses on `#focus-input` and asserts the element receives focus via a `data-focused="true"` attribute
- Added negative scenario (tagged `@trait:ElementTrait`) verifying that attempting to focus on a non-existent element throws the expected error message

**tests/behat/fixtures/elements.html**
- Added "Focus Testing" section with an `<input id="focus-input">` element
- Input includes an `onfocus` handler that sets `data-focused="true"` when focused

**STEPS.md**
- Added documentation entry for the new `@When I focus on the element :selector` step with usage examples

## Implementation Notes

- Follows the step definition format rules in CONTRIBUTING.md (action verb, `When I <verb>` format, method name prefixed with trait name)
- Uses existing helper `elementExecuteJs()` for consistency
- Requires `@javascript` tag due to JavaScript execution
- Closes issue #573

<!-- end of auto-generated comment: release notes by coderabbit.ai -->