### PR TITLE
[#567] Added fixture loading and attribute contains steps to 'XmlTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -1757,6 +1757,37 @@ When I wait for 1 second for AJAX to finish
 
 
 <details>
+  <summary><code>@Given the response content from the file :filename</code></summary>
+
+<br/>
+Set the response XML content from a fixture file
+<br/><br/>
+
+```gherkin
+Given the response content from the file "xml_valid.xml"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the response content is the following:</code></summary>
+
+<br/>
+Set the response XML content directly from a PyString
+<br/><br/>
+
+```gherkin
+Given the response content is the following:
+  """
+  <?xml version="1.0"?><root><item>value</item></root>
+  """
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the response should be in XML format</code></summary>
 
 <br/>
@@ -1929,6 +1960,36 @@ Assert that an XML attribute value does not equal specified text
 ```gherkin
 Then the XML attribute "id" on element "//book" should not be equal to "999"
 Then the XML attribute "category" on element "/library/book[1]" should not be equal to "science"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the XML attribute :attribute_name on element :element should contain :text</code></summary>
+
+<br/>
+Assert that an XML attribute value contains specified text
+<br/><br/>
+
+```gherkin
+Then the XML attribute "category" on element "//book" should contain "fic"
+Then the XML attribute "id" on element "/library/book[1]" should contain "12"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the XML attribute :attribute_name on element :element should not contain :text</code></summary>
+
+<br/>
+Assert that an XML attribute value does not contain specified text
+<br/><br/>
+
+```gherkin
+Then the XML attribute "category" on element "//book" should not contain "science"
+Then the XML attribute "id" on element "/library/book[1]" should not contain "999"
 
 ```
 

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\Then;
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Given;
+use Behat\Step\Then;
 
 /**
  * Assert XML responses with element and attribute checks.
@@ -37,6 +39,11 @@ trait XmlTrait {
   protected ?string $xmlContentHash = NULL;
 
   /**
+   * XML content set directly for testing without an HTTP request.
+   */
+  protected ?string $xmlTestContent = NULL;
+
+  /**
    * Enable internal XML error handling before each scenario.
    */
   #[BeforeScenario]
@@ -48,6 +55,7 @@ trait XmlTrait {
     $this->xmlDocument = NULL;
     $this->xmlXpath = NULL;
     $this->xmlContentHash = NULL;
+    $this->xmlTestContent = NULL;
   }
 
   /**
@@ -57,6 +65,54 @@ trait XmlTrait {
    */
   #[AfterScenario]
   public function xmlAfterScenario(): void {
+    $this->xmlDocument = NULL;
+    $this->xmlXpath = NULL;
+    $this->xmlContentHash = NULL;
+    $this->xmlTestContent = NULL;
+  }
+
+  /**
+   * Set the response XML content from a fixture file.
+   *
+   * @code
+   * Given the response content from the file "xml_valid.xml"
+   * @endcode
+   */
+  #[Given('the response content from the file :filename')]
+  public function xmlSetResponseContentFromFile(string $filename): void {
+    $files_path = rtrim((string) $this->getMinkParameter('files_path'), '/');
+    $file_path = $files_path . '/' . $filename;
+
+    if (!file_exists($file_path)) {
+      throw new \RuntimeException(sprintf('The file "%s" does not exist.', $file_path));
+    }
+
+    $content = file_get_contents($file_path);
+    if ($content === FALSE) {
+      // @codeCoverageIgnoreStart
+      throw new \RuntimeException(sprintf('Failed to read the file "%s".', $file_path));
+      // @codeCoverageIgnoreEnd
+    }
+
+    $this->xmlTestContent = $content;
+    $this->xmlDocument = NULL;
+    $this->xmlXpath = NULL;
+    $this->xmlContentHash = NULL;
+  }
+
+  /**
+   * Set the response XML content directly from a PyString.
+   *
+   * @code
+   * Given the response content:
+   *   """
+   *   <?xml version="1.0"?><root><item>value</item></root>
+   *   """
+   * @endcode
+   */
+  #[Given('the response content:')]
+  public function xmlSetResponseContentDirect(PyStringNode $content): void {
+    $this->xmlTestContent = $content->getRaw();
     $this->xmlDocument = NULL;
     $this->xmlXpath = NULL;
     $this->xmlContentHash = NULL;
@@ -356,6 +412,62 @@ trait XmlTrait {
   }
 
   /**
+   * Assert that an XML attribute value contains specified text.
+   *
+   * @code
+   * Then the XML attribute "category" on element "//book" should contain "fic"
+   * Then the XML attribute "id" on element "/library/book[1]" should contain "12"
+   * @endcode
+   */
+  #[Then('the XML attribute :attribute_name on element :element should contain :text')]
+  public function xmlAssertAttributeContains(string $attribute_name, string $element, string $text): void {
+    $this->xmlEnsureDocument();
+
+    $nodes = $this->xmlXpath->query($element);
+    if ($nodes === FALSE || $nodes->length === 0) {
+      throw new ExpectationException(sprintf('The XML element "%s" was not found.', $element), $this->getSession()->getDriver());
+    }
+
+    $node = $nodes->item(0);
+    if (!$node instanceof \DOMElement || !$node->hasAttribute($attribute_name)) {
+      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" was not found.', $attribute_name, $element), $this->getSession()->getDriver());
+    }
+
+    $actual_value = $node->getAttribute($attribute_name);
+    if (!str_contains($actual_value, $text)) {
+      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" does not contain "%s". Actual value: "%s".', $attribute_name, $element, $text, $actual_value), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that an XML attribute value does not contain specified text.
+   *
+   * @code
+   * Then the XML attribute "category" on element "//book" should not contain "science"
+   * Then the XML attribute "id" on element "/library/book[1]" should not contain "999"
+   * @endcode
+   */
+  #[Then('the XML attribute :attribute_name on element :element should not contain :text')]
+  public function xmlAssertAttributeNotContains(string $attribute_name, string $element, string $text): void {
+    $this->xmlEnsureDocument();
+
+    $nodes = $this->xmlXpath->query($element);
+    if ($nodes === FALSE || $nodes->length === 0) {
+      throw new ExpectationException(sprintf('The XML element "%s" was not found.', $element), $this->getSession()->getDriver());
+    }
+
+    $node = $nodes->item(0);
+    if (!$node instanceof \DOMElement || !$node->hasAttribute($attribute_name)) {
+      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" was not found.', $attribute_name, $element), $this->getSession()->getDriver());
+    }
+
+    $actual_value = $node->getAttribute($attribute_name);
+    if (str_contains($actual_value, $text)) {
+      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" contains "%s", but it should not.', $attribute_name, $element, $text), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
    * Assert that an XML element has a specific number of child elements.
    *
    * @code
@@ -469,6 +581,14 @@ trait XmlTrait {
    *   If no document is loaded.
    */
   protected function xmlEnsureDocument(): void {
+    // Use directly set test content if available.
+    if ($this->xmlTestContent !== NULL) {
+      if ($this->xmlDocument === NULL) {
+        $this->xmlLoadDocument($this->xmlTestContent);
+      }
+      return;
+    }
+
     $content = $this->getSession()->getPage()->getContent();
     $content_hash = md5((string) $content);
 

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -104,13 +104,13 @@ trait XmlTrait {
    * Set the response XML content directly from a PyString.
    *
    * @code
-   * Given the response content:
+   * Given the response content is the following:
    *   """
    *   <?xml version="1.0"?><root><item>value</item></root>
    *   """
    * @endcode
    */
-  #[Given('the response content:')]
+  #[Given('the response content is the following:')]
   public function xmlSetResponseContentDirect(PyStringNode $content): void {
     $this->xmlTestContent = $content->getRaw();
     $this->xmlDocument = NULL;

--- a/tests/behat/features/xml.feature
+++ b/tests/behat/features/xml.feature
@@ -482,8 +482,8 @@ Feature: Check that XmlTrait works
       does not exist
       """
 
-  Scenario: Assert "Given the response content:" works with direct PyString content
-    Given the response content:
+  Scenario: Assert "Given the response content is the following:" works with direct PyString content
+    Given the response content is the following:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <catalog>
@@ -498,11 +498,11 @@ Feature: Check that XmlTrait works
     And the XML attribute "type" on element "//product[@id='p1']" should be equal to "widget"
 
   @trait:XmlTrait
-  Scenario: Assert that "Given the response content:" fails with an exception for invalid XML
+  Scenario: Assert that "Given the response content is the following:" fails with an exception for invalid XML
     Given some behat configuration
     And scenario steps:
       """
-      Given the response content:
+      Given the response content is the following:
         '''
         this is not valid xml <<<
         '''

--- a/tests/behat/features/xml.feature
+++ b/tests/behat/features/xml.feature
@@ -459,3 +459,153 @@ Feature: Check that XmlTrait works
       """
       The XML attribute "nonexistent" on element "//book[@id='123']" was not found.
       """
+
+  Scenario: Assert "Given the response content from the file :filename" works
+    Given the response content from the file "xml_valid.xml"
+    Then the XML element "//book[@id='123']/title" should be equal to "The Great Adventure"
+
+  Scenario: Assert "Given the response content from the file :filename" works with attribute assertions
+    Given the response content from the file "xml_valid.xml"
+    Then the XML attribute "category" on element "//book[@id='123']" should be equal to "fiction"
+
+  @trait:XmlTrait
+  Scenario: Assert that "Given the response content from the file :filename" fails with an exception for missing file
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the response content from the file "nonexistent.xml"
+      Then the XML element "//book" should exist
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      does not exist
+      """
+
+  Scenario: Assert "Given the response content:" works with direct PyString content
+    Given the response content:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <catalog>
+        <product id="p1" type="widget">
+          <name>Blue Widget</name>
+          <price>9.99</price>
+        </product>
+      </catalog>
+      """
+    Then the XML element "//product[@id='p1']/name" should be equal to "Blue Widget"
+    And the XML element "//product[@id='p1']/price" should be equal to "9.99"
+    And the XML attribute "type" on element "//product[@id='p1']" should be equal to "widget"
+
+  @trait:XmlTrait
+  Scenario: Assert that "Given the response content:" fails with an exception for invalid XML
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the response content:
+        '''
+        this is not valid xml <<<
+        '''
+      Then the XML element "//anything" should exist
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Failed to load XML
+      """
+
+  Scenario: Assert "Then the XML attribute :attribute_name on element :element should contain :text" works
+    When I go to "/sites/default/files/xml_valid.xml"
+    Then the XML attribute "category" on element "//book[@id='123']" should contain "fic"
+
+  Scenario: Assert "Then the XML attribute :attribute_name on element :element should contain :text" works with id attribute
+    When I go to "/sites/default/files/xml_valid.xml"
+    Then the XML attribute "id" on element "//book[@id='123']" should contain "12"
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should contain :text" fails with an error for missing element
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      Then the XML attribute "id" on element "//nonexistent" should contain "123"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The XML element "//nonexistent" was not found.
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should contain :text" fails with an error for missing attribute
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      Then the XML attribute "nonexistent" on element "//book[@id='123']" should contain "test"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The XML attribute "nonexistent" on element "//book[@id='123']" was not found.
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should contain :text" fails with an error for text not found
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      Then the XML attribute "category" on element "//book[@id='123']" should contain "science"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The XML attribute "category" on element "//book[@id='123']" does not contain "science".
+      """
+
+  Scenario: Assert "Then the XML attribute :attribute_name on element :element should not contain :text" works
+    When I go to "/sites/default/files/xml_valid.xml"
+    Then the XML attribute "category" on element "//book[@id='123']" should not contain "science"
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should not contain :text" fails with an error for missing element
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      Then the XML attribute "id" on element "//nonexistent" should not contain "123"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The XML element "//nonexistent" was not found.
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should not contain :text" fails with an error for missing attribute
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      Then the XML attribute "nonexistent" on element "//book[@id='123']" should not contain "test"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The XML attribute "nonexistent" on element "//book[@id='123']" was not found.
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should not contain :text" fails with an error when text is found
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      Then the XML attribute "category" on element "//book[@id='123']" should not contain "fic"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The XML attribute "category" on element "//book[@id='123']" contains "fic", but it should not.
+      """


### PR DESCRIPTION
Closes #567

## Summary

Added two fixture-loading steps (`xmlSetResponseContentFromFile` and `xmlSetResponseContentDirect`) to `XmlTrait` so tests can assert XML structure without making HTTP requests. Also added `xmlAssertAttributeContains` and `xmlAssertAttributeNotContains` steps for partial-match assertions on XML attribute values. A `$xmlTestContent` property tracks directly-set content and short-circuits `xmlEnsureDocument()` to use it instead of the Mink session page.

## Changes

**`src/XmlTrait.php`**
- Added `$xmlTestContent` property to hold content set directly without an HTTP request.
- Added `xmlSetResponseContentFromFile(string $filename)` — reads an XML fixture file from the Mink `files_path` and stores it in `$xmlTestContent`.
- Added `xmlSetResponseContentDirect(PyStringNode $content)` — stores a PyString directly as `$xmlTestContent`.
- Added `xmlAssertAttributeContains(string $attribute_name, string $element, string $text)` — asserts attribute value contains the given string.
- Added `xmlAssertAttributeNotContains(string $attribute_name, string $element, string $text)` — asserts attribute value does not contain the given string.
- Modified `xmlEnsureDocument()` to check `$xmlTestContent` first and skip Mink session content when it is set.
- Updated `xmlBeforeScenario()` and `xmlAfterScenario()` to reset `$xmlTestContent`.

**`tests/behat/features/xml.feature`**
- Added scenarios covering all four new steps, including happy-path and negative-assertion variants.

**`STEPS.md`**
- Regenerated to include the four new step entries.

## Before / After

```
Before: xmlEnsureDocument()
┌────────────────────────────┐
│  Get Mink page content     │
│  Hash it                   │
│  Load XML if changed       │
└────────────────────────────┘

After: xmlEnsureDocument()
┌─────────────────────────────────────────┐
│  $xmlTestContent set?                   │
│  ├─ YES → Load XML from $xmlTestContent │
│  │         (only if not yet loaded)     │
│  └─ NO  → Get Mink page content        │
│           Hash it                       │
│           Load XML if changed           │
└─────────────────────────────────────────┘
```
