### PR TITLE
Bumped 'drupal/drupal-extension' to stable and removed 6.0 deprecations.

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -60,10 +60,11 @@ default:
         # Behat would run from within "build" dir.
         root: web
       selectors:
-        message_selector: '.messages'
-        error_message_selector: '.messages.messages--error'
-        success_message_selector: '.messages.messages--status'
-        warning_message_selector: '.messages.messages--warning'
+        messages:
+          default: '.messages'
+          error: '.messages.messages--error'
+          success: '.messages.messages--status'
+          warning: '.messages.messages--warning'
 
     # Capture HTML and JPG screenshots on demand and on failure.
     DrevOps\BehatScreenshotExtension:

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,6 @@
         "drupal/drupal-extension": "^6.0",
         "lullabot/mink-selenium2-driver": "^1.7.4"
     },
-    "conflict": {
-        "drupal/drupal-extension": "<6"
-    },
     "require-dev": {
         "alexskrypnyk/phpunit-helpers": "^0.15.0",
         "cweagans/composer-patches": "^2.0",
@@ -45,6 +42,9 @@
         "phpstan/phpstan": "^2.0.0",
         "phpunit/phpunit": "^11",
         "rector/rector": "^2.0"
+    },
+    "conflict": {
+        "drupal/drupal-extension": "<6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,11 @@
         "php": ">=8.2",
         "behat/behat": "^3.14",
         "behat/mink": ">=1.11",
-        "drupal/drupal-driver": "^3.0.0-RC2",
-        "drupal/drupal-extension": "^6.0.0-RC2",
+        "drupal/drupal-extension": "^6.0",
         "lullabot/mink-selenium2-driver": "^1.7.4"
+    },
+    "conflict": {
+        "drupal/drupal-extension": "<6"
     },
     "require-dev": {
         "alexskrypnyk/phpunit-helpers": "^0.15.0",
@@ -44,8 +46,6 @@
         "phpunit/phpunit": "^11",
         "rector/rector": "^2.0"
     },
-    "minimum-stability": "RC",
-    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "DrevOps\\BehatSteps\\": "src/"


### PR DESCRIPTION
## Summary

Promoted `drupal/drupal-extension` from the pre-release constraint `^6.0.0-RC2` to the stable `^6.0`, now that version 6.0 has been officially released. The direct `drupal/drupal-driver` dependency was removed because it is already a transitive dependency of `drupal/drupal-extension`. A `conflict` entry guards against accidentally installing an incompatible older major. The `minimum-stability: RC` and `prefer-stable: true` overrides are no longer needed now that only stable releases are required. Also migrated the deprecated flat message selector keys in `behat.yml` to the nested format introduced in 6.0, which is the canonical form going forward - the flat keys are removed in 6.1.

## Changes

### `composer.json`

- `require`: Replaced `drupal/drupal-extension: ^6.0.0-RC2` with `^6.0` (stable).
- `require`: Removed the explicit `drupal/drupal-driver: ^3.0.0-RC2` declaration - it is a transitive dependency pulled in by `drupal/drupal-extension`.
- `conflict`: Added `drupal/drupal-extension: <6` to prevent accidental downgrades to an incompatible major.
- Stability flags: Removed `minimum-stability: RC` and `prefer-stable: true` - Composer defaults to stable, so these settings are unnecessary once all constraints target stable releases.

### `behat.yml`

- Message selectors: Migrated from the deprecated flat keys (`message_selector`, `error_message_selector`, `success_message_selector`, `warning_message_selector`) to the nested `selectors.messages.{default,error,success,warning}` map. The flat form still works in 6.0 but emits a deprecation notice and is removed in 6.1.

## Before / After

`composer.json`:

```
Before                                    After
─────────────────────────────────────     ─────────────────────────────────────
"require": {                              "require": {
  ...                                       ...
  "drupal/drupal-driver":                   "drupal/drupal-extension": "^6.0",
    "^3.0.0-RC2",                           ...
  "drupal/drupal-extension":              },
    "^6.0.0-RC2",                         "require-dev": { ... },
  ...                                     "conflict": {
},                                          "drupal/drupal-extension": "<6"
"require-dev": { ... },                   }
"minimum-stability": "RC",
"prefer-stable": true,
```

`behat.yml`:

```
Before                                    After
─────────────────────────────────────     ─────────────────────────────────────
selectors:                                selectors:
  message_selector: '.messages'             messages:
  error_message_selector:                     default: '.messages'
    '.messages.messages--error'               error:
  success_message_selector:                     '.messages.messages--error'
    '.messages.messages--status'              success:
  warning_message_selector:                     '.messages.messages--status'
    '.messages.messages--warning'             warning:
                                                '.messages.messages--warning'
```
