### PR TITLE
[#617] Extended 'ContentTrait' with node access grants rebuild steps

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -2844,6 +2844,34 @@ When I change the moderation state of the "article" content with the title "Test
 </details>
 
 <details>
+  <summary><code>@When I rebuild the access grants for the :content_type content with the title :title</code></summary>
+
+<br/>
+Rebuild node access grants for a content with the specified title
+<br/><br/>
+
+```gherkin
+When I rebuild the access grants for the "article" content with the title "My article"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I rebuild the access grants for all content</code></summary>
+
+<br/>
+Rebuild node access grants for all content
+<br/><br/>
+
+```gherkin
+When I rebuild the access grants for all content
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then :content_type content with the title :title should not exist</code></summary>
 
 <br/>

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -11,6 +11,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use DrevOps\BehatSteps\HelperTrait;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeAccessControlHandlerInterface;
 use Drupal\node\NodeInterface;
 use Drupal\workflows\Entity\Workflow;
 
@@ -263,8 +264,9 @@ trait ContentTrait {
       throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
     }
     // @codeCoverageIgnoreEnd
-
-    \Drupal::entityTypeManager()->getAccessControlHandler('node')->acquireGrants($node);
+    $handler = \Drupal::entityTypeManager()->getAccessControlHandler('node');
+    assert($handler instanceof NodeAccessControlHandlerInterface);
+    $handler->acquireGrants($node);
   }
 
   /**

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -266,7 +266,8 @@ trait ContentTrait {
     // @codeCoverageIgnoreEnd
     $handler = \Drupal::entityTypeManager()->getAccessControlHandler('node');
     assert($handler instanceof NodeAccessControlHandlerInterface);
-    $handler->acquireGrants($node);
+    $grants = $handler->acquireGrants($node);
+    \Drupal::service('node.grant_storage')->write($node, $grants);
   }
 
   /**

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -232,6 +232,58 @@ trait ContentTrait {
   }
 
   /**
+   * Rebuild node access grants for a content with the specified title.
+   *
+   * Loads the node by content type and exact title match, then acquires
+   * grants for it via the node access control handler. Useful after test
+   * fixtures are created to ensure access grants are populated for
+   * modules relying on the node access system.
+   *
+   * @code
+   * When I rebuild the access grants for the "article" content with the title "My article"
+   * @endcode
+   */
+  #[When('I rebuild the access grants for the :content_type content with the title :title')]
+  public function contentRebuildAccessGrantsByTitle(string $content_type, string $title): void {
+    $nids = $this->contentLoadMultiple($content_type, [
+      'title' => $title,
+    ]);
+
+    if (empty($nids)) {
+      throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
+    }
+
+    ksort($nids);
+
+    $nid = end($nids);
+    $node = Node::load($nid);
+
+    // @codeCoverageIgnoreStart
+    if (!$node instanceof NodeInterface) {
+      throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
+    }
+    // @codeCoverageIgnoreEnd
+
+    \Drupal::entityTypeManager()->getAccessControlHandler('node')->acquireGrants($node);
+  }
+
+  /**
+   * Rebuild node access grants for all content.
+   *
+   * Triggers a non-batched rebuild of node access grants for every node
+   * in the system. Useful after enabling or reconfiguring a node access
+   * module during a scenario.
+   *
+   * @code
+   * When I rebuild the access grants for all content
+   * @endcode
+   */
+  #[When('I rebuild the access grants for all content')]
+  public function contentRebuildAccessGrantsAll(): void {
+    node_access_rebuild(FALSE);
+  }
+
+  /**
    * Assert content with specified type and title does not exist.
    *
    * @code

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -318,3 +318,37 @@ Feature: Check that ContentTrait works
       """
       "page" content with the title "[TEST] Exists page" should not exist, but it does (nid:
       """
+
+  @api
+  Scenario: Assert "When I rebuild the access grants for the :content_type content with the title :title" works as expected
+    Given page content:
+      | title                    |
+      | [TEST] Grants page title |
+    And I am logged in as a user with the "administrator" role
+    When I rebuild the access grants for the "page" content with the title "[TEST] Grants page title"
+    And I visit the "page" content page with the title "[TEST] Grants page title"
+    Then I should see "[TEST] Grants page title"
+
+  @api
+  Scenario: Assert "When I rebuild the access grants for all content" works as expected
+    Given page content:
+      | title                        |
+      | [TEST] Grants all page title |
+    And I am logged in as a user with the "administrator" role
+    When I rebuild the access grants for all content
+    And I visit the "page" content page with the title "[TEST] Grants all page title"
+    Then I should see "[TEST] Grants all page title"
+
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "When I rebuild the access grants for the :content_type content with the title :title" works as expected for non-existing content
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      When I rebuild the access grants for the "page" content with the title "[TEST] Non-existing"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Unable to find "page" content with title "[TEST] Non-existing".
+      """


### PR DESCRIPTION
## Summary

Extends `ContentTrait` with two `When` steps for rebuilding Drupal node access grants from within Behat scenarios. These are useful for tests that enable a node access module (core `node.module` grants, `group`, `entity_access_by_field`, `workbench_access`, `permissions_by_term`) and need to populate grant rows before asserting visibility.

- `When I rebuild the access grants for the :content_type content with the title :title` — loads the node by type + exact title and calls `acquireGrants()` via the node access control handler.
- `When I rebuild the access grants for all content` — calls `node_access_rebuild(FALSE)` (non-batched).

Fixes #617

## Acceptance checklist

- [x] Two new steps in `src/Drupal/ContentTrait.php`.
- [x] Steps use `#[When(...)]` tuple annotations.
- [x] Placeholder name is `:content_type` (not `:type`).
- [x] Method names `contentRebuildAccessGrantsByTitle` / `contentRebuildAccessGrantsAll` — consistent with the existing `content*` naming convention.
- [x] Throws a clear exception when no node matches the title.
- [x] Feature tests added to `tests/behat/features/drupal_content.feature`.
- [x] `@trait:ContentTrait` negative test for missing content.
- [ ] `ahoy update-docs` run (deferred — handled in follow-up polish phase).
- [ ] `ahoy lint` passes (deferred — handled in follow-up polish phase).

## Merge order

This PR should be merged **after** #615, which also touches `src/Drupal/ContentTrait.php` and `tests/behat/features/drupal_content.feature`. A rebase onto the post-#615 `main` will be performed in the follow-up polish phase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary

### Overview
Extends `ContentTrait` with two new Behat step definitions to rebuild Drupal node access grants from test scenarios. This enables populating `node_access` grant rows after enabling node access modules, allowing visibility assertions to function correctly.

### Changes

**src/Drupal/ContentTrait.php**
- Added `contentRebuildAccessGrantsByTitle(string $content_type, string $title): void`
  - Step: `When I rebuild the access grants for the :content_type content with the title :title`
  - Loads a node by content type and exact title match, then acquires grants via the node access control handler
  - Throws `RuntimeException` if no matching node is found
- Added `contentRebuildAccessGrantsAll(): void`
  - Step: `When I rebuild the access grants for all content`
  - Triggers non-batched rebuild of node access grants for all nodes via `node_access_rebuild(FALSE)`
- Introduced `NodeAccessControlHandlerInterface` dependency
- Both methods use `#[When(...)]` tuple annotations per coding standards

**tests/behat/features/drupal_content.feature**
- Added positive `@api` scenario: verifies rebuild by title step correctly acquires grants and content is visitable
- Added positive `@api` scenario: verifies rebuild all content step works and content is visitable
- Added negative `@trait:Drupal\ContentTrait` scenario: validates exception thrown when attempting to rebuild grants for non-existent content

**STEPS.md**
- Documented both new step definitions with examples

### Compliance
✓ All step definitions comply with CONTRIBUTING.md guidelines:
  - Use tuple format `#[When(...)]` instead of regular expressions
  - Use descriptive placeholder names (`:content_type`)
  - Method names begin with trait name (`content*`)
  - When steps follow action format ("When I rebuild...")
  - Use proper exception handling for edge cases

### Testing
✓ Feature tests included for both positive and negative scenarios
✓ Follows existing ContentTrait conventions for node loading via entity query

### Outstanding
- Documentation update (`ahoy update-docs`) and linting (`ahoy lint-docs`) deferred to follow-up polish PR
- Merge contingent on prior merge of #615; rebase planned in follow-up polish

<!-- end of auto-generated comment: release notes by coderabbit.ai -->