### PR TITLE
[#571] Added ConfigOverrideTrait to disable Drupal config overrides via tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ from the community.
 | [Drupal\BigPipeTrait](STEPS.md#drupalbigpipetrait) | Bypass Drupal BigPipe when rendering pages. |
 | [Drupal\BlockTrait](STEPS.md#drupalblocktrait) | Manage Drupal blocks. |
 | [Drupal\CacheTrait](STEPS.md#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
+| [Drupal\ConfigOverrideTrait](STEPS.md#drupalconfigoverridetrait) | Disable Drupal config overrides from settings.php during a scenario. |
 | [Drupal\ContentBlockTrait](STEPS.md#drupalcontentblocktrait) | Manage Drupal content blocks. |
 | [Drupal\ContentTrait](STEPS.md#drupalcontenttrait) | Manage Drupal content with workflow and moderation support. |
 | [Drupal\DraggableviewsTrait](STEPS.md#drupaldraggableviewstrait) | Order items in the Drupal Draggable Views. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -30,6 +30,7 @@
 | [Drupal\BigPipeTrait](#drupalbigpipetrait) | Bypass Drupal BigPipe when rendering pages. |
 | [Drupal\BlockTrait](#drupalblocktrait) | Manage Drupal blocks. |
 | [Drupal\CacheTrait](#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
+| [Drupal\ConfigOverrideTrait](#drupalconfigoverridetrait) | Disable Drupal config overrides from settings.php during a scenario. |
 | [Drupal\ContentBlockTrait](#drupalcontentblocktrait) | Manage Drupal content blocks. |
 | [Drupal\ContentTrait](#drupalcontenttrait) | Manage Drupal content with workflow and moderation support. |
 | [Drupal\DraggableviewsTrait](#drupaldraggableviewstrait) | Order items in the Drupal Draggable Views. |
@@ -2710,6 +2711,60 @@ Given the render cache has been cleared
 ```
 
 </details>
+
+## Drupal\ConfigOverrideTrait
+
+[Source](src/Drupal/ConfigOverrideTrait.php), [Example](tests/behat/features/drupal_config_override.feature)
+
+>  Disable Drupal config overrides from settings.php during a scenario.
+>  <br/><br/>
+>  Config overrides set in `settings.php` replace the stored configuration at
+>  runtime. They cannot be disabled from the Behat process because tests run
+>  in a separate process from the system under test (SUT).
+>  <br/><br/>
+>  This trait signals the SUT - through a request header, a `$_SERVER` entry
+>  and an environment variable - that specific config objects should be read
+>  from their original (unoverridden) values. The SUT is responsible for
+>  reading that signal and calling `ImmutableConfig::getOriginal()` instead of
+>  `ImmutableConfig::get()` for the listed config names.
+>  <br/><br/>
+>  Activated by adding `@disable-config-override:CONFIG_NAME` tags to a
+>  feature or scenario. Multiple tags are combined into a comma-separated
+>  list. Runs on every step because some steps reset headers set earlier in
+>  the scenario.
+>  <br/><br/>
+>  Limitations:
+>  - Cannot be used with Selenium/JavaScript drivers (the underlying driver
+>  does not expose request headers).
+>  - The SUT must implement support for the `X-Config-No-Override` header,
+>  the `HTTP_X_CONFIG_NO_OVERRIDE` `$_SERVER` entry or the matching
+>  environment variable. An example implementation:
+>  ```
+>    public function getConfigValue(string $name, string $key): mixed {
+>      $config = $this->configFactory->get($name);
+>      $header = $_SERVER['HTTP_X_CONFIG_NO_OVERRIDE'] ?? getenv('HTTP_X_CONFIG_NO_OVERRIDE') ?: '';
+>      if (in_array($name, array_map('trim', explode(',', $header)), TRUE)) {
+>        return $config->getOriginal($key, FALSE);
+>      }
+>      return $config->get($key);
+>    }
+>  ```
+>  <br/><br/>
+>  Soft dependency: if the consuming context also uses `RestTrait`, the
+>  `$restHeaders` array is updated so standalone REST requests receive the
+>  same signal.
+>  <br/><br/>
+>  Example:
+>  ```
+>  @api @disable-config-override:system.site @disable-config-override:myconfig.settings
+>  Scenario: Render the page with original config values
+>    When I visit "/"
+>    Then the response should contain "Original site name"
+>  ```
+>  <br/><br/>
+>  Skip processing with tags: `@behat-steps-skip:configOverrideBeforeScenario`
+>  and `@behat-steps-skip:configOverrideBeforeStep`.
+
 
 ## Drupal\ContentBlockTrait
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -74,6 +74,19 @@ composer run-script post-install-cmd
 echo "  > Installing Drupal site."
 /usr/bin/env PHP_OPTIONS='-d sendmail_path=/bin/true' /app/build/vendor/bin/drush -r /app/build/web si standard -y --db-url=mysql://drupal:drupal@mariadb/drupal --account-name=admin --account-pass=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL --uri=http://nginx
 
+echo "  > Appending fixture \$config overrides to settings.php for ConfigOverrideTrait tests."
+chmod 666 /app/build/web/sites/default/settings.php
+cat >> /app/build/web/sites/default/settings.php <<'PHP'
+
+// Fixture config overrides used by ConfigOverrideTrait tests. These mimic
+// environment-specific overrides that a real site would set in settings.php,
+// so tests can verify that @disable-config-override:<name> tags let the SUT
+// read the stored (original) values via ImmutableConfig::getOriginal().
+$config['system.site']['name'] = 'Overridden Site Name';
+$config['system.site']['slogan'] = 'Overridden Slogan';
+PHP
+chmod 444 /app/build/web/sites/default/settings.php
+
 echo "  > Running post-install commands defined in the composer.json for each specific fixture."
 composer run-script drupal-post-install
 

--- a/src/Drupal/ConfigOverrideTrait.php
+++ b/src/Drupal/ConfigOverrideTrait.php
@@ -76,11 +76,16 @@ trait ConfigOverrideTrait {
 
   /**
    * Collect `@disable-config-override:*` tags for the current scenario.
+   *
+   * Always clears any propagated signal from a previous scenario first so
+   * state never bleeds between scenarios - even when this hook is bypassed
+   * via `@behat-steps-skip:configOverrideBeforeScenario`.
    */
   #[BeforeScenario]
   public function configOverrideBeforeScenario(BeforeScenarioScope $scope): void {
     $this->configOverrideDisabledNames = [];
     $this->configOverrideSkipBeforeStep = FALSE;
+    $this->configOverrideClearSignal();
 
     if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
       return;
@@ -113,6 +118,9 @@ trait ConfigOverrideTrait {
   #[BeforeStep]
   public function configOverrideBeforeStep(BeforeStepScope $scope): void {
     if ($this->configOverrideSkipBeforeStep || $this->configOverrideDisabledNames === []) {
+      // Nothing to propagate - make sure the driver-level header is also
+      // cleared so a previously-set value does not survive into this step.
+      $this->configOverrideClearDriverHeader();
       return;
     }
 
@@ -137,6 +145,40 @@ trait ConfigOverrideTrait {
 
     // For SUTs accessed via Drush subprocesses.
     putenv('HTTP_X_CONFIG_NO_OVERRIDE=' . $value);
+  }
+
+  /**
+   * Clear the process-level and REST-level X-Config-No-Override signal.
+   *
+   * Driver-level request headers are cleared separately in the BeforeStep
+   * hook because the session is not guaranteed to be started at the point
+   * BeforeScenario runs.
+   */
+  protected function configOverrideClearSignal(): void {
+    unset($_SERVER['HTTP_X_CONFIG_NO_OVERRIDE']);
+    putenv('HTTP_X_CONFIG_NO_OVERRIDE');
+
+    // @phpstan-ignore-next-line function.alreadyNarrowedType
+    if (property_exists($this, 'restHeaders')) {
+      unset($this->restHeaders['X-Config-No-Override']);
+    }
+  }
+
+  /**
+   * Clear the driver-level X-Config-No-Override request header.
+   */
+  protected function configOverrideClearDriverHeader(): void {
+    try {
+      $driver = $this->getSession()->getDriver();
+    }
+    // @codeCoverageIgnoreStart
+    catch (\Exception) {
+      return;
+    }
+    // @codeCoverageIgnoreEnd
+    if (!$driver instanceof Selenium2Driver) {
+      $driver->setRequestHeader('X-Config-No-Override', '');
+    }
   }
 
 }

--- a/src/Drupal/ConfigOverrideTrait.php
+++ b/src/Drupal/ConfigOverrideTrait.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Drupal;
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeStepScope;
+use Behat\Hook\BeforeScenario;
+use Behat\Hook\BeforeStep;
+use Behat\Mink\Driver\Selenium2Driver;
+
+/**
+ * Disable Drupal config overrides from settings.php during a scenario.
+ *
+ * Config overrides set in `settings.php` replace the stored configuration at
+ * runtime. They cannot be disabled from the Behat process because tests run
+ * in a separate process from the system under test (SUT).
+ *
+ * This trait signals the SUT - through a request header, a `$_SERVER` entry
+ * and an environment variable - that specific config objects should be read
+ * from their original (unoverridden) values. The SUT is responsible for
+ * reading that signal and calling `ImmutableConfig::getOriginal()` instead of
+ * `ImmutableConfig::get()` for the listed config names.
+ *
+ * Activated by adding `@disable-config-override:CONFIG_NAME` tags to a
+ * feature or scenario. Multiple tags are combined into a comma-separated
+ * list. Runs on every step because some steps reset headers set earlier in
+ * the scenario.
+ *
+ * Limitations:
+ * - Cannot be used with Selenium/JavaScript drivers (the underlying driver
+ *   does not expose request headers).
+ * - The SUT must implement support for the `X-Config-No-Override` header,
+ *   the `HTTP_X_CONFIG_NO_OVERRIDE` `$_SERVER` entry or the matching
+ *   environment variable. An example implementation:
+ *   @code
+ *   public function getConfigValue(string $name, string $key): mixed {
+ *     $config = $this->configFactory->get($name);
+ *     $header = $_SERVER['HTTP_X_CONFIG_NO_OVERRIDE'] ?? getenv('HTTP_X_CONFIG_NO_OVERRIDE') ?: '';
+ *     if (in_array($name, array_map('trim', explode(',', $header)), TRUE)) {
+ *       return $config->getOriginal($key, FALSE);
+ *     }
+ *     return $config->get($key);
+ *   }
+ *   @endcode
+ *
+ * Soft dependency: if the consuming context also uses `RestTrait`, the
+ * `$restHeaders` array is updated so standalone REST requests receive the
+ * same signal.
+ *
+ * Example:
+ * @code
+ * @api @disable-config-override:system.site @disable-config-override:myconfig.settings
+ * Scenario: Render the page with original config values
+ *   When I visit "/"
+ *   Then the response should contain "Original site name"
+ * @endcode
+ *
+ * Skip processing with tags: `@behat-steps-skip:configOverrideBeforeScenario`
+ * and `@behat-steps-skip:configOverrideBeforeStep`.
+ */
+trait ConfigOverrideTrait {
+
+  /**
+   * Config names parsed from `@disable-config-override:*` tags.
+   *
+   * @var array<int, string>
+   */
+  protected array $configOverrideDisabledNames = [];
+
+  /**
+   * Whether the `BeforeStep` hook should be skipped for this scenario.
+   */
+  protected bool $configOverrideSkipBeforeStep = FALSE;
+
+  /**
+   * Collect `@disable-config-override:*` tags for the current scenario.
+   */
+  #[BeforeScenario]
+  public function configOverrideBeforeScenario(BeforeScenarioScope $scope): void {
+    $this->configOverrideDisabledNames = [];
+    $this->configOverrideSkipBeforeStep = FALSE;
+
+    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+
+    // BeforeStep scope does not have access to scenario tags, so resolve the
+    // skip flag here.
+    if ($scope->getScenario()->hasTag('behat-steps-skip:configOverrideBeforeStep')) {
+      $this->configOverrideSkipBeforeStep = TRUE;
+    }
+
+    $tags = array_unique(array_merge($scope->getFeature()->getTags(), $scope->getScenario()->getTags()));
+    $prefix = 'disable-config-override:';
+    foreach ($tags as $tag) {
+      if (str_starts_with($tag, $prefix)) {
+        $name = substr($tag, strlen($prefix));
+        if ($name !== '' && !in_array($name, $this->configOverrideDisabledNames, TRUE)) {
+          $this->configOverrideDisabledNames[] = $name;
+        }
+      }
+    }
+  }
+
+  /**
+   * Apply the `X-Config-No-Override` signal before every step.
+   *
+   * This runs on every step because some steps reset headers set earlier in
+   * the scenario (for example, Drupal Extension login steps).
+   */
+  #[BeforeStep]
+  public function configOverrideBeforeStep(BeforeStepScope $scope): void {
+    if ($this->configOverrideSkipBeforeStep || $this->configOverrideDisabledNames === []) {
+      return;
+    }
+
+    $value = implode(',', $this->configOverrideDisabledNames);
+
+    // Set request header on the Mink driver for BrowserKit-based sessions.
+    // Selenium-based drivers cannot set request headers - skip silently.
+    $driver = $this->getSession()->getDriver();
+    if (!$driver instanceof Selenium2Driver) {
+      $driver->setRequestHeader('X-Config-No-Override', $value);
+    }
+
+    // Soft dependency on RestTrait: propagate to the standalone REST client
+    // when RestTrait is also used by the consuming context.
+    // @phpstan-ignore-next-line function.alreadyNarrowedType
+    if (property_exists($this, 'restHeaders')) {
+      $this->restHeaders['X-Config-No-Override'] = $value;
+    }
+
+    // For SUTs accessed via direct code invocation within the same process.
+    $_SERVER['HTTP_X_CONFIG_NO_OVERRIDE'] = $value;
+
+    // For SUTs accessed via Drush subprocesses.
+    putenv('HTTP_X_CONFIG_NO_OVERRIDE=' . $value);
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -12,6 +12,7 @@ use DrevOps\BehatSteps\DateTrait;
 use DrevOps\BehatSteps\Drupal\BigPipeTrait;
 use DrevOps\BehatSteps\Drupal\BlockTrait;
 use DrevOps\BehatSteps\Drupal\CacheTrait;
+use DrevOps\BehatSteps\Drupal\ConfigOverrideTrait;
 use DrevOps\BehatSteps\Drupal\ContentBlockTrait;
 use DrevOps\BehatSteps\Drupal\ContentTrait;
 use DrevOps\BehatSteps\Drupal\DraggableviewsTrait;
@@ -58,6 +59,7 @@ class FeatureContext extends DrupalContext {
   use BigPipeTrait;
   use BlockTrait;
   use CacheTrait;
+  use ConfigOverrideTrait;
   use ContentBlockTrait;
   use ContentTrait;
   use CookieTrait;

--- a/tests/behat/features/drupal_config_override.feature
+++ b/tests/behat/features/drupal_config_override.feature
@@ -1,3 +1,4 @@
+@config-override
 Feature: Check that ConfigOverrideTrait works
   As Behat Steps library developer
   I want to provide a way to disable Drupal config overrides for a scenario

--- a/tests/behat/features/drupal_config_override.feature
+++ b/tests/behat/features/drupal_config_override.feature
@@ -1,0 +1,48 @@
+Feature: Check that ConfigOverrideTrait works
+  As Behat Steps library developer
+  I want to provide a way to disable Drupal config overrides for a scenario
+  So that users can test original config values without redeploying the SUT
+
+  @api
+  Scenario: Visiting a page without the tag sends no X-Config-No-Override header
+    When I visit "/mysite_core/test-config-no-override-header"
+    Then the response status code should be 200
+    And the response should not contain "system.site"
+
+  @api @disable-config-override:system.site
+  Scenario: A single @disable-config-override tag sets the X-Config-No-Override header
+    When I visit "/mysite_core/test-config-no-override-header"
+    Then the response status code should be 200
+    And the response should contain "system.site"
+
+  @api @disable-config-override:system.site @disable-config-override:myconfig.settings
+  Scenario: Multiple @disable-config-override tags set a comma-separated X-Config-No-Override header
+    When I visit "/mysite_core/test-config-no-override-header"
+    Then the response status code should be 200
+    And the response should contain "system.site,myconfig.settings"
+
+  @api @disable-config-override:system.site
+  Scenario: The X-Config-No-Override header survives a login step that resets headers
+    Given users:
+      | name      | mail                  | roles         | status |
+      | test_user | test_user@example.com | administrator | 1      |
+    When I am logged in as "test_user"
+    And I visit "/mysite_core/test-config-no-override-header"
+    Then the response status code should be 200
+    And the response should contain "system.site"
+
+  @api @disable-config-override:system.site @behat-steps-skip:configOverrideBeforeScenario
+  Scenario: The @behat-steps-skip:configOverrideBeforeScenario tag bypasses the trait entirely
+    When I visit "/mysite_core/test-config-no-override-header"
+    Then the response status code should be 200
+    And the response should not contain "system.site"
+
+  @api @disable-config-override:system.site @behat-steps-skip:configOverrideBeforeStep
+  Scenario: The @behat-steps-skip:configOverrideBeforeStep tag keeps tag parsing but skips header propagation
+    Given users:
+      | name       | mail                   | roles         | status |
+      | test_user2 | test_user2@example.com | administrator | 1      |
+    When I am logged in as "test_user2"
+    And I visit "/mysite_core/test-config-no-override-header"
+    Then the response status code should be 200
+    And the response should not contain "system.site"

--- a/tests/behat/features/drupal_config_override.feature
+++ b/tests/behat/features/drupal_config_override.feature
@@ -3,6 +3,24 @@ Feature: Check that ConfigOverrideTrait works
   I want to provide a way to disable Drupal config overrides for a scenario
   So that users can test original config values without redeploying the SUT
 
+  # The fixture site has the following overrides in settings.php:
+  #   $config['system.site']['name']   = 'Overridden Site Name';
+  #   $config['system.site']['slogan'] = 'Overridden Slogan';
+  # The stored (original) name is 'Drush Site-Install'.
+
+  @api
+  Scenario: Without the tag, the SUT serves the settings.php-overridden config value
+    When I visit "/mysite_core/test-config-system-site-name"
+    Then the response status code should be 200
+    And the response should contain "Overridden Site Name"
+
+  @api @disable-config-override:system.site
+  Scenario: With @disable-config-override, the SUT serves the original stored config value
+    When I visit "/mysite_core/test-config-system-site-name"
+    Then the response status code should be 200
+    And the response should contain "Drush Site-Install"
+    And the response should not contain "Overridden Site Name"
+
   @api
   Scenario: Visiting a page without the tag sends no X-Config-No-Override header
     When I visit "/mysite_core/test-config-no-override-header"

--- a/tests/behat/fixtures_drupal/d10/web/modules/custom/mysite_core/mysite_core.routing.yml
+++ b/tests/behat/fixtures_drupal/d10/web/modules/custom/mysite_core/mysite_core.routing.yml
@@ -13,3 +13,10 @@ mysite_core.test_time:
     _access: 'TRUE'
   defaults:
     _controller: '\Drupal\mysite_core\Controller\TestContent::testTime'
+
+mysite_core.test_config_no_override_header:
+  path: '/mysite_core/test-config-no-override-header'
+  requirements:
+    _access: 'TRUE'
+  defaults:
+    _controller: '\Drupal\mysite_core\Controller\TestContent::testConfigNoOverrideHeader'

--- a/tests/behat/fixtures_drupal/d10/web/modules/custom/mysite_core/mysite_core.routing.yml
+++ b/tests/behat/fixtures_drupal/d10/web/modules/custom/mysite_core/mysite_core.routing.yml
@@ -20,3 +20,10 @@ mysite_core.test_config_no_override_header:
     _access: 'TRUE'
   defaults:
     _controller: '\Drupal\mysite_core\Controller\TestContent::testConfigNoOverrideHeader'
+
+mysite_core.test_config_system_site_name:
+  path: '/mysite_core/test-config-system-site-name'
+  requirements:
+    _access: 'TRUE'
+  defaults:
+    _controller: '\Drupal\mysite_core\Controller\TestContent::testConfigSystemSiteName'

--- a/tests/behat/fixtures_drupal/d10/web/modules/custom/mysite_core/src/Controller/TestContent.php
+++ b/tests/behat/fixtures_drupal/d10/web/modules/custom/mysite_core/src/Controller/TestContent.php
@@ -65,4 +65,27 @@ final class TestContent extends ControllerBase {
     ]);
   }
 
+  /**
+   * Returns the system.site name, honoring X-Config-No-Override.
+   *
+   * Demonstrates the SUT-side implementation expected by
+   * ConfigOverrideTrait: when the request header lists a config name, the
+   * original (un-overridden) value is returned via
+   * ImmutableConfig::getOriginal().
+   */
+  public function testConfigSystemSiteName(Request $request): Response {
+    $config = $this->config('system.site');
+    $header = (string) $request->headers->get('X-Config-No-Override', '');
+    $disabled = array_filter(array_map(trim(...), explode(',', $header)));
+
+    $value = in_array('system.site', $disabled, TRUE)
+      ? (string) $config->getOriginal('name', FALSE)
+      : (string) $config->get('name');
+
+    return new Response($value, 200, [
+      'Content-Type' => 'text/plain',
+      'Cache-Control' => 'no-cache, no-store, must-revalidate',
+    ]);
+  }
+
 }

--- a/tests/behat/fixtures_drupal/d10/web/modules/custom/mysite_core/src/Controller/TestContent.php
+++ b/tests/behat/fixtures_drupal/d10/web/modules/custom/mysite_core/src/Controller/TestContent.php
@@ -7,6 +7,7 @@ namespace Drupal\mysite_core\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\mysite_core\Time\TimeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -44,6 +45,21 @@ final class TestContent extends ControllerBase {
    */
   public function testTime(): Response {
     return new Response((string) $this->time->getCurrentTime(), 200, [
+      'Content-Type' => 'text/plain',
+      'Cache-Control' => 'no-cache, no-store, must-revalidate',
+    ]);
+  }
+
+  /**
+   * Echoes the value of the X-Config-No-Override request header.
+   *
+   * Used by ConfigOverrideTrait tests to verify that the Behat process
+   * successfully signals the SUT.
+   */
+  public function testConfigNoOverrideHeader(Request $request): Response {
+    $value = (string) $request->headers->get('X-Config-No-Override', '');
+
+    return new Response($value, 200, [
       'Content-Type' => 'text/plain',
       'Cache-Control' => 'no-cache, no-store, must-revalidate',
     ]);

--- a/tests/behat/fixtures_drupal/d11/web/modules/custom/mysite_core/mysite_core.routing.yml
+++ b/tests/behat/fixtures_drupal/d11/web/modules/custom/mysite_core/mysite_core.routing.yml
@@ -13,3 +13,10 @@ mysite_core.test_time:
     _access: 'TRUE'
   defaults:
     _controller: '\Drupal\mysite_core\Controller\TestContent::testTime'
+
+mysite_core.test_config_no_override_header:
+  path: '/mysite_core/test-config-no-override-header'
+  requirements:
+    _access: 'TRUE'
+  defaults:
+    _controller: '\Drupal\mysite_core\Controller\TestContent::testConfigNoOverrideHeader'

--- a/tests/behat/fixtures_drupal/d11/web/modules/custom/mysite_core/mysite_core.routing.yml
+++ b/tests/behat/fixtures_drupal/d11/web/modules/custom/mysite_core/mysite_core.routing.yml
@@ -20,3 +20,10 @@ mysite_core.test_config_no_override_header:
     _access: 'TRUE'
   defaults:
     _controller: '\Drupal\mysite_core\Controller\TestContent::testConfigNoOverrideHeader'
+
+mysite_core.test_config_system_site_name:
+  path: '/mysite_core/test-config-system-site-name'
+  requirements:
+    _access: 'TRUE'
+  defaults:
+    _controller: '\Drupal\mysite_core\Controller\TestContent::testConfigSystemSiteName'

--- a/tests/behat/fixtures_drupal/d11/web/modules/custom/mysite_core/src/Controller/TestContent.php
+++ b/tests/behat/fixtures_drupal/d11/web/modules/custom/mysite_core/src/Controller/TestContent.php
@@ -65,4 +65,27 @@ final class TestContent extends ControllerBase {
     ]);
   }
 
+  /**
+   * Returns the system.site name, honoring X-Config-No-Override.
+   *
+   * Demonstrates the SUT-side implementation expected by
+   * ConfigOverrideTrait: when the request header lists a config name, the
+   * original (un-overridden) value is returned via
+   * ImmutableConfig::getOriginal().
+   */
+  public function testConfigSystemSiteName(Request $request): Response {
+    $config = $this->config('system.site');
+    $header = (string) $request->headers->get('X-Config-No-Override', '');
+    $disabled = array_filter(array_map(trim(...), explode(',', $header)));
+
+    $value = in_array('system.site', $disabled, TRUE)
+      ? (string) $config->getOriginal('name', FALSE)
+      : (string) $config->get('name');
+
+    return new Response($value, 200, [
+      'Content-Type' => 'text/plain',
+      'Cache-Control' => 'no-cache, no-store, must-revalidate',
+    ]);
+  }
+
 }

--- a/tests/behat/fixtures_drupal/d11/web/modules/custom/mysite_core/src/Controller/TestContent.php
+++ b/tests/behat/fixtures_drupal/d11/web/modules/custom/mysite_core/src/Controller/TestContent.php
@@ -7,6 +7,7 @@ namespace Drupal\mysite_core\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\mysite_core\Time\TimeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -44,6 +45,21 @@ final class TestContent extends ControllerBase {
    */
   public function testTime(): Response {
     return new Response((string) $this->time->getCurrentTime(), 200, [
+      'Content-Type' => 'text/plain',
+      'Cache-Control' => 'no-cache, no-store, must-revalidate',
+    ]);
+  }
+
+  /**
+   * Echoes the value of the X-Config-No-Override request header.
+   *
+   * Used by ConfigOverrideTrait tests to verify that the Behat process
+   * successfully signals the SUT.
+   */
+  public function testConfigNoOverrideHeader(Request $request): Response {
+    $value = (string) $request->headers->get('X-Config-No-Override', '');
+
+    return new Response($value, 200, [
       'Content-Type' => 'text/plain',
       'Cache-Control' => 'no-cache, no-store, must-revalidate',
     ]);


### PR DESCRIPTION
Closes #571

## Summary

Adds a new `ConfigOverrideTrait` under `src/Drupal/ConfigOverrideTrait.php` that lets a Behat scenario tell the Drupal system under test (SUT) to ignore config overrides defined in `settings.php` for specific config objects. Because Behat runs in a separate process from the SUT, the trait signals intent via a request header, a `$_SERVER` entry, and an environment variable; the SUT is responsible for reading the signal and calling `ImmutableConfig::getOriginal()` instead of `ImmutableConfig::get()`.

Activation is driven by tags on a feature or scenario:

- `@disable-config-override:CONFIG_NAME` - add one per config object; multiple tags are combined into a comma-separated list.
- `@behat-steps-skip:configOverrideBeforeScenario` - opt out of the trait entirely for a scenario.
- `@behat-steps-skip:configOverrideBeforeStep` - keep tag parsing but skip header propagation.

The `BeforeStep` hook re-applies the header on every step because some steps (for example, Drupal Extension login) reset headers set earlier in the scenario. Selenium-based drivers are skipped silently because they cannot set request headers. When the consuming context also uses `RestTrait`, the `$restHeaders` array is populated via a soft `property_exists()` check so standalone REST requests receive the same signal.

## Changes

- `src/Drupal/ConfigOverrideTrait.php` - new trait with `configOverrideBeforeScenario` and `configOverrideBeforeStep` hooks, tag parsing, BrowserKit header propagation, `$_SERVER` + `putenv()` fallbacks, and a soft `RestTrait` bridge.
- `tests/behat/features/drupal_config_override.feature` - 6 scenarios covering: no tag, single tag, multiple tags (comma-joined), header surviving a login step, `behat-steps-skip:configOverrideBeforeScenario`, and `behat-steps-skip:configOverrideBeforeStep`. Reaches 100% line coverage for the new trait.
- `tests/behat/bootstrap/FeatureContext.php` - registers the new trait on the default context.
- `tests/behat/fixtures_drupal/d10/.../mysite_core.routing.yml` and `src/Controller/TestContent.php` - add `/mysite_core/test-config-no-override-header` route and controller that echoes the received `X-Config-No-Override` header so scenarios can assert it reached the SUT.
- `tests/behat/fixtures_drupal/d11/...` - mirror of the D10 route + controller.
- `STEPS.md` and `README.md` - regenerated via `ahoy update-docs`.

## Before / After

```
Before:
  Behat scenario ──► SUT (Drupal)
                      │
                      └── settings.php overrides always applied
                          → ImmutableConfig::get() returns overridden value
                          → no way to assert original config from Behat


After:
  Behat scenario
    │ @disable-config-override:system.site
    │ @disable-config-override:myconfig.settings
    │
    ├─[BeforeScenario]─► parse tags → ['system.site', 'myconfig.settings']
    │
    └─[BeforeStep, every step]─► set on Mink driver (BrowserKit):
                                   X-Config-No-Override: system.site,myconfig.settings
                                 set $_SERVER['HTTP_X_CONFIG_NO_OVERRIDE']
                                 set putenv('HTTP_X_CONFIG_NO_OVERRIDE=...')
                                 set $this->restHeaders[...] if RestTrait in use
                                   │
                                   ▼
                                 SUT (Drupal)
                                   │
                                   └── reads header / $_SERVER / env
                                       → ImmutableConfig::getOriginal()
                                       → returns unoverridden value
```

## Test plan

- [x] `ahoy lint` (phpcs, phpstan, rector --dry-run, gherkinlint) passes locally.
- [x] `ahoy test-unit` (189 tests, 312 assertions) passes locally.
- [x] `ahoy test-bdd tests/behat/features/drupal_config_override.feature` passes locally (6 scenarios, 100% line coverage for `ConfigOverrideTrait`).
- [ ] CI green on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a Drupal-specific Behat trait that lets scenarios signal the system-under-test (SUT) to ignore config overrides from settings.php for specified config objects. Activation is tag-driven and requires no new step definitions.

## Key Changes

### Core Implementation
- Added trait: src/Drupal/ConfigOverrideTrait.php
  - BeforeScenario hook: parses @disable-config-override:NAME tags (feature + scenario), deduplicates, stores names; honors @behat-steps-skip:configOverrideBeforeScenario and resolves @behat-steps-skip:configOverrideBeforeStep.
  - BeforeStep hook: runs on every step and, when enabled, emits a comma-separated X-Config-No-Override value via:
    - Mink request header for BrowserKit-based drivers (silently skipped for Selenium/JS drivers)
    - $_SERVER['HTTP_X_CONFIG_NO_OVERRIDE']
    - HTTP_X_CONFIG_NO_OVERRIDE environment variable (putenv)
    - Soft integration with RestTrait::$restHeaders when that property exists
  - Clears driver-level header when no names or when BeforeStep propagation is skipped.

### Tests & Fixtures
- tests/behat/features/drupal_config_override.feature: Added eight @api scenarios exercising tag parsing, single/multiple config names, header persistence across a login step, and both skip-tag behaviors.
- tests/behat/bootstrap/FeatureContext.php: Composes the new trait into the test context.
- Fixtures for Drupal 10/11: Added routes and controller actions that echo X-Config-No-Override and return overridden vs original system.site:name depending on the header.
- scripts/provision.sh: Appends system.site overrides to sites/default/settings.php during provisioning to support the tests.

### Documentation
- STEPS.md: Documented the trait, tag usage, skip tags, signaling channels, header-survival behavior, Selenium limitation, and the RestTrait soft-dependency.
- README.md: Added index entry for Drupal\ConfigOverrideTrait.

## Step Definition Compliance (CONTRIBUTING.md)
- No new step definitions (@Given/@When/@Then) were introduced—only hook methods (@BeforeScenario/@BeforeStep). Repository scan found no step-definition annotations in src/Drupal that violate the project's steps-format guidelines. No critical violations detected.

## Testing & CI
- Author reports local linting, unit tests, and BDD feature tests passed; CI pending.
- The feature file included in the PR contains eight concrete scenarios (contrary to an earlier note that it lacked Scenario lines), so BDD tests are present to exercise the trait end-to-end.

## Notes for Reviewers
- The SUT must detect X-Config-No-Override (header / $_SERVER / env) and call ImmutableConfig::getOriginal() for the named config objects.
- Selenium/JS driver limitation: headers cannot be set for JS-enabled sessions; this is documented and the trait silently omits header setting for such drivers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->