### PR TITLE
[#574] Changed element scroll to use center viewport alignment with configurable property.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -455,6 +455,20 @@ Then the element "#header" should be at the top of the viewport
 </details>
 
 <details>
+  <summary><code>@Then the element :selector should be centered in the viewport</code></summary>
+
+<br/>
+Assert the element :selector should be centered in the viewport
+<br/><br/>
+
+```gherkin
+Then the element "#content" should be centered in the viewport
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the element :selector should be displayed</code></summary>
 
 <br/>

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -22,23 +22,27 @@ trait ElementTrait {
   /**
    * Whether to scroll elements to the center of the viewport.
    *
-   * When TRUE (default), uses scrollIntoView() with center alignment, which
-   * positions the element in the middle of the viewport. This avoids
+   * Returns TRUE (default) to use scrollIntoView() with center alignment,
+   * which positions the element in the middle of the viewport. This avoids
    * interaction failures caused by sticky headers, admin toolbars, or fixed
    * navigation.
    *
-   * When FALSE, uses the legacy scrollIntoView(true) behavior, which aligns
-   * the element to the top of the viewport.
+   * Returns FALSE to use the legacy scrollIntoView(true) behavior, which
+   * aligns the element to the top of the viewport.
    *
-   * Override this property in your context class to change the behavior:
+   * Override this method in your context class to change the behavior:
    * @code
    * class FeatureContext extends DrupalContext {
    *   use ElementTrait;
-   *   protected bool $elementScrollIntoViewCenter = FALSE;
+   *   protected function elementScrollIntoViewCenter(): bool {
+   *     return FALSE;
+   *   }
    * }
    * @endcode
    */
-  protected bool $elementScrollIntoViewCenter = TRUE;
+  protected function elementScrollIntoViewCenter(): bool {
+    return TRUE;
+  }
 
   /**
    * Assert that one element appears after another on the page.
@@ -233,6 +237,24 @@ trait ElementTrait {
   }
 
   /**
+   * Assert the element :selector should be centered in the viewport.
+   *
+   * Checks that the vertical center of the element is within the middle third
+   * of the viewport.
+   *
+   * @code
+   * Then the element "#content" should be centered in the viewport
+   * @endcode
+   */
+  #[Then('the element :selector should be centered in the viewport')]
+  public function elementAssertElementCenteredInViewport(string $selector): void {
+    $result = $this->elementExecuteJs($selector, 'var rect = {{ELEMENT}}.getBoundingClientRect(); var element_center = rect.top + rect.height / 2; var viewport_third = window.innerHeight / 3; return (element_center >= viewport_third && element_center <= viewport_third * 2);');
+    if (!$result) {
+      throw new ExpectationException(sprintf('Element with selector "%s" is not centered in the viewport.', $selector), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
    * Accept confirmation dialogs appearing on the page.
    *
    * @code
@@ -299,9 +321,9 @@ trait ElementTrait {
   /**
    * Scroll to an element with ID.
    *
-   * By default, scrolls the element to the center of the viewport. Set the
-   * $elementScrollIntoViewCenter property to FALSE to use the legacy behavior
-   * that aligns the element to the top of the viewport.
+   * By default, scrolls the element to the center of the viewport. Override
+   * the elementScrollIntoViewCenter() method to return FALSE to use the legacy
+   * behavior that aligns the element to the top of the viewport.
    *
    * @code
    * When I scroll to the element "#footer"
@@ -309,7 +331,7 @@ trait ElementTrait {
    */
   #[When('I scroll to the element :selector')]
   public function elementScrollTo(string $selector): void {
-    if ($this->elementScrollIntoViewCenter) {
+    if ($this->elementScrollIntoViewCenter()) {
       $this->elementExecuteJs($selector, '{{ELEMENT}}.scrollIntoView({ behavior: "auto", block: "center", inline: "center" });');
     }
     else {

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -20,6 +20,27 @@ use Behat\Mink\Exception\ExpectationException;
 trait ElementTrait {
 
   /**
+   * Whether to scroll elements to the center of the viewport.
+   *
+   * When TRUE (default), uses scrollIntoView() with center alignment, which
+   * positions the element in the middle of the viewport. This avoids
+   * interaction failures caused by sticky headers, admin toolbars, or fixed
+   * navigation.
+   *
+   * When FALSE, uses the legacy scrollIntoView(true) behavior, which aligns
+   * the element to the top of the viewport.
+   *
+   * Override this property in your context class to change the behavior:
+   * @code
+   * class FeatureContext extends DrupalContext {
+   *   use ElementTrait;
+   *   protected bool $elementScrollIntoViewCenter = FALSE;
+   * }
+   * @endcode
+   */
+  protected bool $elementScrollIntoViewCenter = TRUE;
+
+  /**
    * Assert that one element appears after another on the page.
    *
    * @code
@@ -278,13 +299,22 @@ trait ElementTrait {
   /**
    * Scroll to an element with ID.
    *
+   * By default, scrolls the element to the center of the viewport. Set the
+   * $elementScrollIntoViewCenter property to FALSE to use the legacy behavior
+   * that aligns the element to the top of the viewport.
+   *
    * @code
    * When I scroll to the element "#footer"
    * @endcode
    */
   #[When('I scroll to the element :selector')]
   public function elementScrollTo(string $selector): void {
-    $this->elementExecuteJs($selector, '{{ELEMENT}}.scrollIntoView(true);');
+    if ($this->elementScrollIntoViewCenter) {
+      $this->elementExecuteJs($selector, '{{ELEMENT}}.scrollIntoView({ behavior: "auto", block: "center", inline: "center" });');
+    }
+    else {
+      $this->elementExecuteJs($selector, '{{ELEMENT}}.scrollIntoView(true);');
+    }
   }
 
   /**

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -99,4 +99,14 @@ class FeatureContext extends DrupalContext {
     return strtotime('2024-07-15 12:00:00');
   }
 
+  /**
+   * Override elementScrollIntoViewCenter() to allow runtime toggling.
+   *
+   * This cannot be moved to FeatureContextTrait because traits cannot override
+   * methods from other traits.
+   */
+  protected function elementScrollIntoViewCenter(): bool {
+    return $this->testElementScrollCenter;
+  }
+
 }

--- a/tests/behat/bootstrap/FeatureContextTrait.php
+++ b/tests/behat/bootstrap/FeatureContextTrait.php
@@ -408,6 +408,14 @@ trait FeatureContextTrait {
   }
 
   /**
+   * Set scroll alignment to top (legacy behavior).
+   */
+  #[Given('I set scroll to top alignment')]
+  public function testSetScrollToTopAlignment(): void {
+    $this->elementScrollIntoViewCenter = FALSE;
+  }
+
+  /**
    * Go to the phpserver test page.
    */
   #[Given('/^(?:|I )am on (?:|the )phpserver test page$/')]

--- a/tests/behat/bootstrap/FeatureContextTrait.php
+++ b/tests/behat/bootstrap/FeatureContextTrait.php
@@ -408,11 +408,16 @@ trait FeatureContextTrait {
   }
 
   /**
+   * Whether to use center scroll alignment for testing.
+   */
+  protected bool $testElementScrollCenter = TRUE;
+
+  /**
    * Set scroll alignment to top (legacy behavior).
    */
   #[Given('I set scroll to top alignment')]
   public function testSetScrollToTopAlignment(): void {
-    $this->elementScrollIntoViewCenter = FALSE;
+    $this->testElementScrollCenter = FALSE;
   }
 
   /**

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -234,8 +234,15 @@ Feature: Check that ElementTrait works
     Then I should see the button "You canceled!"
 
   @javascript @phpserver
-  Scenario: Assert scroll to an element with selector
+  Scenario: Assert scroll to an element with selector uses center alignment by default
     Given I am on the phpserver test page
+    When I scroll to the element "#main-inner"
+    Then the element "#main-inner" should be at the top of the viewport
+
+  @javascript @phpserver
+  Scenario: Assert scroll to an element with top alignment when configured
+    Given I set scroll to top alignment
+    And I am on the phpserver test page
     When I scroll to the element "#main-inner"
     Then the element "#main-inner" should be at the top of the viewport
 

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -237,7 +237,7 @@ Feature: Check that ElementTrait works
   Scenario: Assert scroll to an element with selector uses center alignment by default
     Given I am on the phpserver test page
     When I scroll to the element "#main-inner"
-    Then the element "#main-inner" should be at the top of the viewport
+    Then the element "#main-inner" should be centered in the viewport
 
   @javascript @phpserver
   Scenario: Assert scroll to an element with top alignment when configured


### PR DESCRIPTION
Closes #574

## Summary

Updated `ElementTrait::elementScrollTo()` to scroll elements to the center of the viewport by default, rather than aligning to the top. This prevents interaction failures caused by sticky headers, admin toolbars, or fixed navigation overlapping the target element. The behavior is configurable via a new `$elementScrollIntoViewCenter` property on the trait, allowing consuming contexts to revert to the legacy top-alignment behavior when needed.

## Changes

**`src/ElementTrait.php`**
- Added `$elementScrollIntoViewCenter` boolean property (defaults to `TRUE`) with full docblock explaining the behavior and how to override it.
- Updated `elementScrollTo()` to branch on the property: center-aligned `scrollIntoView({ behavior: "auto", block: "center", inline: "center" })` when `TRUE`, legacy `scrollIntoView(true)` when `FALSE`.
- Added inline documentation on the step explaining the default behavior and how to change it.

**`tests/behat/bootstrap/FeatureContextTrait.php`**
- Added `testSetScrollToTopAlignment()` step (`Given I set scroll to top alignment`) to enable testing the legacy behavior path.

**`tests/behat/features/element.feature`**
- Renamed existing scroll scenario to clarify it asserts center alignment is the default.
- Added a second scenario that sets top alignment via the test step and verifies the legacy behavior still works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request implements configurable element scroll alignment and updates tests to cover both centered (default) and legacy top alignment.

### Code Changes

- src/ElementTrait.php
  - Added protected overridable hook: protected function elementScrollIntoViewCenter(): bool (default TRUE).
  - elementScrollTo(string $selector) now:
    - If elementScrollIntoViewCenter() returns TRUE: uses scrollIntoView({ behavior: "auto", block: "center", inline: "center" }) to center elements in the viewport.
    - Otherwise: uses legacy scrollIntoView(true) (top alignment).
  - Added public test/assert helper: elementAssertElementCenteredInViewport(string $selector) — verifies the element’s vertical center lies within the middle third of the viewport and throws ExpectationException when it does not.
  - Updated inline documentation explaining default behavior and override mechanism.

- tests/behat/bootstrap/FeatureContextTrait.php
  - Added protected bool $testElementScrollCenter = TRUE.
  - Added step method with annotation #[Given('I set scroll to top alignment')] to set $testElementScrollCenter = FALSE for tests.

- tests/behat/bootstrap/FeatureContext.php
  - Added protected function elementScrollIntoViewCenter(): bool returning $this->testElementScrollCenter to allow runtime toggling within tests.

- tests/behat/features/element.feature
  - Updated existing scenario to assert center alignment by default.
  - Added a scenario that flips the test configuration and asserts legacy top alignment.

- STEPS.md
  - Added documentation for the new assertion step (Then the element :selector should be centered in the viewport).

### API / Interface Changes

- Added protected method elementScrollIntoViewCenter(): bool to DrevOps\BehatSteps\ElementTrait (overridable hook).
- Changed behavior of public method elementScrollTo(string $selector) in ElementTrait.
- Added public assertion step method elementAssertElementCenteredInViewport(string $selector).

### Tests

- Tests updated/added to cover:
  - Default behavior: element is centered in viewport after scrolling.
  - Legacy behavior: element is top-aligned after setting test flag to top alignment.

### Critical Issue

CRITICAL — Step definition format violation (CONTRIBUTING.md)
- The new test step is annotated as a Given: #[Given('I set scroll to top alignment')].
- Per CONTRIBUTING.md, "Given" must define prerequisites and should not use "Given I" (reserved for actions). Actions must use "When I <verb>".
- This step performs an action (changing runtime test configuration) and therefore violates the repository's step-format rules and the automated lint checks (ahoy lint-docs).
- Recommendation: change the annotation to a When step (e.g., #[When('I set scroll to top alignment')]) to comply with CONTRIBUTING.md.

### Notes
- The behavioral change (centering by default) is observable and may affect consumers; consider semantic versioning impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->