### PR TITLE
Expanded fixture paths inside compound file/image field values.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.2",
         "behat/behat": "^3.14",
         "behat/mink": ">=1.11",
-        "drupal/drupal-driver": "^3.0@RC",
+        "drupal/drupal-driver": "dev-feature/normalise-public as 3.0",
         "drupal/drupal-extension": "^6.0@RC",
         "lullabot/mink-selenium2-driver": "^1.7.4"
     },

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -239,32 +239,120 @@ trait HelperTrait {
         continue;
       }
 
-      $basename = is_array($value) ? ($value[0] ?? NULL) : $value;
+      // Raw compound string (e.g. 'target_id:"foo.jpg", alt:"A"') as written
+      // in the Behat table. Hooks fired by 'RawDrupalContext::nodeCreate()'
+      // run before 'parseEntityFields()', so on the node path the helper sees
+      // the unparsed cell. Rewrite the basename inside the 'target_id:"..."'
+      // segment in place and leave the rest of the cell to the parser.
+      if (is_string($value) && $this->helperLooksLikeCompoundCell($value)) {
+        $rewritten = $this->helperExpandCompoundCellFixtures($value, $fixture_path);
 
-      if (!is_string($basename) || $basename === '') {
+        if ($rewritten !== $value) {
+          $stub->setValue($name, $rewritten);
+        }
+
         continue;
       }
 
-      if (str_contains($basename, '/') || str_contains($basename, '\\') || $basename !== basename($basename)) {
+      // Parsed compound shape (e.g. [['target_id' => 'foo.jpg', 'alt' => 'A']])
+      // produced by 'EntityFieldParser'. This is what the helper sees on the
+      // media path, which calls 'parseEntityFields()' before invoking it.
+      $is_compound = is_array($value) && isset($value[0]) && is_array($value[0]);
+      $records = $is_compound ? $value : [$value];
+      $mutated = FALSE;
+
+      foreach ($records as $index => $record) {
+        if (is_array($record)) {
+          $basename = $record['target_id'] ?? $record[0] ?? NULL;
+        }
+        else {
+          $basename = $record;
+        }
+
+        if (!is_string($basename) || $basename === '') {
+          continue;
+        }
+
+        if (str_contains($basename, '/') || str_contains($basename, '\\') || $basename !== basename($basename)) {
+          continue;
+        }
+
+        if ($this->helperManagedFileExists($basename)) {
+          continue;
+        }
+
+        if (!is_file($fixture_path . $basename)) {
+          continue;
+        }
+
+        if (is_array($record)) {
+          if (array_key_exists('target_id', $record)) {
+            $records[$index]['target_id'] = $fixture_path . $basename;
+          }
+          else {
+            $records[$index][0] = $fixture_path . $basename;
+          }
+        }
+        else {
+          $records[$index] = $fixture_path . $basename;
+        }
+
+        $mutated = TRUE;
+      }
+
+      if (!$mutated) {
         continue;
+      }
+
+      $stub->setValue($name, $is_compound ? $records : $records[0]);
+    }
+  }
+
+  /**
+   * Detect a raw compound cell string of the shape 'key:"..."' or 'key:[...]'.
+   *
+   * Mirrors the top-level pattern 'EntityFieldParser' uses to enter compound
+   * mode: an identifier, optional whitespace, ':', optional whitespace, then
+   * a '"' or '['. Used to distinguish a compound cell that needs in-string
+   * basename rewriting from a bare scalar basename like 'document.pdf'.
+   */
+  protected function helperLooksLikeCompoundCell(string $value): bool {
+    return preg_match('/^\s*[a-z_][a-z0-9_]*\s*:\s*[\"\[]/i', $value) === 1;
+  }
+
+  /**
+   * Rewrite each 'target_id:"basename"' segment to embed the fixture path.
+   *
+   * Only the 'target_id' key is touched and only when the quoted value is a
+   * pure basename (no separators), is not backed by an existing managed file
+   * and resolves to a real file under the fixtures dir. Other compound
+   * columns (e.g. 'alt', 'description') are left untouched so the parser can
+   * still process them.
+   */
+  protected function helperExpandCompoundCellFixtures(string $value, string $fixture_path): string {
+    $callback = function (array $matches) use ($fixture_path): string {
+      $basename = $matches[2];
+
+      if ($basename === '' || str_contains($basename, '/') || str_contains($basename, '\\')) {
+        return $matches[0];
+      }
+
+      if ($basename !== basename($basename)) {
+        return $matches[0];
       }
 
       if ($this->helperManagedFileExists($basename)) {
-        continue;
+        return $matches[0];
       }
 
       if (!is_file($fixture_path . $basename)) {
-        continue;
+        return $matches[0];
       }
 
-      if (is_array($value)) {
-        $value[0] = $fixture_path . $basename;
-        $stub->setValue($name, $value);
-      }
-      else {
-        $stub->setValue($name, $fixture_path . $basename);
-      }
-    }
+      return $matches[1] . $fixture_path . $basename . $matches[3];
+    };
+
+    return (string) preg_replace_callback('/(target_id\s*:\s*")([^"\\\\]+)(")/i', $callback, $value);
   }
 
   /**

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -254,11 +254,18 @@ trait HelperTrait {
         continue;
       }
 
-      // Parsed compound shape (e.g. [['target_id' => 'foo.jpg', 'alt' => 'A']])
-      // produced by 'EntityFieldParser'. This is what the helper sees on the
-      // media path, which calls 'parseEntityFields()' before invoking it.
-      $is_compound = is_array($value) && isset($value[0]) && is_array($value[0]);
-      $records = $is_compound ? $value : [$value];
+      // Parsed shapes produced by 'EntityFieldParser' or the legacy parser:
+      // - scalar: 'foo.jpg' (treated as single-value)
+      // - scalar list: ['foo.jpg', 'bar.jpg'] (multi-value)
+      // - keyed record: ['target_id' => 'foo.jpg', 'alt' => 'A'] (single compound)
+      // - list of records: [['target_id' => 'foo.jpg', 'alt' => 'A'], ...] (multi-value compound)
+      //
+      // Numerically-indexed arrays (lists) are iterated element-by-element so
+      // every delta gets resolved. Keyed records and bare scalars are wrapped
+      // in a single-element list, processed once, and unwrapped on the way
+      // back into the stub.
+      $is_list = is_array($value) && array_is_list($value);
+      $records = $is_list ? $value : [$value];
       $mutated = FALSE;
 
       foreach ($records as $index => $record) {
@@ -299,7 +306,7 @@ trait HelperTrait {
         continue;
       }
 
-      $stub->setValue($name, $is_compound ? $records : $records[0]);
+      $stub->setValue($name, $is_list ? $records : $records[0]);
     }
   }
 

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -262,12 +262,7 @@ trait HelperTrait {
       $mutated = FALSE;
 
       foreach ($records as $index => $record) {
-        if (is_array($record)) {
-          $basename = $record['target_id'] ?? $record[0] ?? NULL;
-        }
-        else {
-          $basename = $record;
-        }
+        $basename = is_array($record) ? $record['target_id'] ?? $record[0] ?? NULL : $record;
 
         if (!is_string($basename) || $basename === '') {
           continue;

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -371,3 +371,22 @@ Feature: Check that ContentTrait works
     And I am logged in as a user with the "administrator" role
     When I visit the "article" content edit page with the title "[TEST] Fixture image"
     Then I should see "[TEST] Fixture image"
+
+  @api
+  Scenario: Assert file field on node resolves compound fixture filename without explicit managed file
+    Given the following article content:
+      | title                         | field_file                                       |
+      | [TEST] Compound fixture file  | target_id:"text.txt", description:"My document"  |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "article" content edit page with the title "[TEST] Compound fixture file"
+    Then I should see "[TEST] Compound fixture file"
+    And the response should contain ".txt"
+
+  @api
+  Scenario: Assert image field on node resolves compound fixture filename without explicit managed file
+    Given the following article content:
+      | title                          | field_image                              |
+      | [TEST] Compound fixture image  | target_id:"image.png", alt:"My image"    |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "article" content edit page with the title "[TEST] Compound fixture image"
+    Then I should see "[TEST] Compound fixture image"

--- a/tests/phpunit/src/HelperTraitTest.php
+++ b/tests/phpunit/src/HelperTraitTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps\Tests;
 
 use DrevOps\BehatSteps\HelperTrait;
+use Drupal\Driver\Core\CoreInterface;
+use Drupal\Driver\DrupalDriverInterface;
+use Drupal\Driver\Entity\EntityStub;
+use Drupal\Driver\Entity\EntityStubInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -142,6 +146,100 @@ class HelperTraitTest extends UnitTestCase {
     ];
   }
 
+  #[DataProvider('dataProviderExpandEntityFieldsFixtures')]
+  public function testExpandEntityFieldsFixtures(array $existing_fixture_files, array $existing_managed_basenames, array $field_types, array $stub_values, callable $expected_factory): void {
+    foreach ($existing_fixture_files as $basename) {
+      file_put_contents($this->fixturesPath . $basename, 'fixture content');
+    }
+
+    $core = $this->createStub(CoreInterface::class);
+    $core->method('getEntityFieldTypes')->willReturn($field_types);
+
+    $driver = $this->createStub(DrupalDriverInterface::class);
+    $driver->method('getCore')->willReturn($core);
+
+    $this->testObject->managedBasenames = $existing_managed_basenames;
+    $this->testObject->driver = $driver;
+    $this->testObject->minkFilesPath = rtrim($this->fixturesPath, DIRECTORY_SEPARATOR);
+
+    $stub = new EntityStub('node', 'article', $stub_values);
+
+    $this->testObject->callHelperExpandEntityFieldsFixtures('node', $stub);
+
+    $this->assertSame($expected_factory($this->fixturesPath), $stub->getValues());
+  }
+
+  public static function dataProviderExpandEntityFieldsFixtures(): array {
+    return [
+      'rewrites bare scalar file' => [
+        ['document.pdf'],
+        [],
+        ['field_file' => 'file'],
+        ['field_file' => 'document.pdf'],
+        fn(string $f): array => ['field_file' => $f . 'document.pdf'],
+      ],
+      'rewrites every entry in a multi-value scalar file list' => [
+        ['document.pdf', 'image.png'],
+        [],
+        ['field_files' => 'file'],
+        ['field_files' => ['document.pdf', 'image.png']],
+        fn(string $f): array => ['field_files' => [$f . 'document.pdf', $f . 'image.png']],
+      ],
+      'rewrites target_id in a single keyed record' => [
+        ['document.pdf'],
+        [],
+        ['field_file' => 'file'],
+        ['field_file' => ['target_id' => 'document.pdf', 'description' => 'My doc']],
+        fn(string $f): array => ['field_file' => ['target_id' => $f . 'document.pdf', 'description' => 'My doc']],
+      ],
+      'rewrites target_id in every entry of a multi-value compound list' => [
+        ['document.pdf', 'image.png'],
+        [],
+        ['field_files' => 'file'],
+        [
+          'field_files' => [
+            ['target_id' => 'document.pdf', 'description' => 'A'],
+            ['target_id' => 'image.png', 'description' => 'B'],
+          ],
+        ],
+        fn(string $f): array => [
+          'field_files' => [
+            ['target_id' => $f . 'document.pdf', 'description' => 'A'],
+            ['target_id' => $f . 'image.png', 'description' => 'B'],
+          ],
+        ],
+      ],
+      'leaves non-file field values unchanged' => [
+        ['document.pdf'],
+        [],
+        ['title' => 'string'],
+        ['title' => 'document.pdf'],
+        fn(string $f): array => ['title' => 'document.pdf'],
+      ],
+      'leaves missing fixture file unchanged' => [
+        [],
+        [],
+        ['field_file' => 'file'],
+        ['field_file' => 'missing.pdf'],
+        fn(string $f): array => ['field_file' => 'missing.pdf'],
+      ],
+      'leaves managed-file basenames unchanged' => [
+        ['document.pdf'],
+        ['document.pdf'],
+        ['field_file' => 'file'],
+        ['field_file' => 'document.pdf'],
+        fn(string $f): array => ['field_file' => 'document.pdf'],
+      ],
+      'rewrites raw compound cell string in target_id segment' => [
+        ['document.pdf'],
+        [],
+        ['field_file' => 'file'],
+        ['field_file' => 'target_id:"document.pdf", description:"A"'],
+        fn(string $f): array => ['field_file' => 'target_id:"' . $f . 'document.pdf", description:"A"'],
+      ],
+    ];
+  }
+
 }
 
 /**
@@ -162,12 +260,34 @@ class HelperTraitTestImplementation {
    */
   public array $managedBasenames = [];
 
