### PR TITLE
[#606] Added webform template cloning step to 'WebformTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -4266,15 +4266,14 @@ Given the webform "Test form" does not exist
 </details>
 
 <details>
-  <summary><code>@Given I clone webform template :template into :title</code></summary>
+  <summary><code>@Given a webform :title from template :template</code></summary>
 
 <br/>
 Clone a webform template into a new webform with the given title
 <br/><br/>
 
 ```gherkin
-Given I clone webform template "Contact" into "My contact form"
-Given a webform "My form" from template "Contact"
+Given a webform "My contact form" from template "Contact"
 
 ```
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -4243,6 +4243,12 @@ Then the user "John" should not be blocked
 
 >  Manage Drupal webforms.
 >  - Delete webforms matching a given title for test isolation.
+>  - Clone webform templates into new webforms for scenario setup.
+>  - Automatically clean up cloned webforms after scenario completion.
+>  
+>  Requires `drupal/webform` module.
+>  <br/><br/>
+>  Skip processing with tag: `@behat-steps-skip:webformAfterScenario`
 
 
 <details>
@@ -4254,6 +4260,21 @@ Remove all webforms with a title containing the given string
 
 ```gherkin
 Given the webform "Test form" does not exist
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given I clone webform template :template into :title</code></summary>
+
+<br/>
+Clone a webform template into a new webform with the given title
+<br/><br/>
+
+```gherkin
+Given I clone webform template "Contact" into "My contact form"
+Given a webform "My form" from template "Contact"
 
 ```
 

--- a/src/Drupal/WebformTrait.php
+++ b/src/Drupal/WebformTrait.php
@@ -7,6 +7,7 @@ namespace DrevOps\BehatSteps\Drupal;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Hook\AfterScenario;
 use Behat\Step\Given;
+use Drupal\Core\Entity\EntityStorageException;
 
 /**
  * Manage Drupal webforms.
@@ -39,7 +40,14 @@ trait WebformTrait {
     }
     // @codeCoverageIgnoreEnd
     foreach (static::$webformEntities as $webform) {
-      $webform->delete();
+      try {
+        $webform->delete();
+      }
+      // @codeCoverageIgnoreStart
+      catch (EntityStorageException) {
+        // Ignore "already deleted" errors to keep teardown resilient.
+      }
+      // @codeCoverageIgnoreEnd
     }
 
     static::$webformEntities = [];
@@ -127,10 +135,16 @@ trait WebformTrait {
    *   An array of matching webform entities.
    */
   protected function webformLoadAll(string $title): array {
+    // Clear config factory cache to pick up webform changes made via the
+    // admin UI in a separate process.
+    \Drupal::configFactory()->reset();
+
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
     $entity_type_manager = \Drupal::getContainer()->get('entity_type.manager');
+    $storage = $entity_type_manager->getStorage('webform');
+    $storage->resetCache();
 
-    $ids = $entity_type_manager->getStorage('webform')->getQuery()
+    $ids = $storage->getQuery()
       ->accessCheck(FALSE)
       ->condition('title', $title, 'CONTAINS')
       ->execute();
@@ -140,7 +154,7 @@ trait WebformTrait {
     }
 
     /** @var \Drupal\webform\WebformInterface[] $webforms */
-    $webforms = $entity_type_manager->getStorage('webform')->loadMultiple($ids);
+    $webforms = $storage->loadMultiple($ids);
 
     return $webforms;
   }

--- a/src/Drupal/WebformTrait.php
+++ b/src/Drupal/WebformTrait.php
@@ -4,14 +4,46 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Hook\AfterScenario;
 use Behat\Step\Given;
 
 /**
  * Manage Drupal webforms.
  *
  * - Delete webforms matching a given title for test isolation.
+ * - Clone webform templates into new webforms for scenario setup.
+ * - Automatically clean up cloned webforms after scenario completion.
+ *
+ * Requires `drupal/webform` module.
+ *
+ * Skip processing with tag: `@behat-steps-skip:webformAfterScenario`
  */
 trait WebformTrait {
+
+  /**
+   * Array of created webform entities for cleanup.
+   *
+   * @var array<int,\Drupal\webform\WebformInterface>
+   */
+  protected static $webformEntities = [];
+
+  /**
+   * Clean all created webform instances after scenario run.
+   */
+  #[AfterScenario]
+  public function webformAfterScenario(AfterScenarioScope $scope): void {
+    // @codeCoverageIgnoreStart
+    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+    // @codeCoverageIgnoreEnd
+    foreach (static::$webformEntities as $webform) {
+      $webform->delete();
+    }
+
+    static::$webformEntities = [];
+  }
 
   /**
    * Remove all webforms with a title containing the given string.
@@ -32,6 +64,57 @@ trait WebformTrait {
     foreach ($webforms as $webform) {
       $webform->delete();
     }
+  }
+
+  /**
+   * Clone a webform template into a new webform with the given title.
+   *
+   * Finds a webform template whose title contains the given string,
+   * duplicates it as a non-template webform, and tracks it for cleanup.
+   *
+   * @param string $template
+   *   The title (or partial title) of the template to clone.
+   * @param string $title
+   *   The title for the new webform.
+   *
+   * @code
+   *   Given I clone webform template "Contact" into "My contact form"
+   *   Given a webform "My form" from template "Contact"
+   * @endcode
+   */
+  #[Given('I clone webform template :template into :title')]
+  public function webformCloneTemplate(string $template, string $title): void {
+    $templates = $this->webformTemplates($template);
+
+    if (empty($templates)) {
+      throw new \RuntimeException(sprintf('No webform template matching "%s" was found.', $template));
+    }
+
+    $source = reset($templates);
+
+    /** @var \Drupal\webform\WebformInterface $clone */
+    $clone = $source->createDuplicate();
+    $clone->set('title', $title);
+    $clone->set('id', $this->webformMachineName($title));
+    $clone->set('template', FALSE);
+    $clone->save();
+
+    static::$webformEntities[] = $clone;
+  }
+
+  /**
+   * Load all webform templates whose title contains the given string.
+   *
+   * @param string $title
+   *   The title string to search for (CONTAINS match).
+   *
+   * @return \Drupal\webform\WebformInterface[]
+   *   An array of matching webform template entities.
+   */
+  protected function webformTemplates(string $title): array {
+    $webforms = $this->webformLoadAll($title);
+
+    return array_filter($webforms, static fn($webform): bool => $webform->isTemplate());
   }
 
   /**
@@ -60,6 +143,24 @@ trait WebformTrait {
     $webforms = $entity_type_manager->getStorage('webform')->loadMultiple($ids);
 
     return $webforms;
+  }
+
+  /**
+   * Generate a sanitized machine name from a title.
+   *
+   * @param string $title
+   *   The human-readable title.
+   *
+   * @return string
+   *   A machine name suitable for a webform ID.
+   */
+  protected function webformMachineName(string $title): string {
+    $machine_name = strtolower($title);
+    $machine_name = (string) preg_replace('/[^a-z0-9_]+/', '_', $machine_name);
+    $machine_name = trim($machine_name, '_');
+    $machine_name = substr($machine_name, 0, 26);
+
+    return $machine_name . '_' . random_int(1000, 9999);
   }
 
 }

--- a/src/Drupal/WebformTrait.php
+++ b/src/Drupal/WebformTrait.php
@@ -36,6 +36,7 @@ trait WebformTrait {
   public function webformAfterScenario(AfterScenarioScope $scope): void {
     // @codeCoverageIgnoreStart
     if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      static::$webformEntities = [];
       return;
     }
     // @codeCoverageIgnoreEnd
@@ -175,7 +176,17 @@ trait WebformTrait {
     $machine_name = trim($machine_name, '_');
     $machine_name = substr($machine_name, 0, 26);
 
-    return $machine_name . '_' . random_int(1000, 9999);
+    $storage = \Drupal::entityTypeManager()->getStorage('webform');
+    $attempts = 0;
+    do {
+      $candidate = $machine_name . '_' . random_int(1000, 9999);
+      $attempts++;
+      if ($attempts > 50) {
+        throw new \RuntimeException(sprintf('Unable to generate a unique webform machine name for "%s" after 50 attempts.', $title));
+      }
+    } while ($storage->load($candidate) !== NULL);
+
+    return $candidate;
   }
 
 }

--- a/src/Drupal/WebformTrait.php
+++ b/src/Drupal/WebformTrait.php
@@ -80,18 +80,17 @@ trait WebformTrait {
    * Finds a webform template whose title contains the given string,
    * duplicates it as a non-template webform, and tracks it for cleanup.
    *
-   * @param string $template
-   *   The title (or partial title) of the template to clone.
    * @param string $title
    *   The title for the new webform.
+   * @param string $template
+   *   The title (or partial title) of the template to clone.
    *
    * @code
-   *   Given I clone webform template "Contact" into "My contact form"
-   *   Given a webform "My form" from template "Contact"
+   *   Given a webform "My contact form" from template "Contact"
    * @endcode
    */
-  #[Given('I clone webform template :template into :title')]
-  public function webformCloneTemplate(string $template, string $title): void {
+  #[Given('a webform :title from template :template')]
+  public function webformCloneTemplate(string $title, string $template): void {
     $templates = $this->webformTemplates($template);
 
     if (empty($templates)) {
@@ -147,6 +146,8 @@ trait WebformTrait {
     $ids = $storage->getQuery()
       ->accessCheck(FALSE)
       ->condition('title', $title, 'CONTAINS')
+      ->sort('title')
+      ->sort('id')
       ->execute();
 
     if (empty($ids)) {

--- a/tests/behat/features/drupal_webform.feature
+++ b/tests/behat/features/drupal_webform.feature
@@ -21,7 +21,7 @@ Feature: Check that WebformTrait works
     Given the webform "Non-existing webform" does not exist
 
   @api @module:webform_templates
-  Scenario: Assert "@Given I clone webform template :template into :title" works as expected
+  Scenario: Assert "@Given a webform :title from template :template" works as expected
     Given I am logged in as a user with the "administrator" role
     When I visit "/admin/structure/webform/add"
     And I fill in "Title" with "Test template form"
@@ -30,18 +30,18 @@ Feature: Check that WebformTrait works
     And I visit "/admin/structure/webform/manage/test_template_form/settings"
     And I check "Allow this webform to be used as a template"
     And I press "Save"
-    When I clone webform template "Test template form" into "Cloned contact form"
+    Given a webform "Cloned contact form" from template "Test template form"
     And I visit "/admin/structure/webform"
     Then I should see "Cloned contact form"
     # Clean up the template.
     When the webform "Test template form" does not exist
 
   @trait:Drupal\WebformTrait
-  Scenario: Assert "@Given I clone webform template :template into :title" fails for non-existing template
+  Scenario: Assert "@Given a webform :title from template :template" fails for non-existing template
     Given some behat configuration
     And scenario steps tagged with "@api":
       """
-      Given I clone webform template "Non-existing template" into "My form"
+      Given a webform "My form" from template "Non-existing template"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:

--- a/tests/behat/features/drupal_webform.feature
+++ b/tests/behat/features/drupal_webform.feature
@@ -19,3 +19,32 @@ Feature: Check that WebformTrait works
   @api
   Scenario: Assert "@Given the webform :title does not exist" works as expected on non-existing webform
     Given the webform "Non-existing webform" does not exist
+
+  @api @module:webform_templates
+  Scenario: Assert "@Given I clone webform template :template into :title" works as expected
+    Given I am logged in as a user with the "administrator" role
+    When I visit "/admin/structure/webform/add"
+    And I fill in "Title" with "Test template form"
+    And I fill in "Machine-readable name" with "test_template_form"
+    And I press "Save"
+    And I visit "/admin/structure/webform/manage/test_template_form/settings"
+    And I check "Allow this webform to be used as a template"
+    And I press "Save"
+    When I clone webform template "Test template form" into "Cloned contact form"
+    And I visit "/admin/structure/webform"
+    Then I should see "Cloned contact form"
+    # Clean up the template.
+    When the webform "Test template form" does not exist
+
+  @trait:Drupal\WebformTrait
+  Scenario: Assert "@Given I clone webform template :template into :title" fails for non-existing template
+    Given some behat configuration
+    And scenario steps tagged with "@api":
+      """
+      Given I clone webform template "Non-existing template" into "My form"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      No webform template matching "Non-existing template" was found.
+      """


### PR DESCRIPTION
Closes #606

## Summary

Adds a new `I clone webform template :template into :title` step to `WebformTrait` so scenarios can duplicate an existing webform template into a fresh, non-template webform for the duration of a test. Cloned webforms are tracked in a static registry and automatically removed in an `AfterScenario` hook so tests stay isolated without manual cleanup. This unblocks scenarios that need a ready-to-use webform derived from a reference template without wiring one up through the UI on every run.

## Changes

- `src/Drupal/WebformTrait.php`
  - Added `webformCloneTemplate()` implementing the `@Given I clone webform template :template into :title` step. It looks up templates by partial title match, duplicates the first match via `createDuplicate()`, renames it, flips `template` to `FALSE`, and saves it.
  - Added protected helper `webformTemplates()` that filters `webformLoadAll()` results down to entities where `isTemplate()` is true.
  - Added protected helper `webformMachineName()` that sanitises the given title into a valid webform ID (lowercased, non-alphanumerics collapsed to underscores, trimmed, capped at 26 characters, suffixed with a random 4-digit integer to avoid collisions).
  - Added a static `$webformEntities` array and a `webformAfterScenario()` `AfterScenario` hook that deletes every tracked clone and resets the array. The hook honours the `@behat-steps-skip:webformAfterScenario` tag.
  - Throws a `\RuntimeException` with a descriptive message when no template matches the given title.
- `tests/behat/features/drupal_webform.feature`
  - Added an `@api` scenario that creates a template via the admin UI, clones it with the new step, and asserts the clone appears on the webform listing.
  - Added a `@trait:Drupal\WebformTrait` negative scenario that runs the step against a missing template and asserts the `No webform template matching "..." was found.` exception surfaces.
- `STEPS.md`
  - Regenerated to document the new step, the cleanup hook, and the skip tag.

## Before / After

Before: `WebformTrait` only exposed a delete-by-title step and had no lifecycle tracking.

```
┌─────────────────────────── WebformTrait ───────────────────────────┐
│                                                                    │
│  #[Given('the webform :title does not exist')]                     │
│  webformDelete($title)                                             │
│                                                                    │
│  protected webformLoadAll($title): WebformInterface[]              │
│                                                                    │
└────────────────────────────────────────────────────────────────────┘
```

After: the trait gains a clone step, a template filter, a machine-name helper, a static registry, and an `AfterScenario` cleanup hook.

```
┌─────────────────────────── WebformTrait ───────────────────────────┐
│                                                                    │
│  protected static $webformEntities = []   ◄── tracks clones        │
│                                                                    │
│  #[AfterScenario]                                                  │
│  webformAfterScenario($scope)                                      │
│    ├── honours @behat-steps-skip:webformAfterScenario              │
│    └── deletes every tracked clone, then resets registry           │
│                                                                    │
│  #[Given('the webform :title does not exist')]                     │
│  webformDelete($title)                                             │
│                                                                    │
│  #[Given('I clone webform template :template into :title')]        │
│  webformCloneTemplate($template, $title)                           │
│    ├── webformTemplates($template)   ──► filter isTemplate()       │
│    │     └── webformLoadAll($template)                             │
│    ├── throws RuntimeException when no match                       │
│    ├── $source->createDuplicate()                                  │
│    ├── set title / id / template = FALSE / save                    │
│    │     └── id via webformMachineName($title)                     │
│    └── static::$webformEntities[] = $clone                         │
│                                                                    │
│  protected webformLoadAll($title): WebformInterface[]              │
│  protected webformTemplates($title): WebformInterface[]            │
│  protected webformMachineName($title): string                      │
│                                                                    │
└────────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR implements webform template cloning for scenarios by adding a new Behat step and supporting helpers to WebformTrait, plus scenario-scoped cleanup and tests.

### Changes Made

1. New Behat step and implementation (src/Drupal/WebformTrait.php)
   - Method: public function webformCloneTemplate(string $title, string $template)
   - Step annotation: #[Given('a webform :title from template :template')]
   - Behaviour: finds webform templates by CONTAINS match on title, duplicates the first match, sets the clone's title and machine name (lowercased, non-alphanumerics collapsed to underscores, trimmed, truncated to 26 chars, suffixed with a random 4-digit integer with uniqueness retry up to 50 attempts), sets `template` to FALSE, saves the clone, and registers it for cleanup.
   - Throws \RuntimeException when no matching template is found with message: No webform template matching "%s" was found.

2. Supporting helpers (src/Drupal/WebformTrait.php)
   - protected function webformTemplates(string $title): array — filters webformLoadAll() to only template webforms.
   - protected function webformLoadAll(string $title): array — resets Drupal config factory and webform storage cache before querying; queries by CONTAINS on title and sorts by title then id for deterministic selection; returns loaded entities.
   - protected function webformMachineName(string $title): string — sanitises title into a base, appends a random 4-digit suffix, and retries up to 50 times to ensure uniqueness; throws if unable to generate unique ID.

3. Cleanup infrastructure (src/Drupal/WebformTrait.php)
   - protected static $webformEntities array to track created clones.
   - #[AfterScenario] public function webformAfterScenario(AfterScenarioScope $scope): void — deletes tracked clones, suppresses EntityStorageException, clears the registry. The hook respects the skip tag @behat-steps-skip:webformAfterScenario and still resets the registry on the skip path.

4. Tests and documentation
   - tests/behat/features/drupal_webform.feature: added positive scenario that creates a template via the UI, clones it with the new step, asserts the clone appears, and cleans up; added a negative scenario asserting the missing-template exception surfaces.
   - STEPS.md updated with the new step and skip-tag note.
   - Commit adjustments addressed code-review feedback: ensure registry reset on skip path and add uniqueness retry for generated machine names.

### Critical Issue — Step-definition rule violation (CONTRIBUTING.md)

- Violation: The new step is declared as a Given (#[Given('a webform :title from template :template')]) but performs an action (cloning). CONTRIBUTING.md requires actions use When steps (format: "When I <verb>").
- Severity: Critical — this conflicts with the repository's step-definition rules and automated linting.
- Required fixes:
  - Change the step annotation to a When step using an action-verb form (examples: #[When('I clone webform template :template into :title')] or #[When('I create a webform :title from template :template')]).
  - Update the trait docblock @code example, STEPS.md, and feature usages to use the When phrasing and ensure parameter ordering and phrasing are consistent across code, docs, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->