### PR TITLE
[#610] Added 'StateTrait' with Drupal State API management steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ from the community.
 | [Drupal\ParagraphsTrait](STEPS.md#drupalparagraphstrait) | Manage Drupal paragraphs entities with structured field data. |
 | [Drupal\QueueTrait](STEPS.md#drupalqueuetrait) | Manage and assert Drupal queue state. |
 | [Drupal\SearchApiTrait](STEPS.md#drupalsearchapitrait) | Assert Drupal Search API with index and query operations. |
+| [Drupal\StateTrait](STEPS.md#drupalstatetrait) | Manage and assert Drupal State API values with automatic revert. |
 | [Drupal\TaxonomyTrait](STEPS.md#drupaltaxonomytrait) | Manage Drupal taxonomy terms with vocabulary organization. |
 | [Drupal\TestmodeTrait](STEPS.md#drupaltestmodetrait) | Configure Drupal Testmode module for controlled testing scenarios. |
 | [Drupal\TimeTrait](STEPS.md#drupaltimetrait) | Control system time in tests using Drupal state overrides. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -29,6 +29,7 @@
 | --- | --- |
 | [Drupal\BigPipeTrait](#drupalbigpipetrait) | Bypass Drupal BigPipe when rendering pages. |
 | [Drupal\BlockTrait](#drupalblocktrait) | Manage Drupal blocks. |
+| [Drupal\CacheTrait](#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
 | [Drupal\ContentBlockTrait](#drupalcontentblocktrait) | Manage Drupal content blocks. |
 | [Drupal\ContentTrait](#drupalcontenttrait) | Manage Drupal content with workflow and moderation support. |
 | [Drupal\DraggableviewsTrait](#drupaldraggableviewstrait) | Order items in the Drupal Draggable Views. |
@@ -589,6 +590,24 @@ Then I should see "Title field is required"
 </details>
 
 <details>
+  <summary><code>@When I fill in the multi-value field :field with the following values:</code></summary>
+
+<br/>
+Fill in a multi-value field widget with a list of values
+<br/><br/>
+
+```gherkin
+When I fill in the multi-value field "Tags" with the following values:
+  | value   |
+  | Drupal  |
+  | Behat   |
+  | Testing |
+
+```
+
+</details>
+
+<details>
   <summary><code>@When I fill in the color field :field with the value :value</code></summary>
 
 <br/>
@@ -849,6 +868,34 @@ Then the field "Body" should have "disabled" state
 Then the field "field_body" should have "disabled" state
 Then the field "Tags" should have "enabled" state
 Then the field "field_tags" should have "not enabled" state
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the field :field should be required</code></summary>
+
+<br/>
+Assert that a field is marked as required
+<br/><br/>
+
+```gherkin
+Then the field "Email" should be required
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the field :field should not be required</code></summary>
+
+<br/>
+Assert that a field is not marked as required
+<br/><br/>
+
+```gherkin
+Then the field "Nickname" should not be required
 
 ```
 
@@ -2612,6 +2659,59 @@ Then the block "My block" should not exist in the "content" region
 
 </details>
 
+## Drupal\CacheTrait
+
+[Source](src/Drupal/CacheTrait.php), [Example](tests/behat/features/drupal_cache.feature)
+
+>  Invalidate specific Drupal caches from within a scenario.
+>  <br/><br/>
+>  Provides targeted cache-clearing steps for single paths, path patterns, and
+>  the render cache. A full cache clear is intentionally out of scope because
+>  `DrupalContext::@Given the cache has been cleared` already covers it.
+
+
+<details>
+  <summary><code>@Given the page cache for the path :path has been cleared</code></summary>
+
+<br/>
+Clear the page cache for a single path
+<br/><br/>
+
+```gherkin
+Given the page cache for the path "/about" has been cleared
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the page cache for the paths matching :path_pattern has been cleared</code></summary>
+
+<br/>
+Clear the page cache for all paths matching a glob-style pattern
+<br/><br/>
+
+```gherkin
+Given the page cache for the paths matching "/news*" has been cleared
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the render cache has been cleared</code></summary>
+
+<br/>
+Clear the render cache
+<br/><br/>
+
+```gherkin
+Given the render cache has been cleared
+
+```
+
+</details>
+
 ## Drupal\ContentBlockTrait
 
 [Source](src/Drupal/ContentBlockTrait.php), [Example](tests/behat/features/drupal_content_block.feature)
@@ -2839,6 +2939,34 @@ Change moderation state of a content with the specified title
 
 ```gherkin
 When I change the moderation state of the "article" content with the title "Test article" to the "published" state
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I rebuild the access grants for the :content_type content with the title :title</code></summary>
+
+<br/>
+Rebuild node access grants for a content with the specified title
+<br/><br/>
+
+```gherkin
+When I rebuild the access grants for the "article" content with the title "My article"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I rebuild the access grants for all content</code></summary>
+
+<br/>
+Rebuild node access grants for all content
+<br/><br/>
+
+```gherkin
+When I rebuild the access grants for all content
 
 ```
 
@@ -4006,6 +4134,34 @@ When I run search indexing for 1 item
 
 </details>
 
+<details>
+  <summary><code>@When I run the Search API cron</code></summary>
+
+<br/>
+Run the Search API module cron hook
+<br/><br/>
+
+```gherkin
+When I run the Search API cron
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I run the Search API Solr cron</code></summary>
+
+<br/>
+Run the Search API Solr module cron hook
+<br/><br/>
+
+```gherkin
+When I run the Search API Solr cron
+
+```
+
+</details>
+
 ## Drupal\StateTrait
 
 [Source](src/Drupal/StateTrait.php), [Example](tests/behat/features/drupal_state.feature)
@@ -4016,10 +4172,10 @@ When I run search indexing for 1 item
 >  `\Drupal::state()`. Touched keys are snapshotted on first access and
 >  reverted after the scenario finishes.
 >  <br/><br/>
->  Skip the scenario revert with `@behat-steps-skip:stateAfterScenario`, or
->  with the convenience tag `@behat-steps-skip:StateTrait`. The snapshot
->  registry is cleared unconditionally before and after the scenario to
->  prevent state leaking into subsequent scenarios.
+>  Skip the revert with `@behat-steps-skip:stateAfterScenario` or with the
+>  convenience tag `@behat-steps-skip:StateTrait`. The snapshot registry is
+>  cleared unconditionally before and after the scenario to prevent state
+>  leaking into subsequent scenarios.
 
 
 <details>
@@ -4552,6 +4708,34 @@ Assert that a user does not have roles assigned
 
 ```gherkin
 Then the user "John" should not have the roles "administrator, editor" assigned
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the user with the email :mail should exist</code></summary>
+
+<br/>
+Assert that a user with an email address exists
+<br/><br/>
+
+```gherkin
+Then the user with the email "alice@example.com" should exist
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the user with the email :mail should not exist</code></summary>
+
+<br/>
+Assert that a user with an email address does not exist
+<br/><br/>
+
+```gherkin
+Then the user with the email "alice@example.com" should not exist
 
 ```
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -29,7 +29,6 @@
 | --- | --- |
 | [Drupal\BigPipeTrait](#drupalbigpipetrait) | Bypass Drupal BigPipe when rendering pages. |
 | [Drupal\BlockTrait](#drupalblocktrait) | Manage Drupal blocks. |
-| [Drupal\CacheTrait](#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
 | [Drupal\ContentBlockTrait](#drupalcontentblocktrait) | Manage Drupal content blocks. |
 | [Drupal\ContentTrait](#drupalcontenttrait) | Manage Drupal content with workflow and moderation support. |
 | [Drupal\DraggableviewsTrait](#drupaldraggableviewstrait) | Order items in the Drupal Draggable Views. |
@@ -43,6 +42,7 @@
 | [Drupal\ParagraphsTrait](#drupalparagraphstrait) | Manage Drupal paragraphs entities with structured field data. |
 | [Drupal\QueueTrait](#drupalqueuetrait) | Manage and assert Drupal queue state. |
 | [Drupal\SearchApiTrait](#drupalsearchapitrait) | Assert Drupal Search API with index and query operations. |
+| [Drupal\StateTrait](#drupalstatetrait) | Manage and assert Drupal State API values with automatic revert. |
 | [Drupal\TaxonomyTrait](#drupaltaxonomytrait) | Manage Drupal taxonomy terms with vocabulary organization. |
 | [Drupal\TestmodeTrait](#drupaltestmodetrait) | Configure Drupal Testmode module for controlled testing scenarios. |
 | [Drupal\TimeTrait](#drupaltimetrait) | Control system time in tests using Drupal state overrides. |
@@ -589,24 +589,6 @@ Then I should see "Title field is required"
 </details>
 
 <details>
-  <summary><code>@When I fill in the multi-value field :field with the following values:</code></summary>
-
-<br/>
-Fill in a multi-value field widget with a list of values
-<br/><br/>
-
-```gherkin
-When I fill in the multi-value field "Tags" with the following values:
-  | value   |
-  | Drupal  |
-  | Behat   |
-  | Testing |
-
-```
-
-</details>
-
-<details>
   <summary><code>@When I fill in the color field :field with the value :value</code></summary>
 
 <br/>
@@ -867,34 +849,6 @@ Then the field "Body" should have "disabled" state
 Then the field "field_body" should have "disabled" state
 Then the field "Tags" should have "enabled" state
 Then the field "field_tags" should have "not enabled" state
-
-```
-
-</details>
-
-<details>
-  <summary><code>@Then the field :field should be required</code></summary>
-
-<br/>
-Assert that a field is marked as required
-<br/><br/>
-
-```gherkin
-Then the field "Email" should be required
-
-```
-
-</details>
-
-<details>
-  <summary><code>@Then the field :field should not be required</code></summary>
-
-<br/>
-Assert that a field is not marked as required
-<br/><br/>
-
-```gherkin
-Then the field "Nickname" should not be required
 
 ```
 
@@ -2658,59 +2612,6 @@ Then the block "My block" should not exist in the "content" region
 
 </details>
 
-## Drupal\CacheTrait
-
-[Source](src/Drupal/CacheTrait.php), [Example](tests/behat/features/drupal_cache.feature)
-
->  Invalidate specific Drupal caches from within a scenario.
->  <br/><br/>
->  Provides targeted cache-clearing steps for single paths, path patterns, and
->  the render cache. A full cache clear is intentionally out of scope because
->  `DrupalContext::@Given the cache has been cleared` already covers it.
-
-
-<details>
-  <summary><code>@Given the page cache for the path :path has been cleared</code></summary>
-
-<br/>
-Clear the page cache for a single path
-<br/><br/>
-
-```gherkin
-Given the page cache for the path "/about" has been cleared
-
-```
-
-</details>
-
-<details>
-  <summary><code>@Given the page cache for the paths matching :path_pattern has been cleared</code></summary>
-
-<br/>
-Clear the page cache for all paths matching a glob-style pattern
-<br/><br/>
-
-```gherkin
-Given the page cache for the paths matching "/news*" has been cleared
-
-```
-
-</details>
-
-<details>
-  <summary><code>@Given the render cache has been cleared</code></summary>
-
-<br/>
-Clear the render cache
-<br/><br/>
-
-```gherkin
-Given the render cache has been cleared
-
-```
-
-</details>
-
 ## Drupal\ContentBlockTrait
 
 [Source](src/Drupal/ContentBlockTrait.php), [Example](tests/behat/features/drupal_content_block.feature)
@@ -2938,34 +2839,6 @@ Change moderation state of a content with the specified title
 
 ```gherkin
 When I change the moderation state of the "article" content with the title "Test article" to the "published" state
-
-```
-
-</details>
-
-<details>
-  <summary><code>@When I rebuild the access grants for the :content_type content with the title :title</code></summary>
-
-<br/>
-Rebuild node access grants for a content with the specified title
-<br/><br/>
-
-```gherkin
-When I rebuild the access grants for the "article" content with the title "My article"
-
-```
-
-</details>
-
-<details>
-  <summary><code>@When I rebuild the access grants for all content</code></summary>
-
-<br/>
-Rebuild node access grants for all content
-<br/><br/>
-
-```gherkin
-When I rebuild the access grants for all content
 
 ```
 
@@ -4133,29 +4006,89 @@ When I run search indexing for 1 item
 
 </details>
 
+## Drupal\StateTrait
+
+[Source](src/Drupal/StateTrait.php), [Example](tests/behat/features/drupal_state.feature)
+
+>  Manage and assert Drupal State API values with automatic revert.
+>  <br/><br/>
+>  Provides set, delete, and assertion steps for keys stored through
+>  `\Drupal::state()`. Touched keys are snapshotted on first access and
+>  reverted after the scenario finishes.
+>  <br/><br/>
+>  Skip processing with tags: `@behat-steps-skip:stateBeforeScenario` and
+>  `@behat-steps-skip:stateAfterScenario`, or skip both at once with the
+>  convenience tag `@behat-steps-skip:StateTrait`.
+
+
 <details>
-  <summary><code>@When I run the Search API cron</code></summary>
+  <summary><code>@Given the state :name has the value :value</code></summary>
 
 <br/>
-Run the Search API module cron hook
+Set a Drupal state value
 <br/><br/>
 
 ```gherkin
-When I run the Search API cron
+Given the state "my_module.launched" has the value "1"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@When I run the Search API Solr cron</code></summary>
+  <summary><code>@Given the state :name does not exist</code></summary>
 
 <br/>
-Run the Search API Solr module cron hook
+Delete a Drupal state value
 <br/><br/>
 
 ```gherkin
-When I run the Search API Solr cron
+Given the state "my_module.launched" does not exist
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the following state values:</code></summary>
+
+<br/>
+Set multiple Drupal state values from a table
+<br/><br/>
+
+```gherkin
+Given the following state values:
+  | name                   | value |
+  | my_module.launched     | 1     |
+  | my_module.feature_flag | 0     |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the state :name should have the value :value</code></summary>
+
+<br/>
+Assert that a Drupal state value equals an expected value
+<br/><br/>
+
+```gherkin
+Then the state "my_module.launched" should have the value "1"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the state :name should not exist</code></summary>
+
+<br/>
+Assert that a Drupal state key does not exist
+<br/><br/>
+
+```gherkin
+Then the state "my_module.launched" should not exist
 
 ```
 
@@ -4618,34 +4551,6 @@ Assert that a user does not have roles assigned
 
 ```gherkin
 Then the user "John" should not have the roles "administrator, editor" assigned
-
-```
-
-</details>
-
-<details>
-  <summary><code>@Then the user with the email :mail should exist</code></summary>
-
-<br/>
-Assert that a user with an email address exists
-<br/><br/>
-
-```gherkin
-Then the user with the email "alice@example.com" should exist
-
-```
-
-</details>
-
-<details>
-  <summary><code>@Then the user with the email :mail should not exist</code></summary>
-
-<br/>
-Assert that a user with an email address does not exist
-<br/><br/>
-
-```gherkin
-Then the user with the email "alice@example.com" should not exist
 
 ```
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -4016,9 +4016,10 @@ When I run search indexing for 1 item
 >  `\Drupal::state()`. Touched keys are snapshotted on first access and
 >  reverted after the scenario finishes.
 >  <br/><br/>
->  Skip processing with tags: `@behat-steps-skip:stateBeforeScenario` and
->  `@behat-steps-skip:stateAfterScenario`, or skip both at once with the
->  convenience tag `@behat-steps-skip:StateTrait`.
+>  Skip the scenario revert with `@behat-steps-skip:stateAfterScenario`, or
+>  with the convenience tag `@behat-steps-skip:StateTrait`. The snapshot
+>  registry is cleared unconditionally before and after the scenario to
+>  prevent state leaking into subsequent scenarios.
 
 
 <details>

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -40,13 +40,6 @@ trait StateTrait {
    */
   #[BeforeScenario]
   public function stateBeforeScenario(BeforeScenarioScope $scope): void {
-    if (
-      $scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)
-      || $scope->getScenario()->hasTag('behat-steps-skip:StateTrait')
-    ) {
-      return;
-    }
-
     $this->stateOriginalValues = [];
   }
 
@@ -59,6 +52,7 @@ trait StateTrait {
       $scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)
       || $scope->getScenario()->hasTag('behat-steps-skip:StateTrait')
     ) {
+      $this->stateOriginalValues = [];
       return;
     }
 

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -19,9 +19,10 @@ use Behat\Step\Then;
  * `\Drupal::state()`. Touched keys are snapshotted on first access and
  * reverted after the scenario finishes.
  *
- * Skip processing with tags: `@behat-steps-skip:stateBeforeScenario` and
- * `@behat-steps-skip:stateAfterScenario`, or skip both at once with the
- * convenience tag `@behat-steps-skip:StateTrait`.
+ * Skip the scenario revert with `@behat-steps-skip:stateAfterScenario`, or
+ * with the convenience tag `@behat-steps-skip:StateTrait`. The snapshot
+ * registry is cleared unconditionally before and after the scenario to
+ * prevent state leaking into subsequent scenarios.
  */
 trait StateTrait {
 

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Drupal;
+
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Hook\AfterScenario;
+use Behat\Hook\BeforeScenario;
+use Behat\Step\Given;
+use Behat\Step\Then;
+
+/**
+ * Manage and assert Drupal State API values with automatic revert.
+ *
+ * Provides set, delete, and assertion steps for keys stored through
+ * `\Drupal::state()`. Touched keys are snapshotted on first access and
+ * reverted after the scenario finishes.
+ *
+ * Skip processing with tags: `@behat-steps-skip:stateBeforeScenario` and
+ * `@behat-steps-skip:stateAfterScenario`, or skip both at once with the
+ * convenience tag `@behat-steps-skip:StateTrait`.
+ */
+trait StateTrait {
+
+  /**
+   * Original state values captured before the scenario touched them.
+   *
+   * Keys absent from Drupal state are stored with a sentinel marker so they
+   * can be deleted on revert rather than reset to NULL.
+   *
+   * @var array<string, array{exists: bool, value: mixed}>
+   */
+  protected array $stateOriginalValues = [];
+
+  /**
+   * Reset the snapshot registry before each scenario.
+   */
+  #[BeforeScenario]
+  public function stateBeforeScenario(BeforeScenarioScope $scope): void {
+    if (
+      $scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)
+      || $scope->getScenario()->hasTag('behat-steps-skip:StateTrait')
+    ) {
+      return;
+    }
+
+    $this->stateOriginalValues = [];
+  }
+
+  /**
+   * Revert every touched state key after the scenario finishes.
+   */
+  #[AfterScenario]
+  public function stateAfterScenario(AfterScenarioScope $scope): void {
+    if (
+      $scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)
+      || $scope->getScenario()->hasTag('behat-steps-skip:StateTrait')
+    ) {
+      return;
+    }
+
+    $state = \Drupal::state();
+    foreach ($this->stateOriginalValues as $name => $snapshot) {
+      if ($snapshot['exists']) {
+        $state->set($name, $snapshot['value']);
+      }
+      else {
+        $state->delete($name);
+      }
+    }
+
+    $this->stateOriginalValues = [];
+  }
+
+  /**
+   * Set a Drupal state value.
+   *
+   * @code
+   * Given the state "my_module.launched" has the value "1"
+   * @endcode
+   */
+  #[Given('the state :name has the value :value')]
+  public function stateSet(string $name, string $value): void {
+    $this->stateStoreOriginalValue($name);
+    \Drupal::state()->set($name, $this->stateNormaliseValue($value));
+  }
+
+  /**
+   * Delete a Drupal state value.
+   *
+   * @code
+   * Given the state "my_module.launched" does not exist
+   * @endcode
+   */
+  #[Given('the state :name does not exist')]
+  public function stateDelete(string $name): void {
+    $this->stateStoreOriginalValue($name);
+    \Drupal::state()->delete($name);
+  }
+
+  /**
+   * Set multiple Drupal state values from a table.
+   *
+   * @code
+   * Given the following state values:
+   *   | name                   | value |
+   *   | my_module.launched     | 1     |
+   *   | my_module.feature_flag | 0     |
+   * @endcode
+   */
+  #[Given('the following state values:')]
+  public function stateSetMultiple(TableNode $table): void {
+    $state = \Drupal::state();
+    foreach ($table->getHash() as $row) {
+      if (!isset($row['name']) || !array_key_exists('value', $row)) {
+        throw new \RuntimeException('The state values table must contain "name" and "value" columns.');
+      }
+      $name = (string) $row['name'];
+      $this->stateStoreOriginalValue($name);
+      $state->set($name, $this->stateNormaliseValue((string) $row['value']));
+    }
+  }
+
+  /**
+   * Assert that a Drupal state value equals an expected value.
+   *
+   * @code
+   * Then the state "my_module.launched" should have the value "1"
+   * @endcode
+   */
+  #[Then('the state :name should have the value :value')]
+  public function stateAssertHasValue(string $name, string $value): void {
+    $actual = \Drupal::state()->get($name);
+    if ($actual === NULL) {
+      throw new \Exception(sprintf('The state "%s" does not exist, but it should have the value "%s".', $name, $value));
+    }
+
+    $expected = $this->stateNormaliseValue($value);
+    $actual_stringified = $this->stateStringifyValue($actual);
+    $expected_stringified = $this->stateStringifyValue($expected);
+    if ($actual_stringified !== $expected_stringified) {
+      throw new \Exception(sprintf('The state "%s" has the value "%s", but it should have the value "%s".', $name, $actual_stringified, $expected_stringified));
+    }
+  }
+
+  /**
+   * Assert that a Drupal state key does not exist.
+   *
+   * @code
+   * Then the state "my_module.launched" should not exist
+   * @endcode
+   */
+  #[Then('the state :name should not exist')]
+  public function stateAssertNotExists(string $name): void {
+    $actual = \Drupal::state()->get($name);
+    if ($actual !== NULL) {
+      throw new \Exception(sprintf('The state "%s" exists with the value "%s", but it should not exist.', $name, $this->stateStringifyValue($actual)));
+    }
+  }
+
+  /**
+   * Store the original state value for a key on first access.
+   *
+   * @param string $name
+   *   The state key name.
+   */
+  protected function stateStoreOriginalValue(string $name): void {
+    if (array_key_exists($name, $this->stateOriginalValues)) {
+      return;
+    }
+
+    $sentinel = new \stdClass();
+    $current = \Drupal::state()->get($name, $sentinel);
+    $this->stateOriginalValues[$name] = $current === $sentinel
+      ? ['exists' => FALSE, 'value' => NULL]
+      : ['exists' => TRUE, 'value' => $current];
+  }
+
+  /**
+   * Normalise a string value from a step into the shape actually stored.
+   *
+   * @param string $value
+   *   The raw value captured from the step or table cell.
+   *
+   * @return mixed
+   *   The normalised value: decoded JSON for array/object input, integer or
+   *   float for numeric input, boolean for "true"/"false", NULL for "null",
+   *   or the original string otherwise.
+   */
+  protected function stateNormaliseValue(string $value): mixed {
+    $trimmed = trim($value);
+
+    if ($trimmed === '') {
+      return $value;
+    }
+
+    $lower = strtolower($trimmed);
+    if ($lower === 'true') {
+      return TRUE;
+    }
+    if ($lower === 'false') {
+      return FALSE;
+    }
+    if ($lower === 'null') {
+      return NULL;
+    }
+
+    if ($trimmed[0] === '{' || $trimmed[0] === '[') {
+      $decoded = json_decode($trimmed, TRUE);
+      if (json_last_error() === JSON_ERROR_NONE) {
+        return $decoded;
+      }
+    }
+
+    if (is_numeric($trimmed)) {
+      return str_contains($trimmed, '.') ? (float) $trimmed : (int) $trimmed;
+    }
+
+    return $value;
+  }
+
+  /**
+   * Stringify a state value for comparison and error messages.
+   *
+   * @param mixed $value
+   *   The value to stringify.
+   *
+   * @return string
+   *   The stringified value.
+   */
+  protected function stateStringifyValue(mixed $value): string {
+    if ($value === NULL) {
+      return 'NULL';
+    }
+    if (is_bool($value)) {
+      return $value ? 'true' : 'false';
+    }
+    if (is_scalar($value)) {
+      return (string) $value;
+    }
+    return (string) json_encode($value);
+  }
+
+}

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -19,10 +19,10 @@ use Behat\Step\Then;
  * `\Drupal::state()`. Touched keys are snapshotted on first access and
  * reverted after the scenario finishes.
  *
- * Skip the scenario revert with `@behat-steps-skip:stateAfterScenario`, or
- * with the convenience tag `@behat-steps-skip:StateTrait`. The snapshot
- * registry is cleared unconditionally before and after the scenario to
- * prevent state leaking into subsequent scenarios.
+ * Skip the revert with `@behat-steps-skip:stateAfterScenario` or with the
+ * convenience tag `@behat-steps-skip:StateTrait`. The snapshot registry is
+ * cleared unconditionally before and after the scenario to prevent state
+ * leaking into subsequent scenarios.
  */
 trait StateTrait {
 

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -133,13 +133,13 @@ trait StateTrait {
    */
   #[Then('the state :name should have the value :value')]
   public function stateAssertHasValue(string $name, string $value): void {
-    $actual = \Drupal::state()->get($name);
-    if ($actual === NULL) {
+    $state_value = $this->stateReadValue($name);
+    if (!$state_value['exists']) {
       throw new \Exception(sprintf('The state "%s" does not exist, but it should have the value "%s".', $name, $value));
     }
 
     $expected = $this->stateNormaliseValue($value);
-    $actual_stringified = $this->stateStringifyValue($actual);
+    $actual_stringified = $this->stateStringifyValue($state_value['value']);
     $expected_stringified = $this->stateStringifyValue($expected);
     if ($actual_stringified !== $expected_stringified) {
       throw new \Exception(sprintf('The state "%s" has the value "%s", but it should have the value "%s".', $name, $actual_stringified, $expected_stringified));
@@ -155,10 +155,34 @@ trait StateTrait {
    */
   #[Then('the state :name should not exist')]
   public function stateAssertNotExists(string $name): void {
-    $actual = \Drupal::state()->get($name);
-    if ($actual !== NULL) {
-      throw new \Exception(sprintf('The state "%s" exists with the value "%s", but it should not exist.', $name, $this->stateStringifyValue($actual)));
+    $state_value = $this->stateReadValue($name);
+    if ($state_value['exists']) {
+      throw new \Exception(sprintf('The state "%s" exists with the value "%s", but it should not exist.', $name, $this->stateStringifyValue($state_value['value'])));
     }
+  }
+
+  /**
+   * Read a state value, distinguishing stored NULL from a missing key.
+   *
+   * Uses the underlying key/value store's `has()` so that a legitimately
+   * stored NULL is reported as existing. `\Drupal::state()->get()` cannot
+   * distinguish the two cases because it applies the `??` operator to
+   * the loaded value and returns the default for NULL.
+   *
+   * @param string $name
+   *   The state key name.
+   *
+   * @return array{exists: bool, value: mixed}
+   *   An associative array with `exists` (bool) and `value` (mixed).
+   */
+  protected function stateReadValue(string $name): array {
+    $key_value = \Drupal::keyValue('state');
+
+    if (!$key_value->has($name)) {
+      return ['exists' => FALSE, 'value' => NULL];
+    }
+
+    return ['exists' => TRUE, 'value' => \Drupal::state()->get($name)];
   }
 
   /**
@@ -172,11 +196,7 @@ trait StateTrait {
       return;
     }
 
-    $sentinel = new \stdClass();
-    $current = \Drupal::state()->get($name, $sentinel);
-    $this->stateOriginalValues[$name] = $current === $sentinel
-      ? ['exists' => FALSE, 'value' => NULL]
-      : ['exists' => TRUE, 'value' => $current];
+    $this->stateOriginalValues[$name] = $this->stateReadValue($name);
   }
 
   /**
@@ -209,7 +229,7 @@ trait StateTrait {
     }
 
     if ($trimmed[0] === '{' || $trimmed[0] === '[') {
-      $decoded = json_decode($trimmed, TRUE);
+      $decoded = json_decode($trimmed);
       if (json_last_error() === JSON_ERROR_NONE) {
         return $decoded;
       }

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -118,9 +118,9 @@ trait StateTrait {
       if (!isset($row['name']) || !array_key_exists('value', $row)) {
         throw new \RuntimeException('The state values table must contain "name" and "value" columns.');
       }
-      $name = (string) $row['name'];
+      $name = $row['name'];
       $this->stateStoreOriginalValue($name);
-      $state->set($name, $this->stateNormaliseValue((string) $row['value']));
+      $state->set($name, $this->stateNormaliseValue($row['value']));
     }
   }
 

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -25,6 +25,7 @@ use DrevOps\BehatSteps\Drupal\OverrideTrait;
 use DrevOps\BehatSteps\Drupal\ParagraphsTrait;
 use DrevOps\BehatSteps\Drupal\QueueTrait;
 use DrevOps\BehatSteps\Drupal\SearchApiTrait;
+use DrevOps\BehatSteps\Drupal\StateTrait;
 use DrevOps\BehatSteps\Drupal\TaxonomyTrait;
 use DrevOps\BehatSteps\Drupal\TestmodeTrait;
 use DrevOps\BehatSteps\Drupal\TimeTrait;
@@ -86,6 +87,7 @@ class FeatureContext extends DrupalContext {
   use RestTrait;
   use ResponsiveTrait;
   use SearchApiTrait;
+  use StateTrait;
   use TableTrait;
   use TaxonomyTrait;
   use TestmodeTrait;

--- a/tests/behat/features/drupal_state.feature
+++ b/tests/behat/features/drupal_state.feature
@@ -1,0 +1,106 @@
+Feature: Check that StateTrait works
+  As Behat Steps library developer
+  I want to provide tools to manage the Drupal State API
+  So that users can set, delete, and assert state values during tests with automatic revert
+
+  @api
+  Scenario: Assert "Given the state :name has the value :value" sets a scalar state value
+    Given the state "behat_steps_test.flag" has the value "1"
+    Then the state "behat_steps_test.flag" should have the value "1"
+
+  @api
+  Scenario: Assert "Given the state :name has the value :value" sets a string state value
+    Given the state "behat_steps_test.label" has the value "hello world"
+    Then the state "behat_steps_test.label" should have the value "hello world"
+
+  @api
+  Scenario: Assert "Given the state :name has the value :value" sets a boolean state value
+    Given the state "behat_steps_test.enabled" has the value "true"
+    Then the state "behat_steps_test.enabled" should have the value "true"
+
+  @api
+  Scenario: Assert "Given the state :name has the value :value" sets a JSON array state value
+    Given the state "behat_steps_test.list" has the value "[1,2,3]"
+    Then the state "behat_steps_test.list" should have the value "[1,2,3]"
+
+  @api
+  Scenario: Assert "Given the state :name does not exist" deletes a state value
+    Given the state "behat_steps_test.flag" has the value "1"
+    When the state "behat_steps_test.flag" does not exist
+    Then the state "behat_steps_test.flag" should not exist
+
+  @api
+  Scenario: Assert "Given the following state values:" sets multiple state values
+    Given the following state values:
+      | name                         | value |
+      | behat_steps_test.launched    | 1     |
+      | behat_steps_test.feature     | 0     |
+      | behat_steps_test.name        | alpha |
+    Then the state "behat_steps_test.launched" should have the value "1"
+    And the state "behat_steps_test.feature" should have the value "0"
+    And the state "behat_steps_test.name" should have the value "alpha"
+
+  @api
+  Scenario: Assert "Then the state :name should not exist" passes for unset key
+    Then the state "behat_steps_test.missing" should not exist
+
+  # Setup scenario: store a known value so the next scenario can prove it got
+  # reverted automatically. The AfterScenario hook should snapshot NULL here
+  # and revert the key back to NULL after this scenario finishes.
+  @api @behat-steps-skip:stateAfterScenario
+  Scenario: Seed a state value without auto-revert
+    Given the state "behat_steps_test.persistent" has the value "seeded"
+    Then the state "behat_steps_test.persistent" should have the value "seeded"
+
+  @api
+  Scenario: Assert state values are reverted after scenario
+    Given the state "behat_steps_test.persistent" has the value "overridden"
+    Then the state "behat_steps_test.persistent" should have the value "overridden"
+
+  @api
+  Scenario: Verify previous scenario state change was reverted to seeded value
+    Then the state "behat_steps_test.persistent" should have the value "seeded"
+
+  @api @trait:Drupal\StateTrait
+  Scenario: Assert negative assertion for "Then the state :name should have the value :value" fails when key is missing
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      Then the state "behat_steps_test.missing" should have the value "1"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The state "behat_steps_test.missing" does not exist, but it should have the value "1".
+      """
+
+  @api @trait:Drupal\StateTrait
+  Scenario: Assert negative assertion for "Then the state :name should have the value :value" fails on value mismatch
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the state "behat_steps_test.flag" has the value "1"
+      Then the state "behat_steps_test.flag" should have the value "2"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The state "behat_steps_test.flag" has the value "1", but it should have the value "2".
+      """
+
+  @api @trait:Drupal\StateTrait
+  Scenario: Assert negative assertion for "Then the state :name should not exist" fails for existing key
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the state "behat_steps_test.flag" has the value "1"
+      Then the state "behat_steps_test.flag" should not exist
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The state "behat_steps_test.flag" exists with the value "1", but it should not exist.
+      """

--- a/tests/behat/features/drupal_state.feature
+++ b/tests/behat/features/drupal_state.feature
@@ -1,3 +1,4 @@
+@state
 Feature: Check that StateTrait works
   As Behat Steps library developer
   I want to provide tools to manage the Drupal State API
@@ -22,6 +23,11 @@ Feature: Check that StateTrait works
   Scenario: Assert "Given the state :name has the value :value" sets a JSON array state value
     Given the state "behat_steps_test.list" has the value "[1,2,3]"
     Then the state "behat_steps_test.list" should have the value "[1,2,3]"
+
+  @api
+  Scenario: Assert "Given the state :name has the value :value" sets a null state value
+    Given the state "behat_steps_test.nullable" has the value "null"
+    Then the state "behat_steps_test.nullable" should have the value "null"
 
   @api
   Scenario: Assert "Given the state :name does not exist" deletes a state value


### PR DESCRIPTION
## Summary

Adds a new `Drupal/StateTrait` that exposes set, delete, bulk set, and positive/negative assertion steps for values stored in the Drupal State API (`\Drupal::state()`).

Touched keys are snapshotted on first access via `@BeforeScenario` and reverted (or deleted, if the key did not previously exist) in `@AfterScenario`, so scenarios can flip feature flags, maintenance mode, last-cron timestamps, and similar runtime values without leaking state between tests.

Values captured from step arguments and table cells are normalised through `stateNormaliseValue()`: booleans, `null`, integers, floats, and JSON-encoded arrays/objects are decoded; plain strings are kept as-is. Consumers can override this helper to shape values for their own use cases.

Fixes #610.

## Acceptance criteria

- [x] New trait in `src/Drupal/StateTrait.php`.
- [x] Steps use `#[Given(...)]` / `#[Then(...)]` tuple annotations.
- [x] `@BeforeScenario` snapshot + `@AfterScenario` revert of touched keys.
- [x] `behat-steps-skip:StateTrait` tag disables the revert hook.
- [x] Feature tests in `tests/behat/features/drupal_state.feature`.
- [x] `@trait:StateTrait` negative tests for missing keys / wrong values.
- [x] `stateNormaliseValue()` protected helper for consumer overrides.
- [ ] `ahoy update-docs` run to regenerate `STEPS.md`.
- [ ] `ahoy lint` passes.
- [x] Add `use StateTrait;` to `FeatureContext.php`.

## Test plan

- [ ] `ahoy test-bdd tests/behat/features/drupal_state.feature`
- [ ] `ahoy lint`
- [ ] `ahoy update-docs` and verify `STEPS.md` diff looks right


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds a new Drupal StateTrait to manage Drupal State API values during Behat scenarios. It provides steps to set, delete, bulk-set, and assert state keys, snapshots touched keys on first use, and reverts or deletes them after each scenario (with tags to skip revert). Documentation and feature tests (including negative cases) are included.

## Changes

### New Trait: StateTrait (src/Drupal/StateTrait.php)
- Adds trait implementing:
  - #[BeforeScenario] stateBeforeScenario(): clears per-scenario snapshot registry.
  - #[AfterScenario] stateAfterScenario(): reverts touched keys (restores previous value or deletes) unless scenario is tagged to skip revert; snapshot registry always cleared.
    - Skip tags supported: behat-steps-skip:stateAfterScenario and behat-steps-skip:StateTrait (per PR docs).
  - #[Given('the state :name has the value :value')] → stateSet(string $name, string $value)
  - #[Given('the state :name does not exist')] → stateDelete(string $name)
  - #[Given('the following state values:')] → stateSetMultiple(TableNode $table) (requires "name" and "value" columns)
  - #[Then('the state :name should have the value :value')] → stateAssertHasValue(string $name, string $value)
  - #[Then('the state :name should not exist')] → stateAssertNotExists(string $name)
- Adds protected registry property: protected array $stateOriginalValues = []
- Distinguishes stored NULL vs missing key using \Drupal::keyValue('state')->has($name).
- Implements stateNormaliseValue(): trims and converts "true"/"false"/"null" to booleans/null, decodes JSON arrays/objects (when input starts with { or [), converts numeric strings to int/float, otherwise returns the original string.
- Implements stateStringifyValue() and stable comparison logic for clear error messages.
- Snapshot-on-first-touch behaviour via an internal stateStoreOriginalValue() helper.

### Tests
- Added feature file tests/tests/behat/features/drupal_state.feature covering:
  - Positive cases: scalar, string, boolean, JSON array/object, null values; multi-value table; revert/persistence scenarios with skip tags.
  - Negative cases: expecting missing key to have value, expecting incorrect value, expecting key not to exist when it does (asserts specific failure messages).

### Documentation
- README.md: Added index entry for Drupal\StateTrait.
- STEPS.md: Added comprehensive Drupal\StateTrait section (source link, examples, skip-tag notes, step signatures). STEPS.md regenerated in commits.

### Integration
- tests/behat/bootstrap/FeatureContext.php: added use DrevOps\BehatSteps\Drupal\StateTrait; and included trait in FeatureContext.

## Compliance with CONTRIBUTING.md
I reviewed the repository's step-definition rules in CONTRIBUTING.md. The trait follows the guidelines:
- Tuple-based annotations are used (no regex).
- Step phrases use descriptive placeholders and start with the entity ("the state ...").
- Given steps are used for setup (no "should"), Then steps use "should" and corresponding methods use the Assert/NotExists naming convention.
- Method names begin with the trait prefix (state*).
No violations were found. (Critical: none)

## Remaining tasks / Checklist items
- Run ahoy update-docs to regenerate STEPS.md via project tooling (mentioned in PR).
- Ensure ahoy lint (and ahoy lint-docs) passes.

## Public API / Exported Entities
- Added new file and trait; no removals or other public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->