+  /**
+   * Value returned by 'getMinkParameter(\'files_path\')'.
+   */
+  public string $minkFilesPath = '';
+
   public function callHelperLooksLikeCompoundCell(string $value): bool {
     return $this->helperLooksLikeCompoundCell($value);
   }
 
   public function callHelperExpandCompoundCellFixtures(string $value, string $fixture_path): string {
     return $this->helperExpandCompoundCellFixtures($value, $fixture_path);
+  }
+
+  public function callHelperExpandEntityFieldsFixtures(string $entity_type, EntityStubInterface $stub): void {
+    $this->helperExpandEntityFieldsFixtures($entity_type, $stub);
+  }
+
+  public function getMinkParameter(string $name): mixed {
+    return $name === 'files_path' ? $this->minkFilesPath : NULL;
+  }
+
+  /**
+   * Holds the stubbed driver instance once the test sets it.
+   */
+  public ?DrupalDriverInterface $driver = NULL;
+
+  public function getDriver(): ?DrupalDriverInterface {
+    return $this->driver;
   }
 
   /**

--- a/tests/phpunit/src/HelperTraitTest.php
+++ b/tests/phpunit/src/HelperTraitTest.php
@@ -20,6 +20,8 @@ class HelperTraitTest extends UnitTestCase {
   protected HelperTraitTestImplementation $testObject;
 
   /**
+   * Per-test fixtures directory.
+   *
    * Absolute path of an isolated fixtures dir created per test, with trailing
    * separator.
    */

--- a/tests/phpunit/src/HelperTraitTest.php
+++ b/tests/phpunit/src/HelperTraitTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests;
+
+use DrevOps\BehatSteps\HelperTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for HelperTrait.
+ */
+#[CoversClass(HelperTrait::class)]
+class HelperTraitTest extends UnitTestCase {
+
+  /**
+   * A test implementation of HelperTrait.
+   */
+  protected HelperTraitTestImplementation $testObject;
+
+  /**
+   * Absolute path of an isolated fixtures dir created per test, with trailing
+   * separator.
+   */
+  protected string $fixturesPath;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->testObject = new HelperTraitTestImplementation();
+
+    $tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat-steps-helper-' . uniqid('', TRUE);
+    mkdir($tmp, 0777, TRUE);
+    $this->fixturesPath = $tmp . DIRECTORY_SEPARATOR;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    if (is_dir($this->fixturesPath)) {
+      foreach (scandir($this->fixturesPath) as $entry) {
+        if ($entry === '.' || $entry === '..') {
+          continue;
+        }
+
+        unlink($this->fixturesPath . $entry);
+      }
+
+      rmdir(rtrim($this->fixturesPath, DIRECTORY_SEPARATOR));
+    }
+
+    parent::tearDown();
+  }
+
+  #[DataProvider('dataProviderLooksLikeCompoundCell')]
+  public function testLooksLikeCompoundCell(string $value, bool $expected): void {
+    $this->assertSame($expected, $this->testObject->callHelperLooksLikeCompoundCell($value));
+  }
+
+  public static function dataProviderLooksLikeCompoundCell(): array {
+    return [
+      'plain basename' => ['document.pdf', FALSE],
+      'empty string' => ['', FALSE],
+      'colon without quote' => ['foo:bar', FALSE],
+      'colon with quote in middle' => ['some text with key:"value" inside', FALSE],
+      'target_id with quoted value' => ['target_id:"foo.jpg"', TRUE],
+      'target_id with spaces' => ['target_id : "foo.jpg"', TRUE],
+      'compound with extra columns' => ['target_id:"foo.jpg", alt:"A"', TRUE],
+      'token shape' => ['target_id:[node:1]', TRUE],
+      'uppercase key' => ['TARGET_ID:"foo.jpg"', TRUE],
+      'leading whitespace' => ['  target_id:"foo.jpg"', TRUE],
+      'key starting with digit' => ['1key:"foo.jpg"', FALSE],
+      'numeric like value' => ['12345', FALSE],
+    ];
+  }
+
+  #[DataProvider('dataProviderExpandCompoundCellFixtures')]
+  public function testExpandCompoundCellFixtures(string $value, array $existing_fixture_files, array $existing_managed_basenames, string $expected_template): void {
+    foreach ($existing_fixture_files as $basename) {
+      file_put_contents($this->fixturesPath . $basename, 'fixture content');
+    }
+
+    $this->testObject->managedBasenames = $existing_managed_basenames;
+
+    $expected = str_replace('{FIXTURES}', $this->fixturesPath, $expected_template);
+    $actual = $this->testObject->callHelperExpandCompoundCellFixtures($value, $this->fixturesPath);
+
+    $this->assertSame($expected, $actual);
+  }
+
+  public static function dataProviderExpandCompoundCellFixtures(): array {
+    return [
+      'rewrites target_id to fixture path when file exists' => [
+        'target_id:"text.txt", description:"My file"',
+        ['text.txt'],
+        [],
+        'target_id:"{FIXTURES}text.txt", description:"My file"',
+      ],
+      'leaves cell unchanged when fixture file is missing' => [
+        'target_id:"missing.txt", description:"My file"',
+        [],
+        [],
+        'target_id:"missing.txt", description:"My file"',
+      ],
+      'leaves cell unchanged when managed file already exists' => [
+        'target_id:"text.txt", description:"My file"',
+        ['text.txt'],
+        ['text.txt'],
+        'target_id:"text.txt", description:"My file"',
+      ],
+      'leaves target_id unchanged when value contains a separator' => [
+        'target_id:"sub/text.txt", description:"My file"',
+        [],
+        [],
+        'target_id:"sub/text.txt", description:"My file"',
+      ],
+      'leaves cell unchanged when no target_id key present' => [
+        'alt:"description only", description:"No file"',
+        ['text.txt'],
+        [],
+        'alt:"description only", description:"No file"',
+      ],
+      'handles image compound with alt sibling' => [
+        'target_id:"image.png", alt:"Some alt"',
+        ['image.png'],
+        [],
+        'target_id:"{FIXTURES}image.png", alt:"Some alt"',
+      ],
+      'rewrites multiple records separated by semicolons' => [
+        'target_id:"text.txt", description:"One"; target_id:"image.png", alt:"Two"',
+        ['text.txt', 'image.png'],
+        [],
+        'target_id:"{FIXTURES}text.txt", description:"One"; target_id:"{FIXTURES}image.png", alt:"Two"',
+      ],
+    ];
+  }
+
+}
+
+/**
+ * Test implementation of HelperTrait.
+ *
+ * Exposes the protected helper methods under the test and stubs the
+ * Drupal-dependent 'helperManagedFileExists()' so unit tests can simulate
+ * pre-existing managed files without bootstrapping Drupal.
+ */
+class HelperTraitTestImplementation {
+
+  use HelperTrait;
+
+  /**
+   * Basenames the stubbed 'helperManagedFileExists()' should report as managed.
+   *
+   * @var string[]
+   */
+  public array $managedBasenames = [];
+
+  public function callHelperLooksLikeCompoundCell(string $value): bool {
+    return $this->helperLooksLikeCompoundCell($value);
+  }
+
+  public function callHelperExpandCompoundCellFixtures(string $value, string $fixture_path): string {
+    return $this->helperExpandCompoundCellFixtures($value, $fixture_path);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Overridden to avoid bootstrapping Drupal in unit tests.
+   */
+  protected function helperManagedFileExists(string $basename): bool {
+    return in_array($basename, $this->managedBasenames, TRUE);
+  }
+
+}


### PR DESCRIPTION
## Summary

`HelperTrait::helperExpandEntityFieldsFixtures()` previously assumed field values were either plain scalars or simple arrays, missing the modern `drupal-extension` compound parser shape where a file/image cell is written as `target_id:"foo.jpg", alt:"A"`. As a result, fixture path expansion was silently skipped for any compound cell, forcing callers to supply absolute paths. This change adds two new code paths - one for raw compound strings (the node route, where the cell arrives before `parseEntityFields()` runs) and one for the already-parsed associative-array shape (the media route) - so fixture basenames are expanded correctly in both cases.

## Changes

**`src/HelperTrait.php`**

- Added `helperLooksLikeCompoundCell()` - detects raw compound cell strings matching the `key:"..."` or `key:[...]` pattern that `EntityFieldParser` uses to enter compound mode.
- Added `helperExpandCompoundCellFixtures()` - rewrites the `target_id:"basename"` segment inside a raw compound string, leaving all other columns (e.g. `alt`, `description`) untouched.
- Refactored the main field-expansion loop to handle three value shapes: raw compound string, parsed compound array (`[['target_id' => 'foo.jpg', 'alt' => 'A']]`), and the original plain scalar/simple array.

**`tests/behat/features/drupal_content.feature`**

- Added scenario for a file field on a node using the compound cell syntax (`target_id:"text.txt", description:"My document"`).
- Added scenario for an image field on a node using the compound cell syntax (`target_id:"image.png", alt:"My image"`).

## Before / After

```
Before (compound cell - path expansion silently skipped):

  helperExpandEntityFieldsFixtures()
    |
    +-- value = 'target_id:"foo.jpg", alt:"A"'   (string, not an array)
    |
    +-- basename = 'target_id:"foo.jpg", alt:"A"' (the whole string)
    |
    +-- str_contains(basename, '"') == FALSE
    |   basename !== basename(basename)  => TRUE   <-- skips
    |
    => field left unchanged, Drupal receives bare basename, file not found


After (compound cell - path expansion applied correctly):

  helperExpandEntityFieldsFixtures()
    |
    +-- value = 'target_id:"foo.jpg", alt:"A"'
    |
    +-- helperLooksLikeCompoundCell() => TRUE
    |
    +-- helperExpandCompoundCellFixtures()
    |     preg_replace_callback on target_id:"..." segment
    |     => 'target_id:"/path/to/fixtures/foo.jpg", alt:"A"'
    |
    => field updated, Drupal receives full path, file found
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR extends fixture path expansion to support compound entity field values in drupal-extension compound parser syntax, ensuring file/image compound cell values (e.g., target_id:"foo.jpg", alt:"A") are expanded to absolute fixture paths so Drupal receives full file paths.

### Changes Made

src/HelperTrait.php
- Added protected helperLooksLikeCompoundCell(string $value): bool to detect raw compound cell strings (patterns like key:"..." or key:[...]).
- Added protected helperExpandCompoundCellFixtures(string $value, string $fixture_path): string to rewrite only the target_id:"basename" segment inside raw compound strings to an absolute fixture path.
- Refactored protected helperExpandEntityFieldsFixtures(string $entity_type, EntityStubInterface $stub): void to handle three shapes:
  1. Raw compound strings (node-style) — in-string target_id rewriting.
  2. Parsed compound associative arrays (media-style) — mutate target_id values in the parsed structure.
  3. Plain scalars and simple arrays — original behavior preserved.
- Expansion rules: only rewrite basenames that contain no path separators, are not already backed by managed files (helperManagedFileExists), and resolve to actual files under the fixtures directory.
- Fixes handling of multi-value scalar lists so the correct element(s) are expanded.

tests/behat/features/drupal_content.feature
- Added scenarios validating file and image fields specified using compound fixture syntax (e.g., target_id:"text.txt", description:"..."; target_id:"image.png", alt:"...") to ensure fixture resolution and resulting content assertions.

tests/phpunit/src/HelperTraitTest.php
- New PHPUnit tests covering helperLooksLikeCompoundCell() and helperExpandCompoundCellFixtures(), with temporary fixture creation and managed-file existence stubbing via a test implementation wrapper.
- Added tests exercising the expanded helperExpandEntityFieldsFixtures behavior across scalar, list and compound shapes.

composer.json
- Updated drupal/drupal-driver dependency to dev-feature/normalise-public as 3.0 to obtain compound-shape support required by the parsing/expansion logic.

### API / Public Surface
- New protected methods in HelperTrait:
  - helperLooksLikeCompoundCell(string): bool
  - helperExpandCompoundCellFixtures(string, string): string
- helperExpandEntityFieldsFixtures(...) behaviour updated (signature unchanged).

### Step Definition Compliance (per CONTRIBUTING.md)
I reviewed CONTRIBUTING.md and the modified Behat feature file. The new scenarios follow the repository's step-definition formatting rules (no new step definitions introduced; tuple-format placeholders and phrasing preserved). No step-definition format violations were found. No Critical issues detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/behat-steps/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->