### PR TITLE
[#601] Added 'QueueTrait' with Drupal core queue management and assertion steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ from the community.
 | [Drupal\ModuleTrait](STEPS.md#drupalmoduletrait) | Enable and disable Drupal modules with automatic state restoration. |
 | [Drupal\OverrideTrait](STEPS.md#drupaloverridetrait) | Override Drupal Extension behaviors. |
 | [Drupal\ParagraphsTrait](STEPS.md#drupalparagraphstrait) | Manage Drupal paragraphs entities with structured field data. |
+| [Drupal\QueueTrait](STEPS.md#drupalqueuetrait) | Manage and assert Drupal queue state. |
 | [Drupal\SearchApiTrait](STEPS.md#drupalsearchapitrait) | Assert Drupal Search API with index and query operations. |
 | [Drupal\TaxonomyTrait](STEPS.md#drupaltaxonomytrait) | Manage Drupal taxonomy terms with vocabulary organization. |
 | [Drupal\TestmodeTrait](STEPS.md#drupaltestmodetrait) | Configure Drupal Testmode module for controlled testing scenarios. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -39,6 +39,7 @@
 | [Drupal\ModuleTrait](#drupalmoduletrait) | Enable and disable Drupal modules with automatic state restoration. |
 | [Drupal\OverrideTrait](#drupaloverridetrait) | Override Drupal Extension behaviors. |
 | [Drupal\ParagraphsTrait](#drupalparagraphstrait) | Manage Drupal paragraphs entities with structured field data. |
+| [Drupal\QueueTrait](#drupalqueuetrait) | Manage and assert Drupal queue state. |
 | [Drupal\SearchApiTrait](#drupalsearchapitrait) | Assert Drupal Search API with index and query operations. |
 | [Drupal\TaxonomyTrait](#drupaltaxonomytrait) | Manage Drupal taxonomy terms with vocabulary organization. |
 | [Drupal\TestmodeTrait](#drupaltestmodetrait) | Configure Drupal Testmode module for controlled testing scenarios. |
@@ -3686,6 +3687,88 @@ Given the following fields for the paragraph "text" exist in the field "field_co
   | field_paragraph_longtext:value  | My paragraph message |
   | field_paragraph_longtext:format | full_html            |
   | ...                             | ...                  |
+
+```
+
+</details>
+
+## Drupal\QueueTrait
+
+[Source](src/Drupal/QueueTrait.php), [Example](tests/behat/features/drupal_queue.feature)
+
+>  Manage and assert Drupal queue state.
+>  - Clear queues before scenarios.
+>  - Process queue items during tests.
+>  - Assert queue item counts.
+
+
+<details>
+  <summary><code>@Given the :queue queue is empty</code></summary>
+
+<br/>
+Empty a queue
+<br/><br/>
+
+```gherkin
+Given the "myqueue" queue is empty
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I process :count item(s) from the :queue queue</code></summary>
+
+<br/>
+Process a specific number of items from a queue
+<br/><br/>
+
+```gherkin
+When I process 5 items from the "myqueue" queue
+When I process 1 item from the "myqueue" queue
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I process all items from the :queue queue</code></summary>
+
+<br/>
+Process all items from a queue
+<br/><br/>
+
+```gherkin
+When I process all items from the "myqueue" queue
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the :queue queue should have :count item(s)</code></summary>
+
+<br/>
+Assert that a queue has a specific number of items
+<br/><br/>
+
+```gherkin
+Then the "myqueue" queue should have 5 items
+Then the "myqueue" queue should have 1 item
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the :queue queue should be empty</code></summary>
+
+<br/>
+Assert that a queue is empty
+<br/><br/>
+
+```gherkin
+Then the "myqueue" queue should be empty
 
 ```
 

--- a/src/Drupal/QueueTrait.php
+++ b/src/Drupal/QueueTrait.php
@@ -63,7 +63,7 @@ trait QueueTrait {
     $processed = 0;
     while ($processed < $count) {
       $item = $queue_instance->claimItem($lease_time);
-      if (!$item) {
+      if (!$item || !is_object($item)) {
         throw new \RuntimeException(sprintf('Queue "%s" has no more items to process. Processed %d of %d requested items.', $queue, $processed, $count));
       }
       $worker->processItem($item->data);
@@ -90,7 +90,7 @@ trait QueueTrait {
     $processed = 0;
     while ($processed < $limit) {
       $item = $queue_instance->claimItem($lease_time);
-      if (!$item) {
+      if (!$item || !is_object($item)) {
         break;
       }
       $worker->processItem($item->data);

--- a/src/Drupal/QueueTrait.php
+++ b/src/Drupal/QueueTrait.php
@@ -62,8 +62,9 @@ trait QueueTrait {
 
     $processed = 0;
     while ($processed < $count) {
+      /** @var \stdClass|false $item */
       $item = $queue_instance->claimItem($lease_time);
-      if (!$item || !is_object($item)) {
+      if (!$item) {
         throw new \RuntimeException(sprintf('Queue "%s" has no more items to process. Processed %d of %d requested items.', $queue, $processed, $count));
       }
       $worker->processItem($item->data);
@@ -89,8 +90,9 @@ trait QueueTrait {
 
     $processed = 0;
     while ($processed < $limit) {
+      /** @var \stdClass|false $item */
       $item = $queue_instance->claimItem($lease_time);
-      if (!$item || !is_object($item)) {
+      if (!$item) {
         break;
       }
       $worker->processItem($item->data);

--- a/src/Drupal/QueueTrait.php
+++ b/src/Drupal/QueueTrait.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Drupal;
+
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Hook\AfterScenario;
+use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+
+/**
+ * Manage and assert Drupal queue state.
+ *
+ * - Clear queues before scenarios.
+ * - Process queue items during tests.
+ * - Assert queue item counts.
+ */
+trait QueueTrait {
+
+  /**
+   * Queue names used during the scenario.
+   *
+   * @var array<string>
+   */
+  protected array $queueNames = [];
+
+  /**
+   * Empty a queue.
+   *
+   * @code
+   * Given the "myqueue" queue is empty
+   * @endcode
+   */
+  #[Given('the :queue queue is empty')]
+  public function queueEmpty(string $queue): void {
+    $this->queueTrackName($queue);
+    $queue_instance = \Drupal::service('queue')->get($queue);
+    $queue_instance->deleteQueue();
+    $queue_instance->createQueue();
+  }
+
+  /**
+   * Process a specific number of items from a queue.
+   *
+   * @code
+   * When I process 5 items from the "myqueue" queue
+   * @endcode
+   *
+   * @code
+   * When I process 1 item from the "myqueue" queue
+   * @endcode
+   */
+  #[When('I process :count item(s) from the :queue queue')]
+  public function queueProcessItems(int $count, string $queue): void {
+    $this->queueTrackName($queue);
+    $queue_instance = \Drupal::service('queue')->get($queue);
+    $worker = \Drupal::service('plugin.manager.queue_worker')->createInstance($queue);
+    $lease_time = $this->queueGetLeaseTime();
+
+    $processed = 0;
+    while ($processed < $count) {
+      $item = $queue_instance->claimItem($lease_time);
+      if (!$item) {
+        throw new \RuntimeException(sprintf('Queue "%s" has no more items to process. Processed %d of %d requested items.', $queue, $processed, $count));
+      }
+      $worker->processItem($item->data);
+      $queue_instance->deleteItem($item);
+      $processed++;
+    }
+  }
+
+  /**
+   * Process all items from a queue.
+   *
+   * @code
+   * When I process all items from the "myqueue" queue
+   * @endcode
+   */
+  #[When('I process all items from the :queue queue')]
+  public function queueProcessAll(string $queue): void {
+    $this->queueTrackName($queue);
+    $queue_instance = \Drupal::service('queue')->get($queue);
+    $worker = \Drupal::service('plugin.manager.queue_worker')->createInstance($queue);
+    $lease_time = $this->queueGetLeaseTime();
+    $limit = $this->queueGetProcessLimit();
+
+    $processed = 0;
+    while ($processed < $limit) {
+      $item = $queue_instance->claimItem($lease_time);
+      if (!$item) {
+        break;
+      }
+      $worker->processItem($item->data);
+      $queue_instance->deleteItem($item);
+      $processed++;
+    }
+
+    if ($processed >= $limit) {
+      throw new \RuntimeException(sprintf('Queue "%s" processing reached the safety limit of %d items.', $queue, $limit));
+    }
+  }
+
+  /**
+   * Assert that a queue has a specific number of items.
+   *
+   * @code
+   * Then the "myqueue" queue should have 5 items
+   * @endcode
+   *
+   * @code
+   * Then the "myqueue" queue should have 1 item
+   * @endcode
+   */
+  #[Then('the :queue queue should have :count item(s)')]
+  public function queueAssertItemCount(string $queue, int $count): void {
+    $this->queueTrackName($queue);
+    $queue_instance = \Drupal::service('queue')->get($queue);
+    $actual = $queue_instance->numberOfItems();
+    if ($actual !== $count) {
+      throw new ExpectationException(sprintf('Expected queue "%s" to have %d items, but it has %d.', $queue, $count, $actual), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a queue is empty.
+   *
+   * @code
+   * Then the "myqueue" queue should be empty
+   * @endcode
+   */
+  #[Then('the :queue queue should be empty')]
+  public function queueAssertEmpty(string $queue): void {
+    $this->queueTrackName($queue);
+    $queue_instance = \Drupal::service('queue')->get($queue);
+    $actual = $queue_instance->numberOfItems();
+    if ($actual !== 0) {
+      throw new ExpectationException(sprintf('Expected queue "%s" to be empty, but it has %d items.', $queue, $actual), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Clean up queues after scenario.
+   */
+  #[AfterScenario('@queue')]
+  public function queueAfterScenario(AfterScenarioScope $scope): void {
+    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+
+    foreach ($this->queueNames as $queue_name) {
+      $queue_instance = \Drupal::service('queue')->get($queue_name);
+      $queue_instance->deleteQueue();
+    }
+
+    $this->queueNames = [];
+  }
+
+  /**
+   * Get the maximum number of items to process.
+   */
+  protected function queueGetProcessLimit(): int {
+    return 1000;
+  }
+
+  /**
+   * Get the lease time for claiming queue items.
+   */
+  protected function queueGetLeaseTime(): int {
+    return 30;
+  }
+
+  /**
+   * Track a queue name for cleanup.
+   */
+  protected function queueTrackName(string $queue_name): void {
+    if (!in_array($queue_name, $this->queueNames)) {
+      $this->queueNames[] = $queue_name;
+    }
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -23,6 +23,7 @@ use DrevOps\BehatSteps\MetatagTrait;
 use DrevOps\BehatSteps\Drupal\ModuleTrait;
 use DrevOps\BehatSteps\Drupal\OverrideTrait;
 use DrevOps\BehatSteps\Drupal\ParagraphsTrait;
+use DrevOps\BehatSteps\Drupal\QueueTrait;
 use DrevOps\BehatSteps\Drupal\SearchApiTrait;
 use DrevOps\BehatSteps\Drupal\TaxonomyTrait;
 use DrevOps\BehatSteps\Drupal\TestmodeTrait;
@@ -75,6 +76,7 @@ class FeatureContext extends DrupalContext {
   use OverrideTrait;
   use ParagraphsTrait;
   use PathTrait;
+  use QueueTrait;
   use ResponseTrait;
   use RestTrait;
   use ResponsiveTrait;

--- a/tests/behat/bootstrap/FeatureContextTrait.php
+++ b/tests/behat/bootstrap/FeatureContextTrait.php
@@ -478,7 +478,7 @@ trait FeatureContextTrait {
   /**
    * Add items to a Drupal queue for testing.
    */
-  #[Given('I add :count items to the :queue queue')]
+  #[Given('I add :count item(s) to the :queue queue')]
   public function testAddItemsToQueue(int $count, string $queue): void {
     $queue_instance = \Drupal::service('queue')->get($queue);
     for ($i = 0; $i < $count; $i++) {

--- a/tests/behat/bootstrap/FeatureContextTrait.php
+++ b/tests/behat/bootstrap/FeatureContextTrait.php
@@ -475,4 +475,15 @@ trait FeatureContextTrait {
     }
   }
 
+  /**
+   * Add items to a Drupal queue for testing.
+   */
+  #[Given('I add :count items to the :queue queue')]
+  public function testAddItemsToQueue(int $count, string $queue): void {
+    $queue_instance = \Drupal::service('queue')->get($queue);
+    for ($i = 0; $i < $count; $i++) {
+      $queue_instance->createItem(['data' => 'test_item_' . $i]);
+    }
+  }
+
 }

--- a/tests/behat/features/drupal_queue.feature
+++ b/tests/behat/features/drupal_queue.feature
@@ -1,0 +1,56 @@
+Feature: Check that QueueTrait works
+  As Behat Steps library developer
+  I want to provide tools to manage Drupal queue state
+  So that users can clear, process, and assert queue items in their tests
+
+  @api @queue
+  Scenario: Assert "Given the :queue queue is empty" clears a queue
+    Given I add 3 items to the "behat_test" queue
+    And the "behat_test" queue should have 3 items
+    When the "behat_test" queue is empty
+    Then the "behat_test" queue should be empty
+
+  @api @queue
+  Scenario: Assert "Then the :queue queue should have :count items" counts items
+    Given the "behat_test" queue is empty
+    And I add 5 items to the "behat_test" queue
+    Then the "behat_test" queue should have 5 items
+
+  @api @queue
+  Scenario: Assert "Then the :queue queue should be empty" passes for empty queue
+    Given the "behat_test" queue is empty
+    Then the "behat_test" queue should be empty
+
+  @api @queue
+  Scenario: Assert "Then the :queue queue should have :count item" works with singular
+    Given the "behat_test" queue is empty
+    And I add 1 items to the "behat_test" queue
+    Then the "behat_test" queue should have 1 item
+
+  @api @trait:Drupal\QueueTrait
+  Scenario: Assert negative assertion for "Then the :queue queue should have :count items" works with wrong count
+    Given some behat configuration
+    And scenario steps tagged with "@api @queue":
+      """
+      Given I go to "/"
+      Then the "behat_test" queue should have 5 items
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected queue "behat_test" to have 5 items, but it has 0.
+      """
+
+  @api @trait:Drupal\QueueTrait
+  Scenario: Assert negative assertion for "Then the :queue queue should be empty" works with non-empty queue
+    Given some behat configuration
+    And scenario steps tagged with "@api @queue":
+      """
+      Given I add 2 items to the "behat_test" queue
+      Then the "behat_test" queue should be empty
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected queue "behat_test" to be empty, but it has 2 items.
+      """

--- a/tests/behat/features/drupal_queue.feature
+++ b/tests/behat/features/drupal_queue.feature
@@ -24,7 +24,7 @@ Feature: Check that QueueTrait works
   @api @queue
   Scenario: Assert "Then the :queue queue should have :count item" works with singular
     Given the "behat_test" queue is empty
-    And I add 1 items to the "behat_test" queue
+    And I add 1 item to the "behat_test" queue
     Then the "behat_test" queue should have 1 item
 
   @api @trait:Drupal\QueueTrait


### PR DESCRIPTION
Closes #601

## Summary
- Added `QueueTrait` providing Behat steps for managing Drupal core queues: clearing, processing items (specific count or all), and asserting item counts.
- Includes `@AfterScenario` cleanup hook (triggered by `@queue` tag) to delete queues used during tests.
- Overridable `queueGetProcessLimit()` and `queueGetLeaseTime()` methods for customizing processing behavior.

## Changes
- `src/Drupal/QueueTrait.php` - New trait with five steps: `Given the :queue queue is empty`, `When I process :count item(s) from the :queue queue`, `When I process all items from the :queue queue`, `Then the :queue queue should have :count item(s)`, `Then the :queue queue should be empty`.
- `tests/behat/features/drupal_queue.feature` - BDD tests covering all steps including positive assertions and negative `@trait` scenarios.
- `tests/behat/bootstrap/FeatureContext.php` - Registered `QueueTrait`.
- `tests/behat/bootstrap/FeatureContextTrait.php` - Added helper step `I add :count items to the :queue queue` for test setup.
- `README.md`, `STEPS.md` - Updated documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Added QueueTrait for Drupal Core Queue Management

### Overview
This PR introduces a new QueueTrait that provides Behat step definitions for managing and asserting Drupal core queues during BDD tests, plus tests and documentation.

### Key Changes

- New trait: src/Drupal/QueueTrait.php
  - Steps:
    - Given the :queue queue is empty
    - When I process :count item(s) from the :queue queue
    - When I process all items from the :queue queue
    - Then the :queue queue should have :count item(s)
    - Then the :queue queue should be empty
  - Tracks touched queues for scenario cleanup and registers #[AfterScenario('@queue')] hook
  - Configurable protected methods: queueGetProcessLimit() (default 1000) and queueGetLeaseTime() (default 30)
  - Implements processing using Drupal core Queue API and the queue worker plugin manager
  - Throws RuntimeException for processing failures and Behat\Mink\Exception\ExpectationException for assertion failures

- Tests and test helpers:
  - tests/behat/features/drupal_queue.feature — positive scenarios and negative @trait scenarios validating error messages and pluralization
  - tests/behat/bootstrap/FeatureContextTrait.php — added step to populate queues for tests
  - tests/behat/bootstrap/FeatureContext.php — registers QueueTrait

- Documentation:
  - README.md — added QueueTrait entry to Drupal steps index
  - STEPS.md — new section documenting all queue-related steps

- Misc:
  - PHPStan-related fix for claimItem() return type noted in commits

### Compliance with CONTRIBUTING.md (steps format)

Critical violation:
- tests/behat/bootstrap/FeatureContextTrait.php adds a Given step annotated as "I add :count items to the :queue queue". CONTRIBUTING.md requires Given steps to define prerequisites and to refrain from using "Given I" (reserved for actions). This step is an action and should be a When step (e.g., "When I add :count items to the :queue queue") or be reworded to a proper prerequisite phrasing (e.g., "Given the :queue queue has :count items").

Other checks:
- Step wording and trait step method names (prefixed with `queue`) in QueueTrait follow the documented naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->