### PR TITLE
[#614] Extended 'UserTrait' with email-based user existence assertions

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -4468,6 +4468,34 @@ Then the user "John" should not have the roles "administrator, editor" assigned
 </details>
 
 <details>
+  <summary><code>@Then the user with the email :mail should exist</code></summary>
+
+<br/>
+Assert that a user with an email address exists
+<br/><br/>
+
+```gherkin
+Then the user with the email "alice@example.com" should exist
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the user with the email :mail should not exist</code></summary>
+
+<br/>
+Assert that a user with an email address does not exist
+<br/><br/>
+
+```gherkin
+Then the user with the email "alice@example.com" should not exist
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the user :name should be blocked</code></summary>
 
 <br/>

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -314,6 +314,61 @@ trait UserTrait {
   }
 
   /**
+   * Assert that a user with an email address exists.
+   *
+   * Performs a case-insensitive match against the user mail property.
+   *
+   * @code
+   * Then the user with the email "alice@example.com" should exist
+   * @endcode
+   */
+  #[Then('the user with the email :mail should exist')]
+  public function userAssertExistsByMail(string $mail): void {
+    if (!$this->userExistsByMail($mail)) {
+      throw new ExpectationException(sprintf('User with email "%s" is expected to exist, but they do not.', $mail), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a user with an email address does not exist.
+   *
+   * Performs a case-insensitive match against the user mail property.
+   *
+   * @code
+   * Then the user with the email "alice@example.com" should not exist
+   * @endcode
+   */
+  #[Then('the user with the email :mail should not exist')]
+  public function userAssertNotExistsByMail(string $mail): void {
+    if ($this->userExistsByMail($mail)) {
+      throw new ExpectationException(sprintf('User with email "%s" is expected to not exist, but they do.', $mail), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Check whether a user with the given email address exists.
+   *
+   * Performs a case-insensitive match against the user mail property.
+   *
+   * @param string $mail
+   *   The email address to check.
+   *
+   * @return bool
+   *   TRUE if a user with the email exists, FALSE otherwise.
+   */
+  protected function userExistsByMail(string $mail): bool {
+    $ids = \Drupal::entityTypeManager()
+      ->getStorage('user')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('mail', $mail, 'LIKE')
+      ->range(0, 1)
+      ->execute();
+
+    return !empty($ids);
+  }
+
+  /**
    * Assert that a user is blocked.
    *
    * @code

--- a/tests/behat/features/drupal_user.feature
+++ b/tests/behat/features/drupal_user.feature
@@ -36,6 +36,41 @@ Feature: Check that UserTrait works
     And user "non_existing" should not exist
 
   @api
+  Scenario: Assert "Then the user with the email :mail should exist" works
+    Then the user with the email "authenticated_user@myexample.com" should exist
+    And the user with the email "AUTHENTICATED_USER@myexample.com" should exist
+    And the user with the email "nobody@example.com" should not exist
+
+  @api @trait:Drupal\UserTrait
+  Scenario: Assert "Then the user with the email :mail should exist" fails for non-existing user
+    Given some behat configuration
+    And scenario steps:
+      """
+      Then the user with the email "nobody@example.com" should exist
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      User with email "nobody@example.com" is expected to exist, but they do not.
+      """
+
+  @api @trait:Drupal\UserTrait
+  Scenario: Assert "Then the user with the email :mail should not exist" fails for existing user
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given users:
+        | name       | mail              | status |
+        | alice_user | alice@example.com | 1      |
+      Then the user with the email "alice@example.com" should not exist
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      User with email "alice@example.com" is expected to not exist, but they do.
+      """
+
+  @api
   Scenario: Assert "When the password for the user :name is :password" works
     Given the password for the user "authenticated_user" is "password123"
 


### PR DESCRIPTION
## Summary

Extends `UserTrait` with two new assertions that check whether a user
with a given email address exists in Drupal. Email is the stable
external identifier for registration, forgot-password, SSO provisioning,
and user-import flows, so asserting on it is more robust than asserting
on auto-generated usernames.

- Added `Then the user with the email :mail should exist`
  (`userAssertExistsByMail`).
- Added `Then the user with the email :mail should not exist`
  (`userAssertNotExistsByMail`).
- Both steps use a case-insensitive `LIKE` property query against the
  `user` entity storage `mail` field.
- Added a positive `@api` scenario and two `@trait:Drupal\UserTrait`
  negative scenarios in `tests/behat/features/drupal_user.feature`.

Fixes #614

## Acceptance checklist

- [x] Two new steps in `src/Drupal/UserTrait.php`.
- [x] Steps use `#[Then(...)]` tuple annotations.
- [x] Case-insensitive email comparison.
- [x] Feature tests in `tests/behat/features/drupal_user.feature`.
- [x] `@trait:UserTrait` negative tests for both polarities.
- [ ] `ahoy update-docs` run.
- [ ] `ahoy lint` passes.

## Test plan

- [ ] Run `ahoy test-bdd tests/behat/features/drupal_user.feature`
- [ ] Run `ahoy lint`
- [ ] Run `ahoy update-docs` and confirm `STEPS.md` is regenerated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds two new Behat step assertions to `UserTrait` for checking Drupal user existence by email address, implementing the requirements from issue #614.

### Changes

**New Step Definitions:**
- `@Then the user with the email :mail should exist` → `userAssertExistsByMail(string $mail)`
- `@Then the user with the email :mail should not exist` → `userAssertNotExistsByMail(string $mail)`

**Implementation Details:**
- Created protected method `userExistsByMail(string $mail): bool` that performs case-insensitive LIKE queries against the user entity storage mail field
- Both step methods use the Behat session driver for exception construction with descriptive error messages
- Steps are defined with `#[Then(...)]` annotations (tuple format, not regex)
- Added comprehensive tests in `drupal_user.feature` with positive @api scenario and negative @trait:Drupal\UserTrait scenarios
- Tests verify case-insensitive matching (authenticated_user@myexample.com and AUTHENTICATED_USER@myexample.com resolve as the same user) and non-existent email detection

**Files Modified:**
- `src/Drupal/UserTrait.php` (+55 lines)
- `tests/behat/features/drupal_user.feature` (+35 lines)
- `STEPS.md` (+28 lines)

### Critical Issue

⚠️ **CRITICAL: Naming Convention Violation** — The method names `userAssertExistsByMail` and `userAssertNotExistsByMail` violate the "Assertion Method Naming Conventions" guidelines in CONTRIBUTING.md.

Per CONTRIBUTING.md, existence assertions for singular subjects must follow the pattern `[entity]Assert[Exists|NotExists]` (e.g., `fieldAssertExists()`, `vocabularyAssertNotExists()`). The current implementation adds a "ByMail" suffix that deviates from this standard convention. While the "ByMail" suffix improves clarity by distinguishing this from other user existence checks, it does not comply with the documented naming patterns. The PR should be updated to use method names that strictly adhere to the existence assertion naming convention, or the CONTRIBUTING.md guidelines should be clarified to permit property-qualified existence assertion names.

### Compliance Summary

- ✅ Uses tuple format step definitions (not regex)
- ✅ Uses descriptive parameter name `:mail` matching Drupal user entity field
- ✅ Uses `#[Then(...)]` annotations
- ✅ Implements case-insensitive comparison using LIKE
- ✅ Adds comprehensive feature tests with positive and negative scenarios
- ✅ Parameter name is descriptive (`:mail`)
- ❌ Method naming violates documented assertion method naming conventions (Critical)
- ⓘ PR notes indicate `ahoy update-docs` and `ahoy lint-docs` remain as manual test steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->