### PR TITLE
[#645] Fixed 'emailBeforeScenario' bootstrap ordering under 'drupal/drupal-extension' 6.x.

### DIFF
--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -61,6 +61,10 @@ trait EmailTrait {
       return;
     }
 
+    // Force the lazy 6.x driver to boot Drupal so '\Drupal::config()' below is
+    // safe regardless of hook ordering between traits.
+    $this->getDriver();
+
     if ($scope->getScenario()->hasTag('debug')) {
       $this->emailDebug = TRUE;
     }

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -49,7 +49,14 @@ trait BehatCliTrait {
       return;
     }
 
-    $this->behatCliWriteFeatureContextFile($traits);
+    // The generated 'FeatureContext.php' normally includes a 'bootstrapDrupal'
+    // workaround that primes the lazy 6.x driver before any trait hook runs.
+    // Scenarios tagged '@behat-cli-no-bootstrap' opt out of that workaround so
+    // a trait under test can be exercised in true isolation - useful for
+    // proving a trait bootstraps Drupal itself when its hooks call '\Drupal::'.
+    $bootstrap_workaround = !$scope->getScenario()->hasTag('behat-cli-no-bootstrap');
+
+    $this->behatCliWriteFeatureContextFile($traits, $bootstrap_workaround);
   }
 
   #[BeforeStep]
