### PR TITLE
[#579] Added webform deletion step to 'WebformTrait'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ from the community.
 | [Drupal\TimeTrait](STEPS.md#drupaltimetrait) | Control system time in tests using Drupal state overrides. |
 | [Drupal\UserTrait](STEPS.md#drupalusertrait) | Manage Drupal users with role and permission assignments. |
 | [Drupal\WatchdogTrait](STEPS.md#drupalwatchdogtrait) | Assert Drupal does not trigger PHP errors during scenarios using Watchdog. |
+| [Drupal\WebformTrait](STEPS.md#drupalwebformtrait) | Manage Drupal webforms. |
 
 
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -45,6 +45,7 @@
 | [Drupal\TimeTrait](#drupaltimetrait) | Control system time in tests using Drupal state overrides. |
 | [Drupal\UserTrait](#drupalusertrait) | Manage Drupal users with role and permission assignments. |
 | [Drupal\WatchdogTrait](#drupalwatchdogtrait) | Assert Drupal does not trigger PHP errors during scenarios using Watchdog. |
+| [Drupal\WebformTrait](#drupalwebformtrait) | Manage Drupal webforms. |
 
 
 ---
@@ -4235,6 +4236,28 @@ Then the user "John" should not be blocked
 >  - `@watchdog:{type}` - limit watchdog messages to specific types.
 >  - `@error` - add to scenarios that are expected to trigger an error.
 
+
+## Drupal\WebformTrait
+
+[Source](src/Drupal/WebformTrait.php), [Example](tests/behat/features/drupal_webform.feature)
+
+>  Manage Drupal webforms.
+>  - Delete webforms matching a given title for test isolation.
+
+
+<details>
+  <summary><code>@Given the webform :title does not exist</code></summary>
+
+<br/>
+Remove all webforms with a title containing the given string
+<br/><br/>
+
+```gherkin
+Given the webform "Test form" does not exist
+
+```
+
+</details>
 
 
 

--- a/src/Drupal/WebformTrait.php
+++ b/src/Drupal/WebformTrait.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Drupal;
+
+use Behat\Step\Given;
+
+/**
+ * Manage Drupal webforms.
+ *
+ * - Delete webforms matching a given title for test isolation.
+ */
+trait WebformTrait {
+
+  /**
+   * Remove all webforms with a title containing the given string.
+   *
+   * Silently succeeds if no matching webforms are found.
+   *
+   * @param string $title
+   *   The title (or partial title) of the webform(s) to delete.
+   *
+   * @code
+   *   Given the webform "Test form" does not exist
+   * @endcode
+   */
+  #[Given('the webform :title does not exist')]
+  public function webformDelete(string $title): void {
+    $webforms = $this->webformLoadAll($title);
+
+    foreach ($webforms as $webform) {
+      $webform->delete();
+    }
+  }
+
+  /**
+   * Load all webforms whose title contains the given string.
+   *
+   * @param string $title
+   *   The title string to search for (CONTAINS match).
+   *
+   * @return \Drupal\webform\WebformInterface[]
+   *   An array of matching webform entities.
+   */
+  protected function webformLoadAll(string $title): array {
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+    $entity_type_manager = \Drupal::getContainer()->get('entity_type.manager');
+
+    $ids = $entity_type_manager->getStorage('webform')->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('title', $title, 'CONTAINS')
+      ->execute();
+
+    if (empty($ids)) {
+      return [];
+    }
+
+    /** @var \Drupal\webform\WebformInterface[] $webforms */
+    $webforms = $entity_type_manager->getStorage('webform')->loadMultiple($ids);
+
+    return $webforms;
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -29,6 +29,7 @@ use DrevOps\BehatSteps\Drupal\TestmodeTrait;
 use DrevOps\BehatSteps\Drupal\TimeTrait;
 use DrevOps\BehatSteps\Drupal\UserTrait;
 use DrevOps\BehatSteps\Drupal\WatchdogTrait;
+use DrevOps\BehatSteps\Drupal\WebformTrait;
 use DrevOps\BehatSteps\ElementTrait;
 use DrevOps\BehatSteps\FieldTrait;
 use DrevOps\BehatSteps\IframeTrait;
@@ -87,6 +88,7 @@ class FeatureContext extends DrupalContext {
   use HelperTrait;
   use WaitTrait;
   use WatchdogTrait;
+  use WebformTrait;
   use XmlTrait;
 
   use FeatureContextTrait;

--- a/tests/behat/features/drupal_webform.feature
+++ b/tests/behat/features/drupal_webform.feature
@@ -1,0 +1,21 @@
+Feature: Check that WebformTrait works
+  As Behat Steps library developer
+  I want to provide tools to manage Drupal webforms programmatically
+  So that users can test webform functionality reliably
+
+  @api
+  Scenario: Assert "@Given the webform :title does not exist" works as expected
+    Given I am logged in as a user with the "administrator" role
+    When I visit "/admin/structure/webform/add"
+    And I fill in "Title" with "Test webform to delete"
+    And I fill in "Machine-readable name" with "test_webform_to_delete"
+    And I press "Save"
+    And I visit "/admin/structure/webform"
+    Then I should see "Test webform to delete"
+    When the webform "Test webform to delete" does not exist
+    And I visit "/admin/structure/webform"
+    Then I should not see "Test webform to delete"
+
+  @api
+  Scenario: Assert "@Given the webform :title does not exist" works as expected on non-existing webform
+    Given the webform "Non-existing webform" does not exist


### PR DESCRIPTION
Closes #579

## Summary

Added a new `WebformTrait` to provide a webform deletion step for test isolation. The step `Given the webform :title does not exist` deletes all webforms matching a given title using a `CONTAINS` condition, silently succeeding if no matching webforms are found. This follows the same cleanup/setup pattern used by `ContentTrait` and `TaxonomyTrait`.

## Changes

### New trait: `src/Drupal/WebformTrait.php`
- `webformDelete(string $title)` — step definition that deletes matching webforms
- `webformLoadAll(string $title)` — helper method that queries webform entities using `CONTAINS` match on the `title` property

### Tests: `tests/behat/features/drupal_webform.feature`
- Scenario: creates a webform via the admin UI, deletes it with the step, verifies removal
- Scenario: calls delete on a non-existing webform to verify no error is thrown

### Updated files
- `tests/behat/bootstrap/FeatureContext.php` — registered `WebformTrait`
- `STEPS.md`, `README.md` — auto-generated documentation updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces `WebformTrait` to add webform deletion support for test isolation in Behat tests.

## Changes

- **New trait:** `src/Drupal/WebformTrait.php` with:
  - `webformDelete(string $title)` — step definition for deleting webforms matching a title using CONTAINS query
  - `webformLoadAll(string $title)` — helper method for querying webforms by title
- **Test coverage:** `tests/behat/features/drupal_webform.feature` with two scenarios validating deletion of existing and non-existing webforms
- **Integration:** `FeatureContext.php` updated to include `WebformTrait`
- **Documentation:** `STEPS.md` and `README.md` auto-updated with trait references

## Critical Issues

### Step Definition/Usage Mismatch (CONTRIBUTING.md Violation)

The step is defined as `#[Given('the webform :title does not exist')]`, but the feature file has an inconsistent usage:
- Line 15: `When the webform "Test webform to delete" does not exist` — uses as **When** step
- Line 21: `Given the webform "Non-existing webform" does not exist` — uses as **Given** step

**CONTRIBUTING.md violations:**
1. **Step type mismatch:** The step performs an action (deletion), which per CONTRIBUTING.md should be a `When` step ("describes an action and must contain an action verb"), not a `Given` step ("defines test prerequisites—conditions or data that must exist").
2. **Feature file execution failure:** Line 15 uses `When` but the definition is `Given`, causing this step to be undefined during test execution.

The definition and usage should be aligned—either define as `#[When('the webform :title does not exist')]` and use `When` consistently, or keep `Given` and update line 15 to use `Given`. Additionally, the semantic correctness per CONTRIBUTING.md suggests `When` is the appropriate step type for a deletion action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->