### PR TITLE
[#646] Added focus assertions to 'ElementTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -527,6 +527,62 @@ Then the element "#content" should be centered in the viewport
 </details>
 
 <details>
+  <summary><code>@Then the element :selector should have keyboard focus</code></summary>
+
+<br/>
+Assert that the element has keyboard focus
+<br/><br/>
+
+```gherkin
+Then the element "#edit-name" should have keyboard focus
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector should not have keyboard focus</code></summary>
+
+<br/>
+Assert that the element does not have keyboard focus
+<br/><br/>
+
+```gherkin
+Then the element "#edit-name" should not have keyboard focus
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector should have a visible focus outline</code></summary>
+
+<br/>
+Assert that the element has a visible focus indicator
+<br/><br/>
+
+```gherkin
+Then the element "#edit-name" should have a visible focus outline
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector should not have a visible focus outline</code></summary>
+
+<br/>
+Assert that the element does not have a visible focus indicator
+<br/><br/>
+
+```gherkin
+Then the element "#decorative-icon" should not have a visible focus outline
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the element :selector should be displayed</code></summary>
 
 <br/>

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -380,6 +380,158 @@ trait ElementTrait {
   }
 
   /**
+   * Assert that the element has keyboard focus.
+   *
+   * Verifies that the element matched by the selector is the current
+   * `document.activeElement`. This is the canonical check for tab-order tests,
+   * skip-link behaviour, modal focus traps, autofocus, and focus-after-action
+   * flows.
+   *
+   * @code
+   * Then the element "#edit-name" should have keyboard focus
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should have keyboard focus')]
+  public function elementAssertHasKeyboardFocus(string $selector): void {
+    $this->elementAssertKeyboardFocus($selector, FALSE);
+  }
+
+  /**
+   * Assert that the element does not have keyboard focus.
+   *
+   * @code
+   * Then the element "#edit-name" should not have keyboard focus
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should not have keyboard focus')]
+  public function elementAssertNotHasKeyboardFocus(string $selector): void {
+    $this->elementAssertKeyboardFocus($selector, TRUE);
+  }
+
+  /**
+   * Assert that the element has a visible focus indicator.
+   *
+   * Verifies that the element renders a visible focus indicator via either
+   * a CSS outline (non-`none` outline-style with a width greater than 0) or
+   * a non-`none` box-shadow. Guards WCAG 2.4.7 (Focus Visible) and catches
+   * accidental `outline: none` regressions introduced by stylesheet changes.
+   *
+   * @code
+   * Then the element "#edit-name" should have a visible focus outline
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should have a visible focus outline')]
+  public function elementAssertHasVisibleFocusOutline(string $selector): void {
+    $this->elementAssertVisibleFocusOutline($selector, FALSE);
+  }
+
+  /**
+   * Assert that the element does not have a visible focus indicator.
+   *
+   * @code
+   * Then the element "#decorative-icon" should not have a visible focus outline
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should not have a visible focus outline')]
+  public function elementAssertNotHasVisibleFocusOutline(string $selector): void {
+    $this->elementAssertVisibleFocusOutline($selector, TRUE);
+  }
+
+  /**
+   * Assert keyboard focus state for an element.
+   *
+   * @param string $selector
+   *   The CSS selector.
+   * @param bool $is_inverted
+   *   Whether to assert that the element does not have keyboard focus.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  protected function elementAssertKeyboardFocus(string $selector, bool $is_inverted): void {
+    $element = $this->getSession()->getPage()->find('css', $selector);
+
+    if (!$element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    $script = <<<JS
+      if ({{ELEMENT}} === document.activeElement) {
+        return '__OK__';
+      }
+      if (!document.activeElement || document.activeElement === document.body) {
+        return '__NONE__';
+      }
+      return document.activeElement.outerHTML.substring(0, 200);
+JS;
+    $result = (string) $this->elementExecuteJs($selector, $script);
+
+    if (!$is_inverted) {
+      if ($result === '__OK__') {
+        return;
+      }
+
+      $message = $result === '__NONE__'
+        ? sprintf('Expected element "%s" to have keyboard focus, but no element is focused.', $selector)
+        : sprintf('Expected element "%s" to have keyboard focus, but focus is on: %s', $selector, $result);
+      throw new ExpectationException($message, $this->getSession()->getDriver());
+    }
+
+    if ($result === '__OK__') {
+      throw new ExpectationException(sprintf('Expected element "%s" to not have keyboard focus, but it does.', $selector), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert visible focus indicator state for an element.
+   *
+   * An element is considered to have a visible focus indicator when either
+   * its computed outline has a non-`none` style with a width greater than 0,
+   * or its computed box-shadow is not `none`.
+   *
+   * @param string $selector
+   *   The CSS selector.
+   * @param bool $is_inverted
+   *   Whether to assert that the element does not have a visible focus
+   *   indicator.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  protected function elementAssertVisibleFocusOutline(string $selector, bool $is_inverted): void {
+    $element = $this->getSession()->getPage()->find('css', $selector);
+
+    if (!$element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    $script = <<<JS
+      var s = window.getComputedStyle({{ELEMENT}});
+      return s.outlineStyle + '|' + s.outlineWidth + '|' + s.boxShadow;
+JS;
+    $result = (string) $this->elementExecuteJs($selector, $script);
+    [$outline_style, $outline_width, $box_shadow] = explode('|', $result, 3);
+
+    $has_outline = $outline_style !== 'none' && (float) $outline_width > 0;
+    $has_shadow = $box_shadow !== 'none' && $box_shadow !== '';
+    $is_visible = $has_outline || $has_shadow;
+
+    if (!$is_inverted && !$is_visible) {
+      throw new ExpectationException(sprintf('Expected element "%s" to have a visible focus outline, but outline-style is "%s", outline-width is "%s", box-shadow is "%s".', $selector, $outline_style, $outline_width, $box_shadow), $this->getSession()->getDriver());
+    }
+
+    if ($is_inverted && $is_visible) {
+      throw new ExpectationException(sprintf('Expected element "%s" to not have a visible focus outline, but outline-style is "%s", outline-width is "%s", box-shadow is "%s".', $selector, $outline_style, $outline_width, $box_shadow), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
    * Assert that element with specified CSS is visible on page.
    *
    * @code

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -497,6 +497,134 @@ Feature: Check that ElementTrait works
       Element matching css "#nonexistent-element" not found.
       """
 
+  @javascript
+  Scenario: Assert "Then the element :selector should have keyboard focus" and its negative form work as expected
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements.html"
+    And I focus on the element "#focus-input"
+    Then the element "#focus-input" should have keyboard focus
+    And the element "#focus-button-outline" should not have keyboard focus
+
+  @javascript
+  Scenario: Assert "Then the element :selector should have a visible focus outline" passes for an element with a CSS outline
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements.html"
+    Then the element "#focus-button-outline" should have a visible focus outline
+    And the element "#focus-button-no-outline" should not have a visible focus outline
+
+  @javascript
+  Scenario: Assert "Then the element :selector should have a visible focus outline" passes for an element using box-shadow as the indicator
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements.html"
+    Then the element "#focus-button-shadow" should have a visible focus outline
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should have keyboard focus" fails when the element does not exist
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements.html"
+      Then the element "#nonexistent-element" should have keyboard focus
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css "#nonexistent-element" not found.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should have keyboard focus" fails when a different element is focused
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements.html"
+      And I focus on the element "#focus-input"
+      Then the element "#focus-button-outline" should have keyboard focus
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#focus-button-outline" to have keyboard focus, but focus is on:
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should have keyboard focus" fails when no element is focused
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements.html"
+      Then the element "#focus-input" should have keyboard focus
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#focus-input" to have keyboard focus, but no element is focused.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should not have keyboard focus" fails when the element is focused
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements.html"
+      And I focus on the element "#focus-input"
+      Then the element "#focus-input" should not have keyboard focus
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#focus-input" to not have keyboard focus, but it does.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should have a visible focus outline" fails when the element does not exist
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements.html"
+      Then the element "#nonexistent-element" should have a visible focus outline
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css "#nonexistent-element" not found.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should have a visible focus outline" fails when the element has no visible indicator
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements.html"
+      Then the element "#focus-button-no-outline" should have a visible focus outline
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#focus-button-no-outline" to have a visible focus outline, but outline-style is "none"
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should not have a visible focus outline" fails when the element has an outline
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements.html"
+      Then the element "#focus-button-outline" should not have a visible focus outline
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#focus-button-outline" to not have a visible focus outline, but outline-style is "solid"
+      """
+
   @javascript @phpserver
   Scenario: Assert click on element works
     Given I am on the phpserver test page

--- a/tests/behat/fixtures/elements.html
+++ b/tests/behat/fixtures/elements.html
@@ -70,6 +70,9 @@
   <div class="section">
     <h2>Focus Testing</h2>
     <input id="focus-input" type="text" placeholder="Focus me" onfocus="this.setAttribute('data-focused', 'true')">
+    <button id="focus-button-outline" type="button" style="outline: 2px solid blue; box-shadow: none;">Outlined button</button>
+    <button id="focus-button-shadow" type="button" style="outline: none; box-shadow: 0 0 0 2px rgb(0, 0, 255);">Shadow button</button>
+    <button id="focus-button-no-outline" type="button" style="outline: none; box-shadow: none;">No outline button</button>
   </div>
 
   <!-- Section: Hover Testing -->


### PR DESCRIPTION
Closes #646

## Summary

Added four focus-related assertions to `ElementTrait`: two for keyboard focus (`should have keyboard focus` / `should not have keyboard focus`) and two for visible focus indicators (`should have a visible focus outline` / `should not have a visible focus outline`). The keyboard-focus check tests whether an element is the current `document.activeElement`; the outline check inspects computed `outline-style`, `outline-width`, and `box-shadow` to catch WCAG 2.4.7 (Focus Visible) regressions. Both pairs delegate to a shared protected helper with an `$is_inverted` flag, following the same DRY pattern used by `elementAssertAttributeWithValue`. Three fixture buttons were added to `elements.html` to exercise all three CSS states (outline, box-shadow, none), and ten new Behat scenarios cover every positive path and error branch.

## Changes

**`src/ElementTrait.php`**
- Added `elementAssertHasKeyboardFocus()` and `elementAssertNotHasKeyboardFocus()` — public step methods that delegate to `elementAssertKeyboardFocus()`.
- Added `elementAssertHasVisibleFocusOutline()` and `elementAssertNotHasVisibleFocusOutline()` — public step methods that delegate to `elementAssertVisibleFocusOutline()`.
- Added `elementAssertKeyboardFocus()` — protected helper; returns `__OK__`, `__NONE__`, or the focused element's outer HTML to build context-rich failure messages.
- Added `elementAssertVisibleFocusOutline()` — protected helper; reads `outline-style`, `outline-width`, and `box-shadow` via `getComputedStyle` and considers an element visible when either the outline or box-shadow is non-`none`.

**`tests/behat/fixtures/elements.html`**
- Added `#focus-button-outline` (CSS outline), `#focus-button-shadow` (box-shadow indicator), and `#focus-button-no-outline` (no visible indicator) to the Focus Testing section.

**`tests/behat/features/element.feature`**
- Added 3 `@javascript` positive scenarios covering focus detection, outline detection, and box-shadow detection.
- Added 7 `@trait:ElementTrait` negative scenarios covering: missing element (both step types), wrong element focused, no element focused, element unexpectedly focused, missing element for outline, no outline when expected, outline present when not expected.

**`STEPS.md`**
- Regenerated to include documentation for all four new step definitions.

## Before / After

```
Before (ElementTrait public step surface, focus section):

  elementFocusOnElement()          @When  the element :selector gets focus

After (ElementTrait public step surface, focus section):

  elementFocusOnElement()                  @When  the element :selector gets focus
  elementAssertHasKeyboardFocus()          @Then  the element :selector should have keyboard focus
  elementAssertNotHasKeyboardFocus()       @Then  the element :selector should not have keyboard focus
  elementAssertHasVisibleFocusOutline()    @Then  the element :selector should have a visible focus outline
  elementAssertNotHasVisibleFocusOutline() @Then  the element :selector should not have a visible focus outline
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Added four public step methods to `ElementTrait` for asserting keyboard focus and visible focus outline states on DOM elements. These steps provide WCAG 2.4.7 (Focus Visible) validation capabilities to prevent accidental `outline: none` regressions.

## Changes

### Core Implementation (`src/ElementTrait.php`, +152 lines)

**Public step methods:**
- `elementAssertHasKeyboardFocus(string $selector)` — Step: `Then the element :selector should have keyboard focus`
- `elementAssertNotHasKeyboardFocus(string $selector)` — Step: `Then the element :selector should not have keyboard focus`
- `elementAssertHasVisibleFocusOutline(string $selector)` — Step: `Then the element :selector should have a visible focus outline`
- `elementAssertNotHasVisibleFocusOutline(string $selector)` — Step: `Then the element :selector should not have a visible focus outline`

**Protected helper methods:**
- `elementAssertKeyboardFocus(string $selector, bool $is_inverted)` — Verifies element matches `document.activeElement`. Returns `__OK__`, `__NONE__` (no focused element), or focused element's truncated outerHTML (first 200 chars) for failure messages. Throws `ElementNotFoundException` if selector matches no elements; `ExpectationException` on assertion failure.
- `elementAssertVisibleFocusOutline(string $selector, bool $is_inverted)` — Checks computed style `outline-style`, `outline-width`, and `box-shadow`. Considers element visible when outline is non-`none` with width > 0, or box-shadow is non-`none`. Throws same exceptions as keyboard focus helper.

All methods follow step definition guidelines: use tuple format (`#[Then(...)]`), start with `element`, include `Assert` prefix, use `should`/`should not` in step text, and start step with entity being asserted.

### Feature Tests (`tests/behat/features/element.feature`, +128 lines)

**Positive scenarios** (`@javascript`):
- Keyboard focus detection: verify focused and non-focused elements
- CSS outline detection: verify element with outline-style
- Box-shadow detection: verify element with box-shadow focus ring

**Negative scenarios** (`@trait`:ElementTrait):
- Keyboard focus: element not found, wrong element focused, no element focused, element incorrectly asserted as unfocused
- Visible outline: element not found, no visible indicator present, outline incorrectly asserted as absent

### Test Fixtures (`tests/behat/fixtures/elements.html`, +3 lines)

Extended Focus Testing section with three button elements:
- `#focus-button-outline` — inline style with `outline: 2px solid blue`
- `#focus-button-shadow` — inline style with `box-shadow: 0 0 0 2px rgb(0, 0, 255)` and `outline: none`
- `#focus-button-no-outline` — inline style with both `outline: none` and `box-shadow: none`

### Documentation (`STEPS.md`, +56 lines)

Updated ElementTrait section to document the four new step definitions with parameter and execution context details.

## Compliance

All step definitions follow CONTRIBUTING.md guidelines:
- ✓ Use tuple format annotations instead of regex
- ✓ Method names begin with trait name (`element`) and include `Assert` prefix
- ✓ Step text uses `should`/`should not` and starts with entity being asserted
- ✓ Use existing `elementExecuteJs()` infrastructure
- ✓ Throw `ElementNotFoundException` for missing selectors, `ExpectationException` for assertion failures
- ✓ Descriptive placeholder name (`:selector`) used consistently

<!-- end of auto-generated comment: release notes by coderabbit.ai -->