### PR TITLE
[#629] Use fixture path for file fields

### DIFF
--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -388,7 +388,7 @@ trait MediaTrait {
         continue;
       }
 
-      if (!empty($field_types[$name]) && $field_types[$name] == 'image') {
+      if (!empty($field_types[$name]) && in_array($field_types[$name], ['image', 'file'], TRUE)) {
         if (is_array($value)) {
           if (!empty($value[0]) && is_file($fixture_path . $value[0])) {
             $stub->{$name}[0] = $fixture_path . $value[0];

--- a/tests/behat/features/drupal_media.feature
+++ b/tests/behat/features/drupal_media.feature
@@ -5,10 +5,6 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert "When I attach the file :file to :field_name media field"
-    Given the following managed files:
-      | path         |
-      | document.pdf |
-
     When the following media "image" do not exist:
       | name             | field_media_image |
       | Test media image | image.png         |
@@ -34,10 +30,7 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert navigate to edit media with specified type and name
-    Given the following managed files:
-      | path         |
-      | document.pdf |
-    And the following media "document" exist:
+    Given the following media "document" exist:
       | name                | field_media_document |
       | Test media document | document.pdf         |
     And I am logged in as a user with the "administrator" role
@@ -75,12 +68,8 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert that mediaCreate() deletes existing media before creating
-    Given the following managed files:
-      | path      |
-      | image.png |
-
     # Create initial media
-    And the following media "image" exist:
+    Given the following media "image" exist:
       | name                | field_media_image |
       | Duplicate test item | image.png         |
 
@@ -101,9 +90,6 @@ Feature: Check that MediaTrait works
   @api
   Scenario: Create single media with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following managed files:
-      | path      |
-      | image.png |
     And the following image media with fields:
       | name              | [TEST] Vertical Image |
       | field_media_image | image.png             |
@@ -113,9 +99,6 @@ Feature: Check that MediaTrait works
   @api
   Scenario: Create multiple media with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following managed files:
-      | path      |
-      | image.png |
     And the following image media with fields:
       | name              | [TEST] V-Image 1 | [TEST] V-Image 2 | [TEST] V-Image 3 |
       | field_media_image | image.png        | image.png        | image.png        |
@@ -126,10 +109,7 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert that mediaCreateWithFields() deletes existing media before creating
-    Given the following managed files:
-      | path      |
-      | image.png |
-    And the following image media with fields:
+    Given the following image media with fields:
       | name              | [TEST] Duplicate vertical |
       | field_media_image | image.png                 |
     And I am logged in as a user with the "administrator" role
@@ -144,10 +124,7 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert "When I visit the media :media_type with the name :name" works
-    Given the following managed files:
-      | path      |
-      | image.png |
-    And the following media "image" exist:
+    Given the following media "image" exist:
       | name              | field_media_image |
       | Test media image  | image.png         |
     And I am logged in as a user with the "administrator" role
@@ -170,10 +147,7 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert "When I visit the media :media_type delete page with the name :name" works
-    Given the following managed files:
-      | path      |
-      | image.png |
-    And the following media "image" exist:
+    Given the following media "image" exist:
       | name              | field_media_image |
       | Test media image  | image.png         |
     And I am logged in as a user with the "administrator" role
@@ -197,10 +171,7 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert "When I visit the media :media_type revisions page with the name :name" works
-    Given the following managed files:
-      | path      |
-      | image.png |
-    And the following media "image" exist:
+    Given the following media "image" exist:
       | name              | field_media_image |
       | Test media image  | image.png         |
     And I am logged in as a user with the "administrator" role
@@ -261,10 +232,7 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert "Then the :media_type media with the name :name should exist" works
-    Given the following managed files:
-      | path      |
-      | image.png |
-    And the following media "image" exist:
+    Given the following media "image" exist:
       | name              | field_media_image |
       | Test media image  | image.png         |
     And I am logged in as a user with the "administrator" role
@@ -289,18 +257,12 @@ Feature: Check that MediaTrait works
     Given I am logged in as a user with the "administrator" role
     Then the "image" media with the name "Non-existent media" should not exist
 
-  @api @trait:Drupal\MediaTrait,Drupal\FileTrait
+  @api @trait:Drupal\MediaTrait
   Scenario: Assert that negative assertion for "Then the :media_type media with the name :name should not exist" fails with an error
-    Given the following managed files:
-      | path      |
-      | image.png |
-    And some behat configuration
+    Given some behat configuration
     And scenario steps:
       """
-      Given the following managed files:
-        | path      |
-        | image.png |
-      And the following media "image" exist:
+      Given the following media "image" exist:
         | name              | field_media_image |
         | Test media image  | image.png         |
       Then the "image" media with the name "Test media image" should not exist


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR extends fixture-based file path expansion in MediaTrait so media fields of type 'file' are treated the same as 'image' fields when resolving fixture file names to absolute fixture paths.

## Changes

- File: src/Drupal/MediaTrait.php
  - In mediaExpandEntityFieldsFixtures() the field-type check was changed from === 'image' to in_array(..., ['image', 'file'], TRUE), allowing both image and file media fields to have provided fixture filenames expanded to absolute fixture file paths. Existing array/single-value handling and assignment logic are unchanged.

- File: tests/behat/features/drupal_media.feature
  - Feature scenarios updated (lines modified) to exercise media creation for document/file media (e.g., creation of media with field_media_document => document.pdf) and continued coverage for image fields. Scenario structure and steps remain using the media-focused creation steps.

## Impact

- Scope: Internal behavior change in a protected helper used by media-creation step definitions.
- Backward compatibility: Backward compatible — extends fixture resolution to 'file' fields in addition to 'image'.
- API/public interface: No exported/public API changes.

## Tests / Documentation

- Existing Behat feature scenarios in tests/behat/features/drupal_media.feature cover media creation for document/file fields and will exercise the updated behavior.

## CONTRIBUTING.md step-definition rules

- I reviewed the relevant steps-format rules in CONTRIBUTING.md. This PR changes only internal logic and test usage; it does not add or alter any step definition signatures.
- No new violations of the step-definition rules in CONTRIBUTING.md were introduced by this PR. (The feature file continues to use existing step text such as "Given the following ..." which conforms to the guidelines; pre-existing "Given I ..." lines in test scenarios are unchanged by this change and therefore not a new violation.)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->