### PR TITLE
[#615] Extended 'ContentTrait' with authored-by-current-user content creation

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -2760,6 +2760,24 @@ Given the following page content with fields:
 </details>
 
 <details>
+  <summary><code>@Given the following :content_type content with the current user as the author:</code></summary>
+
+<br/>
+Create content authored by the currently logged-in user
+<br/><br/>
+
+```gherkin
+Given I am logged in as a user with the "editor" role
+And the following "article" content with the current user as the author:
+  | title            | body             |
+  | My first article | Hello world.     |
+  | My second        | Another article. |
+
+```
+
+</details>
+
+<details>
   <summary><code>@When I visit the :content_type content page with the title :title</code></summary>
 
 <br/>

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -88,6 +88,70 @@ trait ContentTrait {
   }
 
   /**
+   * Create content authored by the currently logged-in user.
+   *
+   * Injects the current user's 'uid' and 'author' into every row before
+   * delegating to the shared node creation logic. Requires a prior
+   * "I am logged in..." step.
+   *
+   * @param string $content_type
+   *   The content type machine name.
+   * @param \Behat\Gherkin\Node\TableNode $table
+   *   Horizontal table of field values (first row is headers).
+   *
+   * @code
+   *   Given I am logged in as a user with the "editor" role
+   *   And the following "article" content with the current user as the author:
+   *     | title            | body             |
+   *     | My first article | Hello world.     |
+   *     | My second        | Another article. |
+   * @endcode
+   */
+  #[Given('the following :content_type content with the current user as the author:')]
+  public function contentCreateWithCurrentUserAsAuthor(string $content_type, TableNode $table): void {
+    $current_user = $this->getUserManager()->getCurrentUser();
+
+    if (!$current_user instanceof \stdClass) {
+      throw new \RuntimeException('No user is currently logged in. Use an "I am logged in..." step before this step.');
+    }
+
+    $rows = $table->getRows();
+    if (empty($rows)) {
+      throw new \RuntimeException('Content table must contain at least a header row.');
+    }
+
+    $headers = array_shift($rows);
+
+    // Remove any pre-existing uid/author columns to ensure the current user
+    // owns the created content.
+    $filtered_headers = [];
+    $kept_indexes = [];
+    foreach ($headers as $index => $header) {
+      if ($header === 'uid' || $header === 'author') {
+        continue;
+      }
+      $filtered_headers[] = $header;
+      $kept_indexes[] = $index;
+    }
+
+    $filtered_headers[] = 'uid';
+    $filtered_headers[] = 'author';
+
+    $new_rows = [$filtered_headers];
+    foreach ($rows as $row) {
+      $new_row = [];
+      foreach ($kept_indexes as $index) {
+        $new_row[] = $row[$index] ?? '';
+      }
+      $new_row[] = (string) $current_user->uid;
+      $new_row[] = (string) $current_user->name;
+      $new_rows[] = $new_row;
+    }
+
+    $this->createNodes($content_type, new TableNode($new_rows));
+  }
+
+  /**
    * Visit a page of a type with a specified title.
    *
    * @code

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -90,9 +90,8 @@ trait ContentTrait {
   /**
    * Create content authored by the currently logged-in user.
    *
-   * Injects the current user's 'uid' and 'author' into every row before
-   * delegating to the shared node creation logic. Requires a prior
-   * "I am logged in..." step.
+   * Injects the current user's UID into every row before delegating to the
+   * shared node creation logic. Requires a prior "I am logged in..." step.
    *
    * @param string $content_type
    *   The content type machine name.
@@ -122,12 +121,12 @@ trait ContentTrait {
 
     $headers = array_shift($rows);
 
-    // Remove any pre-existing uid/author columns to ensure the current user
-    // owns the created content.
+    // Remove any pre-existing uid column so the current user always owns
+    // the created content.
     $filtered_headers = [];
     $kept_indexes = [];
     foreach ($headers as $index => $header) {
-      if ($header === 'uid' || $header === 'author') {
+      if ($header === 'uid') {
         continue;
       }
       $filtered_headers[] = $header;
@@ -135,7 +134,6 @@ trait ContentTrait {
     }
 
     $filtered_headers[] = 'uid';
-    $filtered_headers[] = 'author';
 
     $new_rows = [$filtered_headers];
     foreach ($rows as $row) {
@@ -144,7 +142,6 @@ trait ContentTrait {
         $new_row[] = $row[$index] ?? '';
       }
       $new_row[] = (string) $current_user->uid;
-      $new_row[] = (string) $current_user->name;
       $new_rows[] = $new_row;
     }
 

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -299,6 +299,33 @@ Feature: Check that ContentTrait works
     And I should see "[TEST] V-Page 3"
 
   @api
+  Scenario: Assert "Given the following :content_type content with the current user as the author:" creates content owned by the current user
+    Given I am logged in as a user with the "administrator" role
+    And the following "article" content with the current user as the author:
+      | title                    | body                   |
+      | [TEST] Authored article  | Authored body content  |
+      | [TEST] Authored article2 | Authored body content2 |
+    When I visit the "article" content edit page with the title "[TEST] Authored article"
+    Then I should see "[TEST] Authored article"
+    When I visit the "article" content edit page with the title "[TEST] Authored article2"
+    Then I should see "[TEST] Authored article2"
+
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "Given the following :content_type content with the current user as the author:" fails when no user is logged in
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following "article" content with the current user as the author:
+        | title                    |
+        | [TEST] Authored article  |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      No user is currently logged in. Use an "I am logged in..." step before this step.
+      """
+
+  @api
   Scenario: Assert "Then :content_type content with the title :title should not exist" works as expected
     Given I am logged in as a user with the "administrator" role
     Then "page" content with the title "[TEST] Non-existing page" should not exist


### PR DESCRIPTION
## Summary

Added a new `ContentTrait::contentCreateWithCurrentUserAsAuthor` step so scenarios can create Drupal nodes owned by the currently logged-in user without hardcoding usernames. The step uses a `#[Given(...)]` tuple attribute matching `the following :content_type content with the current user as the author:`, injects the current user's `uid` and `author` into every row, and then delegates to the shared `createNodes()` helper that `contentCreateWithFields` uses. It throws a `\RuntimeException` with a clear message when no user is logged in.

## Changes

- Added `contentCreateWithCurrentUserAsAuthor` in `src/Drupal/ContentTrait.php`.
- Added a positive `@api` scenario in `tests/behat/features/drupal_content.feature` that logs in as an administrator role user and creates two articles via the new step.
- Added a negative `@trait:Drupal\ContentTrait` scenario that asserts the step throws when no user is logged in.

Fixes #615

## Acceptance checklist

- [x] One new step in `src/Drupal/ContentTrait.php`.
- [x] Step uses `#[Given(...)]` tuple annotation.
- [x] Throws `\RuntimeException` with a clear message when no user is logged in.
- [x] Feature tests in `tests/behat/features/drupal_content.feature`.
- [x] `@trait:Drupal\ContentTrait` negative test for the no-user scenario.
- [ ] `ahoy update-docs` run.
- [ ] `ahoy lint` passes.
