### PR TITLE
[#611] Added 'CacheTrait' with targeted Drupal cache invalidation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ from the community.
 | --- | --- |
 | [Drupal\BigPipeTrait](STEPS.md#drupalbigpipetrait) | Bypass Drupal BigPipe when rendering pages. |
 | [Drupal\BlockTrait](STEPS.md#drupalblocktrait) | Manage Drupal blocks. |
+| [Drupal\CacheTrait](STEPS.md#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
 | [Drupal\ContentBlockTrait](STEPS.md#drupalcontentblocktrait) | Manage Drupal content blocks. |
 | [Drupal\ContentTrait](STEPS.md#drupalcontenttrait) | Manage Drupal content with workflow and moderation support. |
 | [Drupal\DraggableviewsTrait](STEPS.md#drupaldraggableviewstrait) | Order items in the Drupal Draggable Views. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -29,6 +29,7 @@
 | --- | --- |
 | [Drupal\BigPipeTrait](#drupalbigpipetrait) | Bypass Drupal BigPipe when rendering pages. |
 | [Drupal\BlockTrait](#drupalblocktrait) | Manage Drupal blocks. |
+| [Drupal\CacheTrait](#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
 | [Drupal\ContentBlockTrait](#drupalcontentblocktrait) | Manage Drupal content blocks. |
 | [Drupal\ContentTrait](#drupalcontenttrait) | Manage Drupal content with workflow and moderation support. |
 | [Drupal\DraggableviewsTrait](#drupaldraggableviewstrait) | Order items in the Drupal Draggable Views. |
@@ -2606,6 +2607,59 @@ Assert that a block with the specified label does not exist in a region
 
 ```gherkin
 Then the block "My block" should not exist in the "content" region
+
+```
+
+</details>
+
+## Drupal\CacheTrait
+
+[Source](src/Drupal/CacheTrait.php), [Example](tests/behat/features/drupal_cache.feature)
+
+>  Invalidate specific Drupal caches from within a scenario.
+>  <br/><br/>
+>  Provides targeted cache-clearing steps for single paths, path patterns, and
+>  the render cache. A full cache clear is intentionally out of scope because
+>  `DrupalContext::@Given the cache has been cleared` already covers it.
+
+
+<details>
+  <summary><code>@Given the page cache for the path :path has been cleared</code></summary>
+
+<br/>
+Clear the page cache for a single path
+<br/><br/>
+
+```gherkin
+Given the page cache for the path "/about" has been cleared
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the page cache for the paths matching :path_pattern has been cleared</code></summary>
+
+<br/>
+Clear the page cache for all paths matching a glob-style pattern
+<br/><br/>
+
+```gherkin
+Given the page cache for the paths matching "/news" has been cleared
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the render cache has been cleared</code></summary>
+
+<br/>
+Clear the render cache
+<br/><br/>
+
+```gherkin
+Given the render cache has been cleared
 
 ```
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -2645,7 +2645,7 @@ Clear the page cache for all paths matching a glob-style pattern
 <br/><br/>
 
 ```gherkin
-Given the page cache for the paths matching "/news" has been cleared
+Given the page cache for the paths matching "/news*" has been cleared
 
 ```
 

--- a/src/Drupal/CacheTrait.php
+++ b/src/Drupal/CacheTrait.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Drupal;
+
+use Behat\Step\Given;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Database\Database;
+
+/**
+ * Invalidate specific Drupal caches from within a scenario.
+ *
+ * Provides targeted cache-clearing steps for single paths, path patterns, and
+ * the render cache. A full cache clear is intentionally out of scope because
+ * `DrupalContext::@Given the cache has been cleared` already covers it.
+ */
+trait CacheTrait {
+
+  /**
+   * Clear the page cache for a single path.
+   *
+   * Invalidates the `url:<path>` and `http_response` cache tags, which causes
+   * the internal page cache to refresh the next time the path is requested.
+   *
+   * @code
+   * Given the page cache for the path "/about" has been cleared
+   * @endcode
+   */
+  #[Given('the page cache for the path :path has been cleared')]
+  public function cacheClearPagePath(string $path): void {
+    if ($path === '') {
+      throw new \InvalidArgumentException('The path must not be empty.');
+    }
+
+    if (!str_starts_with($path, '/')) {
+      throw new \InvalidArgumentException(sprintf('The path "%s" must start with a leading slash.', $path));
+    }
+
+    Cache::invalidateTags(['http_response', 'url:' . $path]);
+  }
+
+  /**
+   * Clear the page cache for all paths matching a glob-style pattern.
+   *
+   * The pattern uses `*` as a wildcard. All other SQL `LIKE` metacharacters
+   * (`%`, `_`, `\`) are escaped so they are treated literally.
+   *
+   * @code
+   * Given the page cache for the paths matching "/news/*" has been cleared
+   * @endcode
+   */
+  #[Given('the page cache for the paths matching :path_pattern has been cleared')]
+  public function cacheClearPagePathWildcard(string $path_pattern): void {
+    if ($path_pattern === '') {
+      throw new \InvalidArgumentException('The path pattern must not be empty.');
+    }
+
+    if (!str_starts_with($path_pattern, '/')) {
+      throw new \InvalidArgumentException(sprintf('The path pattern "%s" must start with a leading slash.', $path_pattern));
+    }
+
+    $bin = $this->cacheGetPageCacheBin();
+    $table = 'cache_' . $bin;
+
+    $database = Database::getConnection();
+    if (!$database->schema()->tableExists($table)) {
+      throw new \RuntimeException(sprintf('The page cache table "%s" does not exist. Ensure the "%s" cache bin is configured.', $table, $bin));
+    }
+
+    // Escape SQL LIKE metacharacters that we do not want to treat as
+    // wildcards, then convert the glob `*` to the SQL `%` wildcard.
+    $like = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $path_pattern);
+    $like = str_replace('*', '%', $like);
+
+    $database->delete($table)
+      ->condition('cid', '%' . $like . '%', 'LIKE')
+      ->execute();
+  }
+
+  /**
+   * Clear the render cache.
+   *
+   * @code
+   * Given the render cache has been cleared
+   * @endcode
+   */
+  #[Given('the render cache has been cleared')]
+  public function cacheClearRender(): void {
+    \Drupal::cache('render')->deleteAll();
+  }
+
+  /**
+   * Get the cache bin used for the page cache.
+   *
+   * Override in your `FeatureContext` if the site uses a custom internal page
+   * cache bin name.
+   */
+  protected function cacheGetPageCacheBin(): string {
+    return 'page';
+  }
+
+}

--- a/src/Drupal/CacheTrait.php
+++ b/src/Drupal/CacheTrait.php
@@ -47,7 +47,7 @@ trait CacheTrait {
    * (`%`, `_`, `\`) are escaped so they are treated literally.
    *
    * @code
-   * Given the page cache for the paths matching "/news/*" has been cleared
+   * Given the page cache for the paths matching "/news*" has been cleared
    * @endcode
    */
   #[Given('the page cache for the paths matching :path_pattern has been cleared')]

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -11,6 +11,7 @@ use DrevOps\BehatSteps\CookieTrait;
 use DrevOps\BehatSteps\DateTrait;
 use DrevOps\BehatSteps\Drupal\BigPipeTrait;
 use DrevOps\BehatSteps\Drupal\BlockTrait;
+use DrevOps\BehatSteps\Drupal\CacheTrait;
 use DrevOps\BehatSteps\Drupal\ContentBlockTrait;
 use DrevOps\BehatSteps\Drupal\ContentTrait;
 use DrevOps\BehatSteps\Drupal\DraggableviewsTrait;
@@ -56,6 +57,7 @@ class FeatureContext extends DrupalContext {
 
   use BigPipeTrait;
   use BlockTrait;
+  use CacheTrait;
   use ContentBlockTrait;
   use ContentTrait;
   use CookieTrait;

--- a/tests/behat/features/drupal_cache.feature
+++ b/tests/behat/features/drupal_cache.feature
@@ -30,7 +30,7 @@ Feature: Check that CacheTrait works
       And the page cache for the path "" has been cleared
       """
     When I run "behat --no-colors"
-    Then it should fail with an exception:
+    Then it should fail with a "InvalidArgumentException" exception:
       """
       The path must not be empty.
       """
@@ -44,7 +44,7 @@ Feature: Check that CacheTrait works
       And the page cache for the path "about" has been cleared
       """
     When I run "behat --no-colors"
-    Then it should fail with an exception:
+    Then it should fail with a "InvalidArgumentException" exception:
       """
       The path "about" must start with a leading slash.
       """
@@ -58,7 +58,7 @@ Feature: Check that CacheTrait works
       And the page cache for the paths matching "" has been cleared
       """
     When I run "behat --no-colors"
-    Then it should fail with an exception:
+    Then it should fail with a "InvalidArgumentException" exception:
       """
       The path pattern must not be empty.
       """
@@ -72,7 +72,7 @@ Feature: Check that CacheTrait works
       And the page cache for the paths matching "news/*" has been cleared
       """
     When I run "behat --no-colors"
-    Then it should fail with an exception:
+    Then it should fail with a "InvalidArgumentException" exception:
       """
       The path pattern "news/*" must start with a leading slash.
       """

--- a/tests/behat/features/drupal_cache.feature
+++ b/tests/behat/features/drupal_cache.feature
@@ -1,0 +1,78 @@
+Feature: Check that CacheTrait works
+  As Behat Steps library developer
+  I want to provide tools for targeted Drupal cache invalidation
+  So that users can clear specific caches in their tests without a full rebuild
+
+  @api
+  Scenario: Assert "Given the page cache for the path :path has been cleared" clears a single path
+    Given I am logged in as a user with the "administrator" role
+    When the page cache for the path "/user" has been cleared
+    Then I go to "/user"
+
+  @api
+  Scenario: Assert "Given the page cache for the paths matching :path_pattern has been cleared" clears matching paths
+    Given I am logged in as a user with the "administrator" role
+    When the page cache for the paths matching "/user*" has been cleared
+    Then I go to "/user"
+
+  @api
+  Scenario: Assert "Given the render cache has been cleared" clears the render cache
+    Given I am logged in as a user with the "administrator" role
+    When the render cache has been cleared
+    Then I go to "/user"
+
+  @api @trait:Drupal\CacheTrait
+  Scenario: Assert clearing the page cache with an empty path fails
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the page cache for the path "" has been cleared
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      The path must not be empty.
+      """
+
+  @api @trait:Drupal\CacheTrait
+  Scenario: Assert clearing the page cache with a path missing a leading slash fails
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the page cache for the path "about" has been cleared
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      The path "about" must start with a leading slash.
+      """
+
+  @api @trait:Drupal\CacheTrait
+  Scenario: Assert clearing the page cache with an empty pattern fails
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the page cache for the paths matching "" has been cleared
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      The path pattern must not be empty.
+      """
+
+  @api @trait:Drupal\CacheTrait
+  Scenario: Assert clearing the page cache with a pattern missing a leading slash fails
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the page cache for the paths matching "news/*" has been cleared
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      The path pattern "news/*" must start with a leading slash.
+      """

--- a/tests/behat/features/drupal_cache.feature
+++ b/tests/behat/features/drupal_cache.feature
@@ -6,20 +6,23 @@ Feature: Check that CacheTrait works
   @api
   Scenario: Assert "Given the page cache for the path :path has been cleared" clears a single path
     Given I am logged in as a user with the "administrator" role
-    When the page cache for the path "/user" has been cleared
-    Then I go to "/user"
+    And the page cache for the path "/user" has been cleared
+    When I go to "/user"
+    Then I should see "Member for"
 
   @api
   Scenario: Assert "Given the page cache for the paths matching :path_pattern has been cleared" clears matching paths
     Given I am logged in as a user with the "administrator" role
-    When the page cache for the paths matching "/user*" has been cleared
-    Then I go to "/user"
+    And the page cache for the paths matching "/user*" has been cleared
+    When I go to "/user"
+    Then I should see "Member for"
 
   @api
   Scenario: Assert "Given the render cache has been cleared" clears the render cache
     Given I am logged in as a user with the "administrator" role
-    When the render cache has been cleared
-    Then I go to "/user"
+    And the render cache has been cleared
+    When I go to "/user"
+    Then I should see "Member for"
 
   @api @trait:Drupal\CacheTrait
   Scenario: Assert clearing the page cache with an empty path fails


### PR DESCRIPTION
## Summary

Adds a new `Drupal\CacheTrait` with three targeted cache-clearing `Given` steps for scenarios that need precise invalidation without a full site-wide rebuild:

- `Given the page cache for the path :path has been cleared` — invalidates the `url:<path>` and `http_response` cache tags for a single URL.
- `Given the page cache for the paths matching :path_pattern has been cleared` — deletes matching rows from the `cache_page` bin, converting glob `*` to SQL `%` and escaping the other `LIKE` metacharacters (`\`, `%`, `_`).
- `Given the render cache has been cleared` — calls `\Drupal::cache('render')->deleteAll()`.

The trait exposes a `cacheGetPageCacheBin()` protected helper so sites with a custom internal page cache bin can override the default `page` bin name. A blanket cache clear is deliberately out of scope — `DrupalContext::@Given the cache has been cleared` already covers it.

Fixes #611

## Acceptance checklist

- [x] New trait in `src/Drupal/CacheTrait.php`.
- [x] Steps use `#[Given(...)]` tuple annotations.
- [x] Wildcard pattern conversion safely escapes SQL `LIKE` metacharacters other than the wildcard itself.
- [x] Feature tests in `tests/behat/features/drupal_cache.feature`.
- [x] `@trait:Drupal\CacheTrait` negative tests for invalid paths.
- [x] `cacheGetPageCacheBin()` protected helper.
- [x] `use CacheTrait;` added to `tests/behat/bootstrap/FeatureContext.php`.
- [ ] `ahoy update-docs` run.
- [ ] `ahoy lint` passes.

## Test plan

- [ ] Run `ahoy test-bdd tests/behat/features/drupal_cache.feature` and verify all positive and `@trait` negative scenarios pass.
- [ ] Run `ahoy lint` to confirm PHPStan, Rector, PHPCS, and Gherkinlint are clean.
- [ ] Run `ahoy update-docs` and confirm `STEPS.md` includes the three new steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces a new `Drupal\CacheTrait` providing three cache invalidation steps for Behat scenarios: clearing page cache for a single path, clearing page cache for paths matching a glob-style pattern, and clearing the render cache.

## Changes

- **src/Drupal/CacheTrait.php**: New trait with three public step methods (`cacheClearPagePath()`, `cacheClearPagePathWildcard()`, `cacheClearRender()`) and a protected override hook (`cacheGetPageCacheBin()`). Includes input validation, SQL escaping for wildcard patterns, and direct database operations for the wildcard matcher.
- **tests/behat/bootstrap/FeatureContext.php**: Added trait usage `use DrevOps\BehatSteps\Drupal\CacheTrait;`
- **tests/behat/features/drupal_cache.feature**: New feature file with 7 scenarios covering success cases and negative test cases for invalid inputs (empty paths, missing leading slashes).
- **README.md**: Added entry to the Drupal steps index linking to `Drupal\CacheTrait`.
- **STEPS.md**: Added documentation section with all three step definitions and usage examples.

## Critical Issues

**Step Definition Type Violation**: The three cache-clearing steps are incorrectly defined as `@Given` steps but are used as `@When` steps in the feature file. Per CONTRIBUTING.md:
- `Given` defines test prerequisites and should use words like "exists" or "have"
- `When` describes actions with action verbs
- Steps describing actions (like "has been cleared") are actions, not prerequisites, and must be `When` steps
- The standard pattern for action steps is `When I <verb>`

The steps are currently defined with `#[Given(...)]` annotations but used as:
- `When the page cache for the path "/user" has been cleared` (line 9 of feature file)
- `When the page cache for the paths matching "/user*" has been cleared` (line 15)
- `When the render cache has been cleared` (line 21)

These must be corrected to use `#[When(...)]` annotations with the proper "I" format (e.g., `When I clear the page cache for the path :path`) to comply with the project's step definition standards.

## Other Observations

- Input validation is thorough (empty path checks, leading slash validation)
- SQL LIKE metacharacter escaping logic is correct
- Negative test coverage for invalid inputs is comprehensive
- Documentation has been properly generated and added

<!-- end of auto-generated comment: release notes by coderabbit.ai -->