### PR TITLE
[#648] Added 'RedirectTrait' for managing and asserting 'redirect' module entities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ from the community.
 | [Drupal\OverrideTrait](STEPS.md#drupaloverridetrait) | Override Drupal Extension behaviors. |
 | [Drupal\ParagraphsTrait](STEPS.md#drupalparagraphstrait) | Manage Drupal paragraphs entities with structured field data. |
 | [Drupal\QueueTrait](STEPS.md#drupalqueuetrait) | Manage and assert Drupal queue state. |
+| [Drupal\RedirectTrait](STEPS.md#drupalredirecttrait) | Manage Drupal redirect entities provided by the contrib `redirect` module. |
 | [Drupal\SearchApiTrait](STEPS.md#drupalsearchapitrait) | Assert Drupal Search API with index and query operations. |
 | [Drupal\StateTrait](STEPS.md#drupalstatetrait) | Manage and assert Drupal State API values with automatic revert. |
 | [Drupal\TaxonomyTrait](STEPS.md#drupaltaxonomytrait) | Manage Drupal taxonomy terms with vocabulary organization. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -43,6 +43,7 @@
 | [Drupal\OverrideTrait](#drupaloverridetrait) | Override Drupal Extension behaviors. |
 | [Drupal\ParagraphsTrait](#drupalparagraphstrait) | Manage Drupal paragraphs entities with structured field data. |
 | [Drupal\QueueTrait](#drupalqueuetrait) | Manage and assert Drupal queue state. |
+| [Drupal\RedirectTrait](#drupalredirecttrait) | Manage Drupal redirect entities provided by the contrib `redirect` module. |
 | [Drupal\SearchApiTrait](#drupalsearchapitrait) | Assert Drupal Search API with index and query operations. |
 | [Drupal\StateTrait](#drupalstatetrait) | Manage and assert Drupal State API values with automatic revert. |
 | [Drupal\TaxonomyTrait](#drupaltaxonomytrait) | Manage Drupal taxonomy terms with vocabulary organization. |
@@ -4241,6 +4242,55 @@ Assert that a queue is empty
 
 ```gherkin
 Then the "myqueue" queue should be empty
+
+```
+
+</details>
+
+## Drupal\RedirectTrait
+
+[Source](src/Drupal/RedirectTrait.php), [Example](tests/behat/features/drupal_redirect.feature)
+
+>  Manage Drupal redirect entities provided by the contrib `redirect` module.
+>  - Create one or more redirects from a table of source/destination/status.
+>  - Delete redirects by source path.
+>  - Automatically clean up created redirects after scenario completion.
+>  
+>  Requires the `redirect` module to be enabled (tag scenarios with
+>  `@module:redirect` or enable it as part of project setup).
+>  <br/><br/>
+>  Skip processing with tag: `@behat-steps-skip:redirectAfterScenario`
+
+
+<details>
+  <summary><code>@Given the following redirects exist:</code></summary>
+
+<br/>
+Create one or more redirects
+<br/><br/>
+
+```gherkin
+Given the following redirects exist:
+  | from              | to                        | status_code |
+  | /old/about        | /about                    | 301         |
+  | /promo            | https://example.com/promo | 302         |
+  | /legacy/contact   | /contact                  |             |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the following redirects do not exist:</code></summary>
+
+<br/>
+Delete redirects by source path
+<br/><br/>
+
+```gherkin
+Given the following redirects do not exist:
+  | /old/about      |
+  | /legacy/contact |
 
 ```
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -4256,11 +4256,9 @@ Then the "myqueue" queue should be empty
 >  - Delete redirects by source path.
 >  - Automatically clean up created redirects after scenario completion.
 >  
->  Requires the `redirect` module to be enabled. Tag scenarios with
->  `@module:redirect` to enable it automatically per scenario - this works only
->  when `ModuleTrait` (or an equivalent `BeforeScenario` handler that processes
->  `module:*` tags) is also included in the Behat context. Alternatively, enable
->  the module as part of the project's base setup.
+>  Requires the `redirect` contrib module to be installed and enabled in the
+>  consumer project: add `drupal/redirect` to `composer.json` and enable the
+>  module as part of the site's standard setup (e.g. in `core.extension.yml`).
 >  <br/><br/>
 >  Skip processing with tag: `@behat-steps-skip:redirectAfterScenario`
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -4256,8 +4256,11 @@ Then the "myqueue" queue should be empty
 >  - Delete redirects by source path.
 >  - Automatically clean up created redirects after scenario completion.
 >  
->  Requires the `redirect` module to be enabled (tag scenarios with
->  `@module:redirect` or enable it as part of project setup).
+>  Requires the `redirect` module to be enabled. Tag scenarios with
+>  `@module:redirect` to enable it automatically per scenario - this works only
+>  when `ModuleTrait` (or an equivalent `BeforeScenario` handler that processes
+>  `module:*` tags) is also included in the Behat context. Alternatively, enable
+>  the module as part of the project's base setup.
 >  <br/><br/>
 >  Skip processing with tag: `@behat-steps-skip:redirectAfterScenario`
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -4254,6 +4254,7 @@ Then the "myqueue" queue should be empty
 >  Manage Drupal redirect entities provided by the contrib `redirect` module.
 >  - Create one or more redirects from a table of source/destination/status.
 >  - Delete redirects by source path.
+>  - Assert that redirects do or do not exist for given source paths.
 >  - Automatically clean up created redirects after scenario completion.
 >  
 >  Requires the `redirect` contrib module to be installed and enabled in the
@@ -4290,6 +4291,40 @@ Delete redirects by source path
 
 ```gherkin
 Given the following redirects do not exist:
+  | /old/about      |
+  | /legacy/contact |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the following redirects should exist:</code></summary>
+
+<br/>
+Assert that one or more redirects exist
+<br/><br/>
+
+```gherkin
+Then the following redirects should exist:
+  | from              | to                        | status_code |
+  | /old/about        | /about                    | 301         |
+  | /promo            | https://example.com/promo |             |
+  | /legacy/contact   |                           |             |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the following redirects should not exist:</code></summary>
+
+<br/>
+Assert that no redirect exists for one or more source paths
+<br/><br/>
+
+```gherkin
+Then the following redirects should not exist:
   | /old/about      |
   | /legacy/contact |
 

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -17,11 +17,9 @@ use Drupal\redirect\Entity\Redirect;
  * - Delete redirects by source path.
  * - Automatically clean up created redirects after scenario completion.
  *
- * Requires the `redirect` module to be enabled. Tag scenarios with
- * `@module:redirect` to enable it automatically per scenario - this works only
- * when `ModuleTrait` (or an equivalent `BeforeScenario` handler that processes
- * `module:*` tags) is also included in the Behat context. Alternatively, enable
- * the module as part of the project's base setup.
+ * Requires the `redirect` contrib module to be installed and enabled in the
+ * consumer project: add `drupal/redirect` to `composer.json` and enable the
+ * module as part of the site's standard setup (e.g. in `core.extension.yml`).
  *
  * Skip processing with tag: `@behat-steps-skip:redirectAfterScenario`
  */
@@ -174,7 +172,7 @@ trait RedirectTrait {
   protected function redirectAssertModuleEnabled(): void {
     // @codeCoverageIgnoreStart
     if (!\Drupal::moduleHandler()->moduleExists('redirect')) {
-      throw new \RuntimeException('The "redirect" module is not enabled. Enable it for scenarios that use RedirectTrait steps (e.g. tag the scenario with "@module:redirect").');
+      throw new \RuntimeException('The "redirect" module is not enabled. Add "drupal/redirect" to the consumer project\'s composer.json and enable the module as part of the site setup.');
     }
     // @codeCoverageIgnoreEnd
   }

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -8,6 +8,8 @@ use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Hook\AfterScenario;
 use Behat\Step\Given;
+use Behat\Step\Then;
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\redirect\Entity\Redirect;
 
 /**
@@ -15,6 +17,7 @@ use Drupal\redirect\Entity\Redirect;
  *
  * - Create one or more redirects from a table of source/destination/status.
  * - Delete redirects by source path.
+ * - Assert that redirects do or do not exist for given source paths.
  * - Automatically clean up created redirects after scenario completion.
  *
  * Requires the `redirect` contrib module to be installed and enabled in the
@@ -110,11 +113,11 @@ trait RedirectTrait {
     $storage = \Drupal::entityTypeManager()->getStorage('redirect');
 
     foreach ($table->getColumn(0) as $path) {
-      $path = ltrim(trim((string) $path), '/');
+      $source = $this->redirectNormalizeSource($path);
 
       $ids = $storage->getQuery()
         ->accessCheck(FALSE)
-        ->condition('redirect_source.path', $path)
+        ->condition('redirect_source.path', $source)
         ->execute();
 
       if (empty($ids)) {
@@ -131,6 +134,107 @@ trait RedirectTrait {
         $this->redirects,
         fn(Redirect $redirect): bool => !in_array((int) $redirect->id(), $deleted_ids, TRUE),
       ));
+    }
+  }
+
+  /**
+   * Assert that one or more redirects exist.
+   *
+   * Provide redirect data in the following format:
+   *
+   * | from              | to                        | status_code |
+   * | /old/about        | /about                    | 301         |
+   * | /promo            | https://example.com/promo |             |
+   * | /legacy/contact   |                           |             |
+   *
+   * The `from` column is required. The `to` and `status_code` columns are
+   * optional: when blank or omitted, only the source path is matched. When
+   * `to` is provided, internal paths (`/about`) are normalised to
+   * `internal:/about` to match the storage format. When `status_code` is
+   * provided, it is validated against the allowed set (301, 302, 303, 307,
+   * 308).
+   *
+   * @code
+   * Then the following redirects should exist:
+   *   | from              | to                        | status_code |
+   *   | /old/about        | /about                    | 301         |
+   *   | /promo            | https://example.com/promo |             |
+   *   | /legacy/contact   |                           |             |
+   * @endcode
+   */
+  #[Then('the following redirects should exist:')]
+  public function redirectAssertExist(TableNode $table): void {
+    $this->redirectAssertModuleEnabled();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('redirect');
+    $missing = [];
+
+    foreach ($table->getHash() as $row) {
+      $from = isset($row['from']) ? trim($row['from']) : '';
+
+      if ($from === '') {
+        throw new \RuntimeException('Each redirect row must define a non-empty "from" path.');
+      }
+
+      $query = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('redirect_source.path', $this->redirectNormalizeSource($from));
+
+      $to = isset($row['to']) ? trim($row['to']) : '';
+      if ($to !== '') {
+        $query->condition('redirect_redirect.uri', $this->redirectNormalizeDestination($to));
+      }
+
+      $status_code_raw = isset($row['status_code']) ? trim($row['status_code']) : '';
+      if ($status_code_raw !== '') {
+        $query->condition('status_code', $this->redirectNormalizeStatusCode($status_code_raw));
+      }
+
+      $ids = $query->execute();
+
+      if (empty($ids)) {
+        $missing[] = $this->redirectFormatRow($from, $to, $status_code_raw);
+      }
+    }
+
+    if ($missing !== []) {
+      throw new \Exception(sprintf('The following redirects should exist but were not found: %s.', implode(', ', $missing)));
+    }
+  }
+
+  /**
+   * Assert that no redirect exists for one or more source paths.
+   *
+   * Provide one source path per row.
+   *
+   * @code
+   * Then the following redirects should not exist:
+   *   | /old/about      |
+   *   | /legacy/contact |
+   * @endcode
+   */
+  #[Then('the following redirects should not exist:')]
+  public function redirectAssertNotExist(TableNode $table): void {
+    $this->redirectAssertModuleEnabled();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('redirect');
+    $present = [];
+
+    foreach ($table->getColumn(0) as $path) {
+      $source = $this->redirectNormalizeSource($path);
+
+      $ids = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('redirect_source.path', $source)
+        ->execute();
+
+      if (!empty($ids)) {
+        $present[] = sprintf('"%s"', $path);
+      }
+    }
+
+    if ($present !== []) {
+      throw new \Exception(sprintf('The following redirects should not exist but were found: %s.', implode(', ', $present)));
     }
   }
 
@@ -204,6 +308,45 @@ trait RedirectTrait {
     }
 
     return $status_code;
+  }
+
+  /**
+   * Normalise a source path the same way the `redirect` module stores it.
+   */
+  protected function redirectNormalizeSource(string $path): string {
+    return ltrim(trim($path), '/');
+  }
+
+  /**
+   * Normalise a destination URI the same way `Redirect::setRedirect()` does.
+   *
+   * Internal paths gain an `internal:/` prefix; external `http(s)://` URLs
+   * pass through unchanged. Values that already begin with `internal:` are
+   * returned as-is to avoid double-prefixing.
+   */
+  protected function redirectNormalizeDestination(string $uri): string {
+    if (str_starts_with($uri, 'internal:')) {
+      return $uri;
+    }
+
+    return UrlHelper::isExternal($uri) ? $uri : 'internal:/' . ltrim($uri, '/');
+  }
+
+  /**
+   * Format a redirect row for inclusion in an assertion failure message.
+   */
+  protected function redirectFormatRow(string $from, string $to, string $status_code): string {
+    $parts = [sprintf('from="%s"', $from)];
+
+    if ($to !== '') {
+      $parts[] = sprintf('to="%s"', $to);
+    }
+
+    if ($status_code !== '') {
+      $parts[] = sprintf('status_code=%s', $status_code);
+    }
+
+    return sprintf('{%s}', implode(', ', $parts));
   }
 
 }

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -17,8 +17,11 @@ use Drupal\redirect\Entity\Redirect;
  * - Delete redirects by source path.
  * - Automatically clean up created redirects after scenario completion.
  *
- * Requires the `redirect` module to be enabled (tag scenarios with
- * `@module:redirect` or enable it as part of project setup).
+ * Requires the `redirect` module to be enabled. Tag scenarios with
+ * `@module:redirect` to enable it automatically per scenario - this works only
+ * when `ModuleTrait` (or an equivalent `BeforeScenario` handler that processes
+ * `module:*` tags) is also included in the Behat context. Alternatively, enable
+ * the module as part of the project's base setup.
  *
  * Skip processing with tag: `@behat-steps-skip:redirectAfterScenario`
  */

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Drupal;
+
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Hook\AfterScenario;
+use Behat\Step\Given;
+use Drupal\redirect\Entity\Redirect;
+
+/**
+ * Manage Drupal redirect entities provided by the contrib `redirect` module.
+ *
+ * - Create one or more redirects from a table of source/destination/status.
+ * - Delete redirects by source path.
+ * - Automatically clean up created redirects after scenario completion.
+ *
+ * Requires the `redirect` module to be enabled (tag scenarios with
+ * `@module:redirect` or enable it as part of project setup).
+ *
+ * Skip processing with tag: `@behat-steps-skip:redirectAfterScenario`
+ */
+trait RedirectTrait {
+
+  /**
+   * Allowed HTTP status codes for redirects.
+   *
+   * @var int[]
+   */
+  protected static $redirectAllowedStatusCodes = [301, 302, 303, 307, 308];
+
+  /**
+   * Redirects created during a scenario.
+   *
+   * @var \Drupal\redirect\Entity\Redirect[]
+   */
+  protected $redirects = [];
+
+  /**
+   * Create one or more redirects.
+   *
+   * Provide redirect data in the following format:
+   *
+   * | from              | to                        | status_code |
+   * | /old/about        | /about                    | 301         |
+   * | /promo            | https://example.com/promo | 302         |
+   * | /legacy/contact   | /contact                  |             |
+   *
+   * The `status_code` column is optional and defaults to `301` when omitted
+   * or left blank. Allowed values: 301, 302, 303, 307, 308.
+   *
+   * Destinations may be internal paths (`/about`) or external URLs
+   * (`https://example.com/promo`). Internal paths are stored as
+   * `internal:/about` so the `redirect` module routes them correctly.
+   *
+   * @code
+   * Given the following redirects exist:
+   *   | from              | to                        | status_code |
+   *   | /old/about        | /about                    | 301         |
+   *   | /promo            | https://example.com/promo | 302         |
+   *   | /legacy/contact   | /contact                  |             |
+   * @endcode
+   */
+  #[Given('the following redirects exist:')]
+  public function redirectCreate(TableNode $table): void {
+    $this->redirectAssertModuleEnabled();
+
+    foreach ($table->getHash() as $row) {
+      $from = isset($row['from']) ? trim($row['from']) : '';
+      $to = isset($row['to']) ? trim($row['to']) : '';
+
+      if ($from === '') {
+        throw new \RuntimeException('Each redirect row must define a non-empty "from" path.');
+      }
+
+      if ($to === '') {
+        throw new \RuntimeException(sprintf('Redirect from "%s" is missing a non-empty "to" value.', $from));
+      }
+
+      $status_code = $this->redirectNormalizeStatusCode($row['status_code'] ?? NULL);
+
+      $redirect = Redirect::create(['status_code' => $status_code]);
+      $redirect->setSource($from);
+      $redirect->setRedirect($to);
+      $redirect->save();
+
+      $this->redirects[] = $redirect;
+    }
+  }
+
+  /**
+   * Delete redirects by source path.
+   *
+   * Provide one source path per row. Rows that match no existing redirect are
+   * silently skipped.
+   *
+   * @code
+   * Given the following redirects do not exist:
+   *   | /old/about      |
+   *   | /legacy/contact |
+   * @endcode
+   */
+  #[Given('the following redirects do not exist:')]
+  public function redirectDelete(TableNode $table): void {
+    $this->redirectAssertModuleEnabled();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('redirect');
+
+    foreach ($table->getColumn(0) as $path) {
+      $path = ltrim(trim((string) $path), '/');
+
+      $ids = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('redirect_source.path', $path)
+        ->execute();
+
+      if (empty($ids)) {
+        continue;
+      }
+
+      $entities = $storage->loadMultiple($ids);
+      $storage->delete($entities);
+
+      // Drop any cleanup references for the just-deleted redirects so the
+      // after-scenario hook does not attempt to delete them again.
+      $deleted_ids = array_map(intval(...), array_keys($entities));
+      $this->redirects = array_values(array_filter(
+        $this->redirects,
+        fn(Redirect $redirect): bool => !in_array((int) $redirect->id(), $deleted_ids, TRUE),
+      ));
+    }
+  }
+
+  /**
+   * Remove all created redirects after scenario run.
+   */
+  #[AfterScenario('@api')]
+  public function redirectAfterScenario(AfterScenarioScope $scope): void {
+    // @codeCoverageIgnoreStart
+    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+    // @codeCoverageIgnoreEnd
+    if (empty($this->redirects)) {
+      return;
+    }
+
+    // @codeCoverageIgnoreStart
+    if (!\Drupal::moduleHandler()->moduleExists('redirect')) {
+      $this->redirects = [];
+
+      return;
+    }
+    // @codeCoverageIgnoreEnd
+    $storage = \Drupal::entityTypeManager()->getStorage('redirect');
+    $ids = array_filter(array_map(fn(Redirect $redirect): int => (int) $redirect->id(), $this->redirects));
+    $entities = $ids !== [] ? $storage->loadMultiple($ids) : [];
+
+    if (!empty($entities)) {
+      $storage->delete($entities);
+    }
+
+    $this->redirects = [];
+  }
+
+  /**
+   * Throw when the `redirect` module is not enabled.
+   */
+  protected function redirectAssertModuleEnabled(): void {
+    // @codeCoverageIgnoreStart
+    if (!\Drupal::moduleHandler()->moduleExists('redirect')) {
+      throw new \RuntimeException('The "redirect" module is not enabled. Enable it for scenarios that use RedirectTrait steps (e.g. tag the scenario with "@module:redirect").');
+    }
+    // @codeCoverageIgnoreEnd
+  }
+
+  /**
+   * Normalise the status code value from a table cell.
+   *
+   * @param string|null $value
+   *   The raw value from the table cell, or NULL when the column is missing.
+   *
+   * @return int
+   *   A valid HTTP redirect status code.
+   */
+  protected function redirectNormalizeStatusCode(?string $value): int {
+    $value = $value === NULL ? '' : trim($value);
+
+    if ($value === '') {
+      return 301;
+    }
+
+    if (!ctype_digit($value)) {
+      throw new \RuntimeException(sprintf('Invalid redirect status code "%s". Allowed values are: %s.', $value, implode(', ', static::$redirectAllowedStatusCodes)));
+    }
+
+    $status_code = (int) $value;
+
+    if (!in_array($status_code, static::$redirectAllowedStatusCodes, TRUE)) {
+      throw new \RuntimeException(sprintf('Invalid redirect status code "%d". Allowed values are: %s.', $status_code, implode(', ', static::$redirectAllowedStatusCodes)));
+    }
+
+    return $status_code;
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -25,6 +25,7 @@ use DrevOps\BehatSteps\Drupal\ModuleTrait;
 use DrevOps\BehatSteps\Drupal\OverrideTrait;
 use DrevOps\BehatSteps\Drupal\ParagraphsTrait;
 use DrevOps\BehatSteps\Drupal\QueueTrait;
+use DrevOps\BehatSteps\Drupal\RedirectTrait;
 use DrevOps\BehatSteps\Drupal\SearchApiTrait;
 use DrevOps\BehatSteps\Drupal\StateTrait;
 use DrevOps\BehatSteps\Drupal\TaxonomyTrait;
@@ -85,6 +86,7 @@ class FeatureContext extends DrupalContext {
   use ParagraphsTrait;
   use PathTrait;
   use QueueTrait;
+  use RedirectTrait;
   use ResponseTrait;
   use RestTrait;
   use ResponsiveTrait;

--- a/tests/behat/features/drupal_redirect.feature
+++ b/tests/behat/features/drupal_redirect.feature
@@ -93,6 +93,152 @@ Feature: Check that RedirectTrait works
     And I go to "/strip-slash"
     Then the path should not be "/user/login"
 
+  @api
+  Scenario: Assert "Then the following redirects should exist:" matches by source, destination, and status code
+    Given the following redirects exist:
+      | from           | to                                | status_code |
+      | /assert-301    | /user/login                       | 301         |
+      | /assert-302    | /user/login                       | 302         |
+      | /assert-extern | https://example.com/promo-landing |             |
+    Then the following redirects should exist:
+      | from           | to                                | status_code |
+      | /assert-301    | /user/login                       | 301         |
+      | /assert-302    | /user/login                       | 302         |
+      | /assert-extern | https://example.com/promo-landing |             |
+
+  @api
+  Scenario: Assert "Then the following redirects should exist:" matches by source only when other columns are blank or omitted
+    Given the following redirects exist:
+      | from        | to          |
+      | /by-source  | /user/login |
+    Then the following redirects should exist:
+      | from        |
+      | /by-source  |
+    And the following redirects should exist:
+      | from        | to | status_code |
+      | /by-source  |    |             |
+
+  @api
+  Scenario: Assert "Then the following redirects should exist:" accepts source paths without a leading slash
+    Given the following redirects exist:
+      | from        | to          |
+      | /no-slash   | /user/login |
+    Then the following redirects should exist:
+      | from      | to          |
+      | no-slash  | /user/login |
+
+  @api
+  Scenario: Assert "Then the following redirects should exist:" accepts an "internal:" prefix on the destination
+    Given the following redirects exist:
+      | from         | to          |
+      | /prefix-dest | /user/login |
+    Then the following redirects should exist:
+      | from         | to                    |
+      | /prefix-dest | internal:/user/login  |
+
+  @api
+  Scenario: Assert "Then the following redirects should not exist:" passes when no redirect matches
+    Then the following redirects should not exist:
+      | /never-was       |
+      | /also-never-was  |
+
+  @api
+  Scenario: Assert "Then the following redirects should not exist:" passes after deletion
+    Given the following redirects exist:
+      | from       | to          |
+      | /will-go   | /user/login |
+    When the following redirects do not exist:
+      | /will-go |
+    Then the following redirects should not exist:
+      | /will-go |
+
+  @api @trait:Drupal\RedirectTrait
+  Scenario: Assert "Then the following redirects should exist:" fails when a redirect is missing
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following redirects exist:
+        | from    | to          |
+        | /there  | /user/login |
+      Then the following redirects should exist:
+        | from        | to          |
+        | /there      | /user/login |
+        | /not-there  | /user/login |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The following redirects should exist but were not found: {from="/not-there", to="/user/login"}.
+      """
+
+  @api @trait:Drupal\RedirectTrait
+  Scenario: Assert "Then the following redirects should exist:" fails when destination does not match
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following redirects exist:
+        | from         | to          |
+        | /wrong-dest  | /user/login |
+      Then the following redirects should exist:
+        | from         | to             |
+        | /wrong-dest  | /admin/content |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The following redirects should exist but were not found: {from="/wrong-dest", to="/admin/content"}.
+      """
+
+  @api @trait:Drupal\RedirectTrait
+  Scenario: Assert "Then the following redirects should exist:" fails when status code does not match
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following redirects exist:
+        | from         | to          | status_code |
+        | /wrong-code  | /user/login | 301         |
+      Then the following redirects should exist:
+        | from         | to          | status_code |
+        | /wrong-code  | /user/login | 302         |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The following redirects should exist but were not found: {from="/wrong-code", to="/user/login", status_code=302}.
+      """
+
+  @api @trait:Drupal\RedirectTrait
+  Scenario: Assert "Then the following redirects should exist:" fails when "from" is empty
+    Given some behat configuration
+    And scenario steps:
+      """
+      Then the following redirects should exist:
+        | from | to          |
+        |      | /user/login |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Each redirect row must define a non-empty "from" path.
+      """
+
+  @api @trait:Drupal\RedirectTrait
+  Scenario: Assert "Then the following redirects should not exist:" fails when a redirect is still present
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following redirects exist:
+        | from      | to          |
+        | /lingers  | /user/login |
+      Then the following redirects should not exist:
+        | /lingers |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The following redirects should not exist but were found: "/lingers".
+      """
+
   @api @trait:Drupal\RedirectTrait
   Scenario: Assert "Given the following redirects exist:" fails on an unsupported status code
     Given some behat configuration

--- a/tests/behat/features/drupal_redirect.feature
+++ b/tests/behat/features/drupal_redirect.feature
@@ -1,0 +1,154 @@
+Feature: Check that RedirectTrait works
+  As Behat Steps library developer
+  I want to provide tools to manage redirect entities programmatically
+  So that users can test legacy-URL preservation, vanity URLs, and path rewrites
+
+  @api
+  Scenario: Assert "Given the following redirects exist:" creates redirects with default status code
+    Given the following redirects exist:
+      | from         | to          |
+      | /old-path-1  | /user/login |
+      | /old-path-2  | /user/login |
+    When I am an anonymous user
+    And I go to "/old-path-1"
+    Then the path should be "/user/login"
+
+    When I go to "/old-path-2"
+    Then the path should be "/user/login"
+
+  @api
+  Scenario: Assert "Given the following redirects exist:" accepts explicit, omitted, and blank status codes
+    Given the following redirects exist:
+      | from              | to          | status_code |
+      | /default-status   | /user/login |             |
+      | /explicit-301     | /user/login | 301         |
+      | /explicit-302     | /user/login | 302         |
+      | /explicit-307     | /user/login | 307         |
+    When I am an anonymous user
+    And I go to "/default-status"
+    Then the path should be "/user/login"
+
+    When I go to "/explicit-301"
+    Then the path should be "/user/login"
+
+    When I go to "/explicit-302"
+    Then the path should be "/user/login"
+
+    When I go to "/explicit-307"
+    Then the path should be "/user/login"
+
+  @api
+  Scenario: Assert "Given the following redirects exist:" accepts source paths without a leading slash
+    Given the following redirects exist:
+      | from           | to          |
+      | no-leading     | /user/login |
+    When I am an anonymous user
+    And I go to "/no-leading"
+    Then the path should be "/user/login"
+
+  @api
+  Scenario: Assert "Given the following redirects exist:" accepts external destinations
+    Given the following redirects exist:
+      | from   | to                                |
+      | /promo | https://example.com/promo-landing |
+    When I am logged in as a user with the "administrator" role
+    And I go to "/admin/config/search/redirect"
+    Then I should see the text "promo"
+
+  @api
+  Scenario: Assert "Given the following redirects do not exist:" removes targeted redirects only
+    Given the following redirects exist:
+      | from        | to          |
+      | /keep-me    | /user/login |
+      | /delete-me  | /user/login |
+    When the following redirects do not exist:
+      | /delete-me |
+    And I am an anonymous user
+    And I go to "/keep-me"
+    Then the path should be "/user/login"
+
+    When I go to "/delete-me"
+    Then the path should not be "/user/login"
+
+  @api
+  Scenario: Assert "Given the following redirects do not exist:" silently skips paths that have no redirect
+    Given the following redirects exist:
+      | from     | to          |
+      | /present | /user/login |
+    When the following redirects do not exist:
+      | /never-created |
+      | /also-missing  |
+    And I am an anonymous user
+    And I go to "/present"
+    Then the path should be "/user/login"
+
+  @api
+  Scenario: Assert "Given the following redirects do not exist:" accepts source paths without a leading slash
+    Given the following redirects exist:
+      | from         | to          |
+      | /strip-slash | /user/login |
+    When the following redirects do not exist:
+      | strip-slash |
+    And I am an anonymous user
+    And I go to "/strip-slash"
+    Then the path should not be "/user/login"
+
+  @api @trait:Drupal\RedirectTrait
+  Scenario: Assert "Given the following redirects exist:" fails on an unsupported status code
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following redirects exist:
+        | from     | to          | status_code |
+        | /unused  | /user/login | 404         |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Invalid redirect status code "404". Allowed values are: 301, 302, 303, 307, 308.
+      """
+
+  @api @trait:Drupal\RedirectTrait
+  Scenario: Assert "Given the following redirects exist:" fails on a non-numeric status code
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following redirects exist:
+        | from     | to          | status_code |
+        | /unused  | /user/login | abc         |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Invalid redirect status code "abc". Allowed values are: 301, 302, 303, 307, 308.
+      """
+
+  @api @trait:Drupal\RedirectTrait
+  Scenario: Assert "Given the following redirects exist:" fails when "from" is empty
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following redirects exist:
+        | from | to          |
+        |      | /user/login |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Each redirect row must define a non-empty "from" path.
+      """
+
+  @api @trait:Drupal\RedirectTrait
+  Scenario: Assert "Given the following redirects exist:" fails when "to" is empty
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following redirects exist:
+        | from     | to |
+        | /unused  |    |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Redirect from "/unused" is missing a non-empty "to" value.
+      """

--- a/tests/behat/fixtures_drupal/d10/composer.json
+++ b/tests/behat/fixtures_drupal/d10/composer.json
@@ -19,6 +19,7 @@
         "drupal/eck": "^2.1",
         "drupal/paragraphs": "^1.19",
         "drupal/pathauto": "^1.14",
+        "drupal/redirect": "^1.11",
         "drupal/scheduled_transitions": "^2.6",
         "drupal/search_api": "^1.38",
         "drupal/testmode": "^2.6",

--- a/tests/behat/fixtures_drupal/d10/config/sync/core.extension.yml
+++ b/tests/behat/fixtures_drupal/d10/config/sync/core.extension.yml
@@ -44,6 +44,7 @@ module:
   page_cache: 0
   path: 0
   path_alias: 0
+  redirect: 0
   scheduled_transitions: 0
   search: 0
   search_api: 0

--- a/tests/behat/fixtures_drupal/d10/config/sync/redirect.settings.yml
+++ b/tests/behat/fixtures_drupal/d10/config/sync/redirect.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: FEwQLW1wXW7fiJdG1B2bxW1c_-k6w-r-3V3bSsW6PqM
+auto_redirect: true
+default_status_code: 301
+passthrough_querystring: true
+warning: false
+ignore_admin_path: false
+access_check: false
+route_normalizer_enabled: false

--- a/tests/behat/fixtures_drupal/d10/config/sync/system.action.redirect_delete_action.yml
+++ b/tests/behat/fixtures_drupal/d10/config/sync/system.action.redirect_delete_action.yml
@@ -1,0 +1,13 @@
+uuid: 2fd8d7bd-db78-4212-a4f4-1d0e42cf8b4e
+langcode: en
+status: true
+dependencies:
+  module:
+    - redirect
+_core:
+  default_config_hash: 2T-yEyZvw_9I2XVc5fquqcWBvzm6y2o3be2YbQwKe8E
+id: redirect_delete_action
+label: 'Delete redirect'
+type: redirect
+plugin: redirect_delete_action
+configuration: {  }

--- a/tests/behat/fixtures_drupal/d10/config/sync/views.view.redirect.yml
+++ b/tests/behat/fixtures_drupal/d10/config/sync/views.view.redirect.yml
@@ -1,0 +1,674 @@
+uuid: 1e06c2ae-2be3-4a54-8a71-28b9e0b1e548
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - redirect
+    - user
+_core:
+  default_config_hash: DexqLBdD7TB7piALIPEvcHI9NvY1BNibYaTSF-aJWUw
+id: redirect
+label: Redirect
+module: views
+description: 'List of redirects'
+tag: ''
+base_table: redirect
+base_field: rid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'administer redirects'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ previous'
+            next: 'next ›'
+            first: '« first'
+            last: 'last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            redirect_source__path: redirect_source__path
+            redirect_redirect__uri: redirect_redirect__uri
+            enabled: enabled
+            status_code: status_code
+            language: language
+            created: created
+            operations: operations
+          info:
+            redirect_source__path:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            redirect_redirect__uri:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            enabled:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status_code:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            language:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: created
+          empty_table: false
+      row:
+        type: fields
+      fields:
+        redirect_bulk_form:
+          id: redirect_bulk_form
+          table: redirect
+          field: redirect_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: 'With selection'
+          include_exclude: exclude
+          selected_actions: {  }
+          entity_type: redirect
+          plugin_id: redirect_bulk_form
+        redirect_source__path:
+          id: redirect_source__path
+          table: redirect
+          field: redirect_source__path
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: From
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: path
+          type: redirect_source
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: redirect
+          entity_field: redirect_source
+          plugin_id: field
+        redirect_redirect__uri:
+          id: redirect_redirect__uri
+          table: redirect
+          field: redirect_redirect__uri
+          entity_type: redirect
+          entity_field: redirect_redirect
+          plugin_id: field
+        enabled:
+          id: enabled
+          table: redirect
+          field: enabled
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: redirect
+          entity_field: enabled
+          plugin_id: field
+          label: Enabled
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: enabled-disabled
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        status_code:
+          id: status_code
+          table: redirect
+          field: status_code
+          entity_type: redirect
+          entity_field: status_code
+          plugin_id: field
+        language:
+          id: language
+          table: redirect
+          field: language
+          entity_type: redirect
+          entity_field: language
+          plugin_id: field
+        created:
+          id: created
+          table: redirect
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: fallback
+          custom_date_format: ''
+          timezone: ''
+          entity_type: redirect
+          entity_field: created
+          plugin_id: date
+        operations:
+          id: operations
+          table: redirect
+          field: operations
+          entity_type: redirect
+          plugin_id: entity_operations
+      filters:
+        redirect_source__path:
+          id: redirect_source__path
+          table: redirect
+          field: redirect_source__path
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: redirect_source__path_op
+            label: From
+            description: ''
+            use_operator: false
+            operator: redirect_source__path_op
+            identifier: redirect_source__path
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: redirect
+          entity_field: redirect_source
+          plugin_id: string
+        redirect_redirect__uri:
+          id: redirect_redirect__uri
+          table: redirect
+          field: redirect_redirect__uri
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: redirect_redirect__uri_op
+            label: To
+            description: ''
+            use_operator: false
+            operator: redirect_redirect__uri_op
+            identifier: redirect_redirect__uri
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: redirect
+          entity_field: redirect_redirect
+          plugin_id: string
+        status_code:
+          id: status_code
+          table: redirect
+          field: status_code
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_code_op
+            label: 'Status code'
+            description: ''
+            use_operator: false
+            operator: status_code_op
+            identifier: status_code
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: true
+          group_info:
+            label: 'Status code'
+            description: ''
+            identifier: status_code
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: '300 Multiple Choices'
+                operator: '='
+                value:
+                  value: '300'
+                  min: ''
+                  max: ''
+              2:
+                title: '301 Moved Permanently'
+                operator: '='
+                value:
+                  value: '301'
+                  min: ''
+                  max: ''
+              3:
+                title: '302 Found'
+                operator: '='
+                value:
+                  value: '302'
+                  min: ''
+                  max: ''
+              4:
+                title: '303 See Other'
+                operator: '='
+                value:
+                  value: '303'
+                  min: ''
+                  max: ''
+              5:
+                title: '304 Not Modified'
+                operator: '='
+                value:
+                  value: '304'
+                  min: ''
+                  max: ''
+              6:
+                title: '305 Use Proxy'
+                operator: '='
+                value:
+                  value: '305'
+                  min: ''
+                  max: ''
+              7:
+                title: '307 Temporary Redirect'
+                operator: '='
+                value:
+                  value: '307'
+                  min: ''
+                  max: ''
+          entity_type: redirect
+          entity_field: status_code
+          plugin_id: numeric
+        language:
+          id: language
+          table: redirect
+          field: language
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: language_op
+            label: 'Original language'
+            description: ''
+            use_operator: false
+            operator: language_op
+            identifier: language
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: redirect
+          entity_field: language
+          plugin_id: language
+      sorts: {  }
+      title: Redirect
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'There is no redirect yet.'
+          plugin_id: text_custom
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      cacheable: false
+      max-age: 0
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/search/redirect
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      cacheable: false
+      max-age: 0
+      tags: {  }

--- a/tests/behat/fixtures_drupal/d11/composer.json
+++ b/tests/behat/fixtures_drupal/d11/composer.json
@@ -19,6 +19,7 @@
         "drupal/eck": "^2.1@beta",
         "drupal/paragraphs": "^1.19",
         "drupal/pathauto": "^1.14",
+        "drupal/redirect": "^1.11",
         "drupal/scheduled_transitions": "^2.6",
         "drupal/search_api": "^1.38",
         "drupal/testmode": "^2.6",

--- a/tests/behat/fixtures_drupal/d11/config/sync/core.extension.yml
+++ b/tests/behat/fixtures_drupal/d11/config/sync/core.extension.yml
@@ -44,6 +44,7 @@ module:
   page_cache: 0
   path: 0
   path_alias: 0
+  redirect: 0
   scheduled_transitions: 0
   search: 0
   search_api: 0

--- a/tests/behat/fixtures_drupal/d11/config/sync/redirect.settings.yml
+++ b/tests/behat/fixtures_drupal/d11/config/sync/redirect.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: FEwQLW1wXW7fiJdG1B2bxW1c_-k6w-r-3V3bSsW6PqM
+auto_redirect: true
+default_status_code: 301
+passthrough_querystring: true
+warning: false
+ignore_admin_path: false
+access_check: false
+route_normalizer_enabled: false

--- a/tests/behat/fixtures_drupal/d11/config/sync/system.action.redirect_delete_action.yml
+++ b/tests/behat/fixtures_drupal/d11/config/sync/system.action.redirect_delete_action.yml
@@ -1,0 +1,13 @@
+uuid: 2fd8d7bd-db78-4212-a4f4-1d0e42cf8b4e
+langcode: en
+status: true
+dependencies:
+  module:
+    - redirect
+_core:
+  default_config_hash: 2T-yEyZvw_9I2XVc5fquqcWBvzm6y2o3be2YbQwKe8E
+id: redirect_delete_action
+label: 'Delete redirect'
+type: redirect
+plugin: redirect_delete_action
+configuration: {  }

--- a/tests/behat/fixtures_drupal/d11/config/sync/views.view.redirect.yml
+++ b/tests/behat/fixtures_drupal/d11/config/sync/views.view.redirect.yml
@@ -1,0 +1,674 @@
+uuid: 1e06c2ae-2be3-4a54-8a71-28b9e0b1e548
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - redirect
+    - user
+_core:
+  default_config_hash: DexqLBdD7TB7piALIPEvcHI9NvY1BNibYaTSF-aJWUw
+id: redirect
+label: Redirect
+module: views
+description: 'List of redirects'
+tag: ''
+base_table: redirect
+base_field: rid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'administer redirects'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ previous'
+            next: 'next ›'
+            first: '« first'
+            last: 'last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            redirect_source__path: redirect_source__path
+            redirect_redirect__uri: redirect_redirect__uri
+            enabled: enabled
+            status_code: status_code
+            language: language
+            created: created
+            operations: operations
+          info:
+            redirect_source__path:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            redirect_redirect__uri:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            enabled:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status_code:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            language:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: created
+          empty_table: false
+      row:
+        type: fields
+      fields:
+        redirect_bulk_form:
+          id: redirect_bulk_form
+          table: redirect
+          field: redirect_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: 'With selection'
+          include_exclude: exclude
+          selected_actions: {  }
+          entity_type: redirect
+          plugin_id: redirect_bulk_form
+        redirect_source__path:
+          id: redirect_source__path
+          table: redirect
+          field: redirect_source__path
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: From
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: path
+          type: redirect_source
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: redirect
+          entity_field: redirect_source
+          plugin_id: field
+        redirect_redirect__uri:
+          id: redirect_redirect__uri
+          table: redirect
+          field: redirect_redirect__uri
+          entity_type: redirect
+          entity_field: redirect_redirect
+          plugin_id: field
+        enabled:
+          id: enabled
+          table: redirect
+          field: enabled
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: redirect
+          entity_field: enabled
+          plugin_id: field
+          label: Enabled
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: enabled-disabled
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        status_code:
+          id: status_code
+          table: redirect
+          field: status_code
+          entity_type: redirect
+          entity_field: status_code
+          plugin_id: field
+        language:
+          id: language
+          table: redirect
+          field: language
+          entity_type: redirect
+          entity_field: language
+          plugin_id: field
+        created:
+          id: created
+          table: redirect
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: fallback
+          custom_date_format: ''
+          timezone: ''
+          entity_type: redirect
+          entity_field: created
+          plugin_id: date
+        operations:
+          id: operations
+          table: redirect
+          field: operations
+          entity_type: redirect
+          plugin_id: entity_operations
+      filters:
+        redirect_source__path:
+          id: redirect_source__path
+          table: redirect
+          field: redirect_source__path
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: redirect_source__path_op
+            label: From
+            description: ''
+            use_operator: false
+            operator: redirect_source__path_op
+            identifier: redirect_source__path
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: redirect
+          entity_field: redirect_source
+          plugin_id: string
+        redirect_redirect__uri:
+          id: redirect_redirect__uri
+          table: redirect
+          field: redirect_redirect__uri
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: redirect_redirect__uri_op
+            label: To
+            description: ''
+            use_operator: false
+            operator: redirect_redirect__uri_op
+            identifier: redirect_redirect__uri
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: redirect
+          entity_field: redirect_redirect
+          plugin_id: string
+        status_code:
+          id: status_code
+          table: redirect
+          field: status_code
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_code_op
+            label: 'Status code'
+            description: ''
+            use_operator: false
+            operator: status_code_op
+            identifier: status_code
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: true
+          group_info:
+            label: 'Status code'
+            description: ''
+            identifier: status_code
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: '300 Multiple Choices'
+                operator: '='
+                value:
+                  value: '300'
+                  min: ''
+                  max: ''
+              2:
+                title: '301 Moved Permanently'
+                operator: '='
+                value:
+                  value: '301'
+                  min: ''
+                  max: ''
+              3:
+                title: '302 Found'
+                operator: '='
+                value:
+                  value: '302'
+                  min: ''
+                  max: ''
+              4:
+                title: '303 See Other'
+                operator: '='
+                value:
+                  value: '303'
+                  min: ''
+                  max: ''
+              5:
+                title: '304 Not Modified'
+                operator: '='
+                value:
+                  value: '304'
+                  min: ''
+                  max: ''
+              6:
+                title: '305 Use Proxy'
+                operator: '='
+                value:
+                  value: '305'
+                  min: ''
+                  max: ''
+              7:
+                title: '307 Temporary Redirect'
+                operator: '='
+                value:
+                  value: '307'
+                  min: ''
+                  max: ''
+          entity_type: redirect
+          entity_field: status_code
+          plugin_id: numeric
+        language:
+          id: language
+          table: redirect
+          field: language
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: language_op
+            label: 'Original language'
+            description: ''
+            use_operator: false
+            operator: language_op
+            identifier: language
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: redirect
+          entity_field: language
+          plugin_id: language
+      sorts: {  }
+      title: Redirect
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'There is no redirect yet.'
+          plugin_id: text_custom
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      cacheable: false
+      max-age: 0
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/search/redirect
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      cacheable: false
+      max-age: 0
+      tags: {  }


### PR DESCRIPTION
Closes #648

## Summary

Added `Drupal\RedirectTrait` to the library. The trait exposes four table-driven steps for managing and asserting `redirect` contrib module entities in Behat scenarios: two `Given` steps for creation/deletion and two `Then` steps for existence assertions. An `AfterScenario` cleanup hook removes any redirect entities created during the scenario, with a `@behat-steps-skip:redirectAfterScenario` opt-out tag. Both the Drupal 10 and Drupal 11 fixture sites were updated to install and enable the `redirect` module with `route_normalizer_enabled: false` to keep the module's route normalizer subscriber from breaking the existing `PathTrait` front-page tests.

## Changes

**New trait - `src/Drupal/RedirectTrait.php`**
- `Given the following redirects exist:` - table columns `from`, `to`, optional `status_code`. Defaults to 301 when the column is absent or blank. Validates the status code against the allowed set `{301, 302, 303, 307, 308}`. Internal paths and external `http(s)://` URLs are passed through to `Redirect::setSource()` and `Redirect::setRedirect()`.
- `Given the following redirects do not exist:` - single-column table of source paths. Silently skips paths with no matching redirect (consistent with `MenuTrait::menuLinksDelete`). Also drops the deleted IDs from the in-scenario `$redirects` tracking array so the `AfterScenario` hook does not attempt a double-delete.
- `Then the following redirects should exist:` - table with required `from` and optional `to` / `status_code` columns. Each row asserts that a matching redirect entity exists. Blank or omitted columns are not part of the match. Failure message lists every unmatched row with the matched columns spelled out, e.g. `{from="/x", to="/y", status_code=302}`.
- `Then the following redirects should not exist:` - single-column table of source paths. Each row asserts that no redirect with that source path exists. Failure message lists every path that is still present.
- `redirectAfterScenario` AfterScenario hook tagged `@api` with `behat-steps-skip:redirectAfterScenario` opt-out.
- Runtime module-presence guard (`redirectAssertModuleEnabled`) wrapped in `@codeCoverageIgnore`. Throws a clear `\RuntimeException` directing the consumer to add `drupal/redirect` to `composer.json` and enable the module as part of site setup.
- Protected helpers extracted for reuse across create / delete / assert: `redirectNormalizeSource`, `redirectNormalizeDestination` (mirrors `Redirect::setRedirect()` semantics with extra guard against double `internal:` prefixing), `redirectNormalizeStatusCode`, `redirectFormatRow`.

**New test file - `tests/behat/features/drupal_redirect.feature`** (22 scenarios)
- 13 positive `@api` scenarios covering: default / explicit / blank / omitted status codes, internal and external destinations, source paths with and without leading slash, targeted delete, silent-skip of missing paths, leading-slash stripping on delete, full assertion match (source + destination + status), source-only assertion, leading-slash tolerance on assert, `internal:` prefix tolerance on the destination column, vacuous-true `should not exist` against an empty store, and `should not exist` after a deletion.
- 9 `@api @trait:Drupal\RedirectTrait` subprocess scenarios covering: invalid numeric status code, non-numeric status code, empty `from` on create, empty `to` on create, missing redirect on `should exist`, mismatched destination on `should exist`, mismatched status code on `should exist`, empty `from` on `should exist`, and a still-present redirect on `should not exist`.

**Test bootstrap - `tests/behat/bootstrap/FeatureContext.php`**
- Added `use RedirectTrait;` and the corresponding `use` import.

**Fixture dependencies - `d10/composer.json`, `d11/composer.json`**
- Added `drupal/redirect: ^1.11` to both fixture `composer.json` files so `ahoy build` installs the module on a clean provision.

**Fixture configuration - `d10/` and `d11/config/sync/`**
- `core.extension.yml` - enabled `redirect` module.
- `redirect.settings.yml` - default settings with `route_normalizer_enabled: false`.
- `system.action.redirect_delete_action.yml` - module-provided bulk delete action.
- `views.view.redirect.yml` - module-provided admin list view at `/admin/config/search/redirect`.

**Documentation**
- `README.md` and `STEPS.md` regenerated to include `RedirectTrait` in the trait table and step reference.

## Before / After

```
Trait surface (alphabetical excerpt):

  Before:                       After:
    QueueTrait                    QueueTrait
    SearchApiTrait              + RedirectTrait
    StateTrait                    SearchApiTrait
                                  StateTrait

RedirectTrait public step surface:

                                +--------------------------------------------------+
                                | Given the following redirects exist:             |
                                | Given the following redirects do not exist:      |
                                | Then  the following redirects should exist:      |
                                | Then  the following redirects should not exist:  |
                                +--------------------------------------------------+
```