@@ -71,14 +78,21 @@ trait BehatCliTrait {
    *
    * @param array $traits
    *   Optional array of trait classes.
+   * @param bool $bootstrap_workaround
+   *   When TRUE (default), the generated context includes a 'bootstrapDrupal'
+   *   '@BeforeScenario @api' hook that primes the lazy 6.x driver. Pass FALSE
+   *   to omit that hook so a trait under test can be exercised in true
+   *   isolation - useful for proving a trait bootstraps Drupal itself when
+   *   its hooks call '\Drupal::' before any step runs.
    *
    * @return string
    *   Path to written file.
    */
-  public function behatCliWriteFeatureContextFile(array $traits = []): string {
+  public function behatCliWriteFeatureContextFile(array $traits = [], bool $bootstrap_workaround = TRUE): string {
     $tokens = [
       '{{USE_DECLARATION}}' => '',
       '{{USE_IN_CLASS}}' => '',
+      '{{BOOTSTRAP_METHOD}}' => '',
     ];
     foreach ($traits as $trait) {
       // Check if trait contains slash to determine if it's in a subdirectory.
@@ -138,16 +152,8 @@ trait BehatCliTrait {
       $tokens['{{USE_IN_CLASS}}'] .= sprintf('use %s;' . PHP_EOL, $trait_name);
     }
 
-    $content = <<<'EOL'
-<?php
-
-use Drupal\DrupalExtension\Context\DrupalContext;
-{{USE_DECLARATION}}
-
-class FeatureContext extends DrupalContext {
-  {{USE_IN_CLASS}}
-
-  use FeatureContextTrait;
+    if ($bootstrap_workaround) {
+      $tokens['{{BOOTSTRAP_METHOD}}'] = <<<'EOL'
 
   /**
    * Force Drupal bootstrap before any @api scenario step runs.
@@ -163,6 +169,20 @@ class FeatureContext extends DrupalContext {
     $this->getDriver();
   }
 
+EOL;
+    }
+
+    $content = <<<'EOL'
+<?php
+
+use Drupal\DrupalExtension\Context\DrupalContext;
+{{USE_DECLARATION}}
+
+class FeatureContext extends DrupalContext {
+  {{USE_IN_CLASS}}
+
+  use FeatureContextTrait;
+{{BOOTSTRAP_METHOD}}
   /**
    * @Given I throw test exception with message :message
    */

--- a/tests/behat/features/drupal_email.feature
+++ b/tests/behat/features/drupal_email.feature
@@ -689,6 +689,20 @@ Feature: Check that EmailTrait works
     When I run "behat --no-colors"
     Then it should pass
 
+  @trait:Drupal\EmailTrait @behat-cli-no-bootstrap
+  Scenario: Assert that EmailTrait boots the Drupal kernel itself when used in isolation
+    Given some behat configuration
+    And scenario steps tagged with "@api @email":
+      """
+      When I send test email to "test@example.com" with:
+        '''
+        Test content
+        '''
+      Then an email should be sent to the "test@example.com"
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
   @api @email @email:default
   Scenario: As a developer, I want to verify custom email handler type tag is processed
     When I send test email to "test@example.com" with:


### PR DESCRIPTION
Closes #645

## Summary

`EmailTrait::emailBeforeScenario()` calls `\Drupal::config()` (via `emailEnableTestSystem()` → `emailGetMailSystemDefault()`) before the Drupal kernel is guaranteed to be booted. Under `drupal/drupal-extension` 6.x the driver bootstraps lazily inside `getDriver()`, and Behat does not guarantee ordering between `BeforeScenario` hooks on different traits. On any scenario tagged `@api @email`, if the email hook fires before another trait triggers the bootstrap, the first `\Drupal::config()` call throws `Drupal\Core\DependencyInjection\ContainerNotInitializedException` and the scenario fails before its first step.

The fix is one line: call `$this->getDriver()` at the top of `emailBeforeScenario()` (after the existing tag guards) to prime the lazy bootstrap. This matches the pattern documented in `OverrideTrait::overrideBootstrapDrupal()` and removes the need for consumers to monkey-patch the hook in their own `FeatureContext`.

## Changes

### `src/Drupal/EmailTrait.php`

Added `$this->getDriver();` in `emailBeforeScenario()` after the `behat-steps-skip` and `@email` tag guards, with a code comment explaining the lazy-bootstrap reason. The call is idempotent — when the kernel is already booted by another trait's hook, it is a no-op.

### `tests/behat/bootstrap/BehatCliTrait.php`

The generated `FeatureContext.php` template used by `@trait:` subprocess scenarios includes a `bootstrapDrupal()` workaround method that primes the lazy driver. That workaround was silently masking the bug in `EmailTrait` (and the same bug latent in other traits whose hooks call `\Drupal::`). Extracted the workaround into a `{{BOOTSTRAP_METHOD}}` template token, gated on a new `bool $bootstrap_workaround = TRUE` parameter on `behatCliWriteFeatureContextFile()`. Default is `TRUE` so every existing `@trait:` scenario behaves identically.

Added a tag scan in `behatCliBeforeScenario()`: scenarios tagged `@behat-cli-no-bootstrap` cause the generated context to omit the workaround, allowing a trait to be exercised in true isolation.

### `tests/behat/features/drupal_email.feature`

Added one regression scenario tagged `@trait:Drupal\EmailTrait @behat-cli-no-bootstrap` that runs an `@api @email` inner subprocess and asserts it passes. Before the fix the scenario fails with `\Drupal::$container is not initialized yet. \Drupal::setContainer() must be called with a real container. (Drupal\Core\DependencyInjection\ContainerNotInitializedException)` reported on the `FeatureContext::emailBeforeScenario()` hook. After the fix the scenario passes.

## Before / After

```
BEFORE:                                       AFTER:

@api @email scenario                          @api @email scenario
       │                                             │
       ▼                                             ▼
EmailTrait::emailBeforeScenario               EmailTrait::emailBeforeScenario
       │                                             │
       │ (no bootstrap call)                         │ $this->getDriver()
       ▼                                             │  ───► kernel booted
\Drupal::config('system.mail')                       ▼
       │                                      \Drupal::config('system.mail')
       ▼                                             │
ContainerNotInitializedException ✗                   ▼
                                              test_mail_collector enabled ✓
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a race condition in `EmailTrait::emailBeforeScenario()` under drupal/drupal-extension 6.x, where the method could call `\Drupal::config()` before the Drupal kernel was guaranteed to be booted. The fix ensures the lazy-loading 6.x driver is primed by calling `$this->getDriver()` at the start of the hook (after existing tag guards), making the trait self-sufficient when used in isolation.

## Changes

**src/Drupal/EmailTrait.php**
- Added `$this->getDriver()` call in `emailBeforeScenario()` (line 66) to force Drupal bootstrap before `\Drupal::config()` is accessed
- The call is placed after existing scenario tag guards and is idempotent
- Includes explanatory comment about lazy 6.x driver bootstrap behavior

**tests/behat/bootstrap/BehatCliTrait.php**
- Updated `behatCliBeforeScenario()` to detect the `@behat-cli-no-bootstrap` tag and pass a `$bootstrap_workaround` boolean flag
- Extended `behatCliWriteFeatureContextFile()` signature: added `bool $bootstrap_workaround = TRUE` parameter
- When `$bootstrap_workaround` is enabled (default), the generated FeatureContext template includes a `bootstrapDrupal()` method annotated with `#[BeforeScenario `@api`]` that calls `$this->getDriver()`
- When disabled (via `@behat-cli-no-bootstrap` tag), the workaround is omitted to test traits in isolation
- Implemented via `{{BOOTSTRAP_METHOD}}` token replacement in the template

**tests/behat/features/drupal_email.feature**
- Added regression scenario (lines 692-704) tagged with `@trait:Drupal\EmailTrait` and `@behat-cli-no-bootstrap`
- Scenario verifies that EmailTrait bootstraps the Drupal kernel itself when used in isolation by running an `@api `@email`` inner subprocess
- Uses only existing step definitions; no new steps added
- Asserts the subprocess scenario passes

## Acceptance Criteria Met

✓ EmailTrait::emailBeforeScenario() calls $this->getDriver() after tag guards  
✓ `@api` `@email` scenarios run standalone without depending on other traits for bootstrap  
✓ getDriver() call is idempotent  
✓ Regression test exercises the trait in isolation  
✓ Generated FeatureContext template supports bootstrap workaround omission via `@behat-cli-no-bootstrap` tag  

## Code Quality

- No violations of CONTRIBUTING.md step definition rules (no new step definitions introduced)
- No alterations to exported or public entity signatures (only method parameter additions with defaults)
- Total changes: +50 lines, -12 lines across three files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->