### PR TITLE
Bumped 'drupal/drupal-driver' and 'drupal/drupal-extension' to RC1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "php": ">=8.2",
         "behat/behat": "^3.14",
         "behat/mink": ">=1.11",
-        "drupal/drupal-driver": "^3.0@alpha",
-        "drupal/drupal-extension": "^6.0@alpha",
+        "drupal/drupal-driver": "^3.0@RC",
+        "drupal/drupal-extension": "^6.0@RC",
         "lullabot/mink-selenium2-driver": "^1.7.4"
     },
     "require-dev": {
@@ -44,7 +44,7 @@
         "phpunit/phpunit": "^11",
         "rector/rector": "^2.0"
     },
-    "minimum-stability": "alpha",
+    "minimum-stability": "RC",
     "prefer-stable": true,
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

Tightens the Composer stability constraints for `drupal/drupal-driver` and `drupal/drupal-extension` from `@alpha` to `@RC` now that the upstream maintainers have shipped their first RC tags (`v3.0.0-rc1` and `v6.0.0-rc1`). The `minimum-stability` field is updated from `alpha` to `RC` to match. This is the natural follow-up to #631, which introduced the initial migration to the 6.0/3.0 line under alpha stability; with RC tags now available, consumers of this library no longer need to whitelist alpha stability project-wide.

## Changes

### Composer

- `drupal/drupal-driver` constraint: `^3.0@alpha` → `^3.0@RC` (resolves to `v3.0.0-rc1`).
- `drupal/drupal-extension` constraint: `^6.0@alpha` → `^6.0@RC` (resolves to `v6.0.0-rc1`).
- `minimum-stability`: `alpha` → `RC`.

No library source code changed - this is a Composer-metadata-only change. `prefer-stable: true` is unchanged, so every other dependency continues to resolve to its latest stable tag.

## Consumer impact

Downstream projects no longer need to whitelist `alpha` stability for these two packages. With this release, the following root `composer.json` snippet is sufficient:

```json
"require-dev": {
    "drevops/behat-steps": "^3.9",
    "drupal/drupal-driver": "^3.0@RC",
    "drupal/drupal-extension": "^6.0@RC"
}
```

Or, project-wide:

```json
"minimum-stability": "RC",
"prefer-stable": true
```

Once the upstream packages ship stable `v3.0.0` and `v6.0.0` tags the per-package `@RC` flags can be dropped entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates Composer dependency constraints for two Drupal Behat packages to their release-candidate versions, reflecting upstream RC1 releases.

## Changes

**Composer.json updates:**
- `drupal/drupal-driver`: `^3.0@alpha` → `^3.0@RC`
- `drupal/drupal-extension`: `^6.0@alpha` → `^6.0@RC`
- `minimum-stability`: `alpha` → `RC`

No source code changes or step definition modifications.

## Impact

This is a metadata-only change. Downstream projects can now require these packages with per-package `@RC` flags, or set `"minimum-stability": "RC"` with `"prefer-stable": true`. Once upstream releases stable v3.0.0 and v6.0.0 tags, the `@RC` flags can be removed.

**Step Definition Compliance**: Not applicable — this PR contains no step definition code changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/behat-steps/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->