### PR TITLE
Bumped 'drupal/drupal-driver' and 'drupal/drupal-extension' to RC2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.2",
         "behat/behat": "^3.14",
         "behat/mink": ">=1.11",
-        "drupal/drupal-driver": "dev-feature/normalise-public as 3.0",
+        "drupal/drupal-driver": "^3.0@RC",
         "drupal/drupal-extension": "^6.0@RC",
         "lullabot/mink-selenium2-driver": "^1.7.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "behat/behat": "^3.14",
         "behat/mink": ">=1.11",
         "drupal/drupal-driver": "^3.0.0-RC2",
-        "drupal/drupal-extension": "^6.0@RC",
+        "drupal/drupal-extension": "^6.0.0-RC2",
         "lullabot/mink-selenium2-driver": "^1.7.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.2",
         "behat/behat": "^3.14",
         "behat/mink": ">=1.11",
-        "drupal/drupal-driver": "^3.0@RC",
+        "drupal/drupal-driver": "^3.0.0-RC2",
         "drupal/drupal-extension": "^6.0@RC",
         "lullabot/mink-selenium2-driver": "^1.7.4"
     },


### PR DESCRIPTION
## Summary

Bumps both `drupal/drupal-driver` and `drupal/drupal-extension` to their newly released RC2 packages and locks each constraint at RC2 as the minimum bound.

For `drupal/drupal-driver`, this replaces a temporary dev-branch pin (`dev-feature/normalise-public as 3.0`) that was introduced because the `normalise-public` changes needed for compound field normalisation were not yet in any tagged release. `drupal/drupal-driver v3.0.0-RC2` was released on 2026-05-19 and ships those changes, so the dev pin is no longer needed.

For `drupal/drupal-extension`, this tightens the previous `^6.0@RC` constraint to `^6.0.0-RC2` to match. `drupal/drupal-extension v6.0.0-RC2` was also released on 2026-05-19.

The `^X.Y.Z-RC2` form sets RC2 as the minimum: RC1 is excluded, RC2 and any later release in the same major (including the eventual stable) are allowed. With `prefer-stable: true` in the project's Composer config, the stable release will be preferred automatically once it ships.

## Changes

### `composer.json`

- `drupal/drupal-driver`: `dev-feature/normalise-public as 3.0` → `^3.0.0-RC2`
- `drupal/drupal-extension`: `^6.0@RC` → `^6.0.0-RC2`

## Before / After

```
Before
------
"drupal/drupal-driver":    "dev-feature/normalise-public as 3.0"
"drupal/drupal-extension": "^6.0@RC"
                              ↑ allows RC1, RC2, RC3, ...

After
-----
"drupal/drupal-driver":    "^3.0.0-RC2"
"drupal/drupal-extension": "^6.0.0-RC2"
                              ↑ excludes RC1; allows RC2+ and stable
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated Drupal package dependencies in composer.json:
- `drupal/drupal-driver` bumped from dev branch (`dev-feature/normalise-public as 3.0`) to `^3.0.0-RC2`
- `drupal/drupal-extension` updated from `^6.0@RC` to `^6.0.0-RC2`

This replaces a temporary dev-branch constraint with the released RC2 version that includes necessary changes for compound field normalisation. The semver constraint allows RC2 and later 3.x releases (including stable 3.0.0 once published), with stable versions preferred due to the project's `prefer-stable: true` configuration.

**Changes**: 2 lines modified in composer.json

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/behat-steps/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->