### PR TITLE
[#647] Added 'DropzoneTrait' for multi-file drag-and-drop step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ from the community.
 | [AccessibilityTrait](STEPS.md#accessibilitytrait) | Assess accessibility of rendered pages. |
 | [CookieTrait](STEPS.md#cookietrait) | Verify and inspect browser cookies. |
 | [DateTrait](STEPS.md#datetrait) | Convert relative date expressions into timestamps or formatted dates. |
+| [DropzoneTrait](STEPS.md#dropzonetrait) | Simulate a real multi-file drag-and-drop gesture onto a Dropzone target. |
 | [ElementTrait](STEPS.md#elementtrait) | Interact with HTML elements using CSS selectors and DOM attributes. |
 | [FieldTrait](STEPS.md#fieldtrait) | Manipulate form fields and verify widget functionality. |
 | [FileDownloadTrait](STEPS.md#filedownloadtrait) | Test file download functionality with content verification. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -7,6 +7,7 @@
 | [AccessibilityTrait](#accessibilitytrait) | Assess accessibility of rendered pages. |
 | [CookieTrait](#cookietrait) | Verify and inspect browser cookies. |
 | [DateTrait](#datetrait) | Convert relative date expressions into timestamps or formatted dates. |
+| [DropzoneTrait](#dropzonetrait) | Simulate a real multi-file drag-and-drop gesture onto a Dropzone target. |
 | [ElementTrait](#elementtrait) | Interact with HTML elements using CSS selectors and DOM attributes. |
 | [FieldTrait](#fieldtrait) | Manipulate form fields and verify widget functionality. |
 | [FileDownloadTrait](#filedownloadtrait) | Test file download functionality with content verification. |
@@ -304,6 +305,58 @@ Then a cookie with a name containing "user" and a value containing "guest" shoul
 >  - `[relative:-1 day]` converted to `1893456000`
 >  - `[relative:-1 day#Y-m-d]` converted to `2017-11-5`
 
+
+## DropzoneTrait
+
+[Source](src/DropzoneTrait.php), [Example](tests/behat/features/dropzone.feature)
+
+>  Simulate a real multi-file drag-and-drop gesture onto a Dropzone target.
+>  - Drop one or more files on a CSS-selected target in a single native event.
+>  - Fixture paths resolve against the Mink `files_path` parameter.
+>  - Works on any element that handles native `drop` events (Dropzone.js,
+>  custom drop targets, framework widgets).
+>  <br/><br/>
+>  Why this exists: Mink's `attachFile` writes each file to a hidden
+>  `<input type="file">` sequentially, so file A finishes uploading before
+>  file B starts. Real users release multiple files together, which fires a
+>  single `drop` event whose `dataTransfer.files` contains all of them and
+>  triggers concurrent uploads. Race conditions in dedup maps, status
+>  indicators, error handlers, and server-side queues only reproduce under
+>  the multi-file path - this trait reproduces it.
+>  <br/><br/>
+>  `@javascript`-only: requires a headless browser session.
+
+
+<details>
+  <summary><code>@When I drop the file :path on the :selector dropzone</code></summary>
+
+<br/>
+Drop a single file on the target element
+<br/><br/>
+
+```gherkin
+When I drop the file "document.pdf" on the ".dropzone" dropzone
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I drop the following files on the :selector dropzone:</code></summary>
+
+<br/>
+Drop one or more files on the target element in a single native event
+<br/><br/>
+
+```gherkin
+When I drop the following files on the ".dropzone" dropzone:
+  | document.pdf |
+  | image.png    |
+  | text.txt     |
+
+```
+
+</details>
 
 ## ElementTrait
 

--- a/src/DropzoneTrait.php
+++ b/src/DropzoneTrait.php
@@ -153,8 +153,13 @@ trait DropzoneTrait {
       throw new \RuntimeException('The Mink "files_path" parameter is not configured.');
     }
 
-    $base = rtrim((string) realpath((string) $files_path), DIRECTORY_SEPARATOR);
-    $full_path = $base . DIRECTORY_SEPARATOR . ltrim($path, '/');
+    $resolved_files_path = realpath((string) $files_path);
+    if ($resolved_files_path === FALSE || !is_dir($resolved_files_path)) {
+      throw new \RuntimeException('The Mink "files_path" parameter is invalid or not accessible.');
+    }
+
+    $base = rtrim($resolved_files_path, DIRECTORY_SEPARATOR);
+    $full_path = $base . DIRECTORY_SEPARATOR . ltrim($path, "/\\");
 
     if (!is_file($full_path)) {
       throw new \RuntimeException(sprintf('The fixture file "%s" does not exist.', $full_path));

--- a/src/DropzoneTrait.php
+++ b/src/DropzoneTrait.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps;
+
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Step\When;
+
+/**
+ * Simulate a real multi-file drag-and-drop gesture onto a Dropzone target.
+ *
+ * - Drop one or more files on a CSS-selected target in a single native event.
+ * - Fixture paths resolve against the Mink `files_path` parameter.
+ * - Works on any element that handles native `drop` events (Dropzone.js,
+ *   custom drop targets, framework widgets).
+ *
+ * Why this exists: Mink's `attachFile` writes each file to a hidden
+ * `<input type="file">` sequentially, so file A finishes uploading before
+ * file B starts. Real users release multiple files together, which fires a
+ * single `drop` event whose `dataTransfer.files` contains all of them and
+ * triggers concurrent uploads. Race conditions in dedup maps, status
+ * indicators, error handlers, and server-side queues only reproduce under
+ * the multi-file path - this trait reproduces it.
+ *
+ * `@javascript`-only: requires a headless browser session.
+ */
+trait DropzoneTrait {
+
+  /**
+   * Drop a single file on the target element.
+   *
+   * @code
+   * When I drop the file "document.pdf" on the ".dropzone" dropzone
+   * @endcode
+   *
+   * @javascript
+   */
+  #[When('I drop the file :path on the :selector dropzone')]
+  public function dropzoneDropFile(string $path, string $selector): void {
+    $this->dropzoneDropFiles($selector, new TableNode([[$path]]));
+  }
+
+  /**
+   * Drop one or more files on the target element in a single native event.
+   *
+   * Provide one fixture path per row.
+   *
+   * @code
+   * When I drop the following files on the ".dropzone" dropzone:
+   *   | document.pdf |
+   *   | image.png    |
+   *   | text.txt     |
+   * @endcode
+   *
+   * @javascript
+   */
+  #[When('I drop the following files on the :selector dropzone:')]
+  public function dropzoneDropFiles(string $selector, TableNode $paths): void {
+    $session = $this->getSession();
+    $page = $session->getPage();
+
+    if ($page->find('css', $selector) === NULL) {
+      throw new ElementNotFoundException($session->getDriver(), 'element', 'css', $selector);
+    }
+
+    $resolved_paths = [];
+    foreach ($paths->getColumn(0) as $row) {
+      $resolved_paths[] = $this->dropzoneResolvePath((string) $row);
+    }
+
+    $token = str_replace('.', '', uniqid('', TRUE));
+    $holder_ids = [];
+    foreach (array_keys($resolved_paths) as $index) {
+      $holder_ids[] = 'behat_dropzone_holder_' . $token . '_' . $index;
+    }
+
+    $session->executeScript(sprintf(
+      "(function(){
+        var ids = %s;
+        for (var i = 0; i < ids.length; i++) {
+          var input = document.createElement('input');
+          input.type = 'file';
+          input.id = ids[i];
+          input.style.position = 'fixed';
+          input.style.left = '-9999px';
+          input.style.opacity = '0';
+          document.body.appendChild(input);
+        }
+      })();",
+      json_encode($holder_ids)
+    ));
+
+    foreach ($holder_ids as $index => $holder_id) {
+      $page->attachFileToField($holder_id, $resolved_paths[$index]);
+    }
+
+    $session->executeScript(sprintf(
+      "(function(){
+        var ids = %s;
+        var selector = %s;
+        var target = document.querySelector(selector);
+        if (!target) {
+          throw new Error('Dropzone target \"' + selector + '\" disappeared between resolution and dispatch.');
+        }
+        var dt = new DataTransfer();
+        for (var i = 0; i < ids.length; i++) {
+          var holder = document.getElementById(ids[i]);
+          if (holder && holder.files && holder.files.length > 0) {
+            dt.items.add(holder.files[0]);
+          }
+        }
+        target.dispatchEvent(new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt
+        }));
+        for (var j = 0; j < ids.length; j++) {
+          var node = document.getElementById(ids[j]);
+          if (node && node.parentNode) {
+            node.parentNode.removeChild(node);
+          }
+        }
+      })();",
+      json_encode($holder_ids),
+      json_encode($selector)
+    ));
+  }
+
+  /**
+   * Resolve a fixture path against the Mink `files_path` parameter.
+   *
+   * @param string $path
+   *   Fixture path, typically a bare filename like `document.pdf`.
+   *
+   * @return string
+   *   Absolute path to the fixture file.
+   *
+   * @throws \RuntimeException
+   *   When the resolved fixture does not exist.
+   */
+  protected function dropzoneResolvePath(string $path): string {
+    $path = trim($path);
+
+    if ($path === '') {
+      throw new \RuntimeException('A fixture file path cannot be empty.');
+    }
+
+    $files_path = $this->getMinkParameter('files_path');
+
+    if (empty($files_path)) {
+      throw new \RuntimeException('The Mink "files_path" parameter is not configured.');
+    }
+
+    $base = rtrim((string) realpath((string) $files_path), DIRECTORY_SEPARATOR);
+    $full_path = $base . DIRECTORY_SEPARATOR . ltrim($path, '/');
+
+    if (!is_file($full_path)) {
+      throw new \RuntimeException(sprintf('The fixture file "%s" does not exist.', $full_path));
+    }
+
+    return $full_path;
+  }
+
+}

--- a/src/DropzoneTrait.php
+++ b/src/DropzoneTrait.php
@@ -160,7 +160,12 @@ trait DropzoneTrait {
       throw new \RuntimeException(sprintf('The fixture file "%s" does not exist.', $full_path));
     }
 
-    return $full_path;
+    $resolved = realpath($full_path);
+    if ($resolved === FALSE || !str_starts_with($resolved, $base . DIRECTORY_SEPARATOR)) {
+      throw new \RuntimeException(sprintf('The fixture file "%s" is outside the configured "files_path".', $path));
+    }
+
+    return $resolved;
   }
 
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -34,6 +34,7 @@ use DrevOps\BehatSteps\Drupal\TimeTrait;
 use DrevOps\BehatSteps\Drupal\UserTrait;
 use DrevOps\BehatSteps\Drupal\WatchdogTrait;
 use DrevOps\BehatSteps\Drupal\WebformTrait;
+use DrevOps\BehatSteps\DropzoneTrait;
 use DrevOps\BehatSteps\ElementTrait;
 use DrevOps\BehatSteps\FieldTrait;
 use DrevOps\BehatSteps\FileDownloadTrait;
@@ -67,6 +68,7 @@ class FeatureContext extends DrupalContext {
   use CookieTrait;
   use DateTrait;
   use DraggableviewsTrait;
+  use DropzoneTrait;
   use EckTrait;
   use ElementTrait;
   use EmailTrait;

--- a/tests/behat/features/dropzone.feature
+++ b/tests/behat/features/dropzone.feature
@@ -42,6 +42,21 @@ Feature: Check that DropzoneTrait works
     And I should see "text.txt"
     And the "#event-count" element should contain "2"
 
+  # Real Dropzone.js library integration.
+
+  @javascript @phpserver
+  Scenario: Assert multi-file drop populates a real Dropzone.js instance
+    Given I am an anonymous user
+    When I visit "/sites/default/files/dropzone_dropzonejs.html"
+    And I drop the following files on the "#real-dropzone" dropzone:
+      | document.pdf |
+      | image.png    |
+      | text.txt     |
+    Then the "#accepted-count" element should contain "3"
+    And the "#real-dropzone" element should contain "document.pdf"
+    And the "#real-dropzone" element should contain "image.png"
+    And the "#real-dropzone" element should contain "text.txt"
+
   # Negative tests.
 
   @trait:DropzoneTrait

--- a/tests/behat/features/dropzone.feature
+++ b/tests/behat/features/dropzone.feature
@@ -1,0 +1,92 @@
+Feature: Check that DropzoneTrait works
+  As Behat Steps library developer
+  I want to provide a tool to simulate multi-file drag-and-drop
+  So that users can test concurrent file-drop pipelines
+
+  @javascript @phpserver
+  Scenario: Assert single-file drop on default selector
+    Given I am an anonymous user
+    When I visit "/sites/default/files/dropzone.html"
+    And I drop the file "document.pdf" on the ".dropzone" dropzone
+    Then I should see "document.pdf"
+    And the "#event-count" element should contain "1"
+
+  @javascript @phpserver
+  Scenario: Assert multi-file drop fires a single drop event
+    Given I am an anonymous user
+    When I visit "/sites/default/files/dropzone.html"
+    And I drop the following files on the ".dropzone" dropzone:
+      | document.pdf |
+      | image.png    |
+      | text.txt     |
+    Then I should see "document.pdf"
+    And I should see "image.png"
+    And I should see "text.txt"
+    And the "#event-count" element should contain "1"
+
+  @javascript @phpserver
+  Scenario: Assert drop on a non-default selector
+    Given I am an anonymous user
+    When I visit "/sites/default/files/dropzone.html"
+    And I drop the file "image.png" on the "#secondary-zone" dropzone
+    Then the "#secondary-output" element should contain "image.png"
+    And the "#primary-output" element should not contain "image.png"
+
+  @javascript @phpserver
+  Scenario: Assert two consecutive drops in one scenario do not collide
+    Given I am an anonymous user
+    When I visit "/sites/default/files/dropzone.html"
+    And I drop the file "document.pdf" on the ".dropzone" dropzone
+    And I drop the file "text.txt" on the ".dropzone" dropzone
+    Then I should see "document.pdf"
+    And I should see "text.txt"
+    And the "#event-count" element should contain "2"
+
+  # Negative tests.
+
+  @trait:DropzoneTrait
+  Scenario: Assert "When I drop the file ..." fails when target element is missing
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/dropzone.html"
+      And I drop the file "document.pdf" on the ".nonexistent-zone" dropzone
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css ".nonexistent-zone" not found.
+      """
+
+  @trait:DropzoneTrait
+  Scenario: Assert "When I drop the file ..." fails when fixture file is missing
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/dropzone.html"
+      And I drop the file "missing-fixture.bin" on the ".dropzone" dropzone
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      missing-fixture.bin" does not exist.
+      """
+
+  @trait:DropzoneTrait
+  Scenario: Assert "When I drop the following files ..." fails when fixture file is missing
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/dropzone.html"
+      And I drop the following files on the ".dropzone" dropzone:
+        | document.pdf       |
+        | missing-second.bin |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      missing-second.bin" does not exist.
+      """

--- a/tests/behat/fixtures/dropzone.html
+++ b/tests/behat/fixtures/dropzone.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Dropzone</title>
+<style>
+  body { font-family: sans-serif; padding: 1rem; }
+  .dropzone, #secondary-zone {
+    border: 2px dashed #999;
+    padding: 2rem;
+    margin: 1rem 0;
+    background: #f5f5f5;
+    min-height: 80px;
+  }
+  #secondary-zone { border-color: #c70039; background: #fff5f0; }
+  ul { padding-left: 1.5rem; }
+  li.dropped-file { font-family: monospace; }
+</style>
+</head>
+<body>
+<h1>Dropzone fixture</h1>
+
+<div class="dropzone">Drop files here</div>
+<h2>Files dropped on primary:</h2>
+<ul id="primary-output"></ul>
+
+<div id="secondary-zone">Drop files on secondary</div>
+<h2>Files dropped on secondary:</h2>
+<ul id="secondary-output"></ul>
+
+<h2>Drop event count:</h2>
+<p id="event-count">0</p>
+
+<script>
+  var eventCount = 0;
+
+  function wireDropTarget(target, outputId) {
+    target.addEventListener('dragover', function (event) {
+      event.preventDefault();
+    });
+    target.addEventListener('drop', function (event) {
+      event.preventDefault();
+      eventCount++;
+      document.getElementById('event-count').textContent = String(eventCount);
+
+      var output = document.getElementById(outputId);
+      var files = event.dataTransfer && event.dataTransfer.files ? event.dataTransfer.files : [];
+      for (var i = 0; i < files.length; i++) {
+        var li = document.createElement('li');
+        li.className = 'dropped-file';
+        li.textContent = files[i].name;
+        output.appendChild(li);
+      }
+    });
+  }
+
+  wireDropTarget(document.querySelector('.dropzone'), 'primary-output');
+  wireDropTarget(document.getElementById('secondary-zone'), 'secondary-output');
+</script>
+</body>
+</html>

--- a/tests/behat/fixtures/dropzone_dropzonejs.html
+++ b/tests/behat/fixtures/dropzone_dropzonejs.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Dropzone.js fixture</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/dropzone@5.9.3/dist/min/dropzone.min.css">
+<script src="https://cdn.jsdelivr.net/npm/dropzone@5.9.3/dist/min/dropzone.min.js"></script>
+<style>
+  body { font-family: sans-serif; padding: 1rem; }
+  .dropzone-form {
+    border: 2px dashed #4caf50;
+    background: #f0fff0;
+    min-height: 120px;
+  }
+</style>
+</head>
+<body>
+<h1>Real Dropzone.js fixture</h1>
+
+<form class="dropzone-form dropzone" id="real-dropzone" action="/no-upload"></form>
+
+<h2>Accepted file count:</h2>
+<p id="accepted-count">0</p>
+
+<script>
+  Dropzone.autoDiscover = false;
+  var instance = new Dropzone('#real-dropzone', {
+    url: '/no-upload',
+    autoProcessQueue: false,
+    maxFiles: 10,
+    acceptedFiles: '*',
+    parallelUploads: 10
+  });
+  instance.on('addedfile', function () {
+    document.getElementById('accepted-count').textContent = String(instance.files.length);
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #647

## Summary

Adds `DropzoneTrait` to the generic namespace, providing two `When` steps that simulate a real multi-file drag-and-drop gesture by dispatching a single native `drop` event whose `dataTransfer.files` contains all requested files simultaneously. Unlike Mink's `attachFile`, which writes files to a hidden `<input type="file">` one at a time (sequential uploads), this trait reproduces the concurrent-upload code path that real users trigger - exposing race conditions in dedup maps, status-indicator clobbering, queue deadlocks, and server-side handlers that only manifest under the multi-file path. Fixture paths are resolved against the Mink `files_path` parameter and validated to prevent path-traversal escapes.

## Changes

**New trait - `src/DropzoneTrait.php`**
- `When I drop the file :path on the :selector dropzone` - single-file convenience step (delegates to the multi-file step with a one-row TableNode)
- `When I drop the following files on the :selector dropzone:` - drops N files in a single native `drop` event; injects temporary off-screen `<input type="file">` elements to satisfy browser security, collects the `File` objects into a `DataTransfer`, dispatches `DragEvent('drop', ...)` on the resolved CSS target, then removes the holder inputs
- `dropzoneResolvePath()` - resolves each path against `files_path`, rejects missing files and paths that escape the configured base directory via `realpath` comparison

**New tests - `tests/behat/features/dropzone.feature`**
- 4 positive `@javascript @phpserver` scenarios: single-file drop, multi-file drop (verifies a single `drop` event fires), drop on a non-default selector, two consecutive drops in one scenario
- 3 negative `@trait:DropzoneTrait` scenarios: missing target element, missing single fixture file, missing file in a multi-file list

**New fixture - `tests/behat/fixtures/dropzone.html`**
- Minimal HTML page with a `.dropzone` primary target and a `#secondary-zone` secondary target; JavaScript listeners append dropped filenames to separate output lists and increment a shared event counter, letting scenarios assert both which files landed where and how many `drop` events fired

**Registration - `tests/behat/bootstrap/FeatureContext.php`**
- Imported and applied `DropzoneTrait` alongside the existing generic traits

**Docs - `STEPS.md`, `README.md`**
- Regenerated by `ahoy update-docs`; `DropzoneTrait` entry added to the trait table in both files

## Before / After

```
BEFORE (Mink attachFile - sequential, one event per file)
─────────────────────────────────────────────────────────
  attachFile("document.pdf")  →  upload A starts → upload A finishes
  attachFile("image.png")     →  upload B starts → upload B finishes
  attachFile("text.txt")      →  upload C starts → upload C finishes

  Event sequence: input:change, input:change, input:change
  Concurrent upload window: NONE (each file finishes before next starts)
  Race conditions reproduced: NO

AFTER (DropzoneTrait - all files in one drop event)
───────────────────────────────────────────────────
  dropzoneDropFiles(".dropzone", ["document.pdf", "image.png", "text.txt"])
    │
    ├── inject hidden <input id="holder_0"> → attachFile → File A
    ├── inject hidden <input id="holder_1"> → attachFile → File B
    ├── inject hidden <input id="holder_2"> → attachFile → File C
    │
    └── dt = new DataTransfer()
        dt.items.add(File A)
        dt.items.add(File B)
        dt.items.add(File C)
        target.dispatchEvent(new DragEvent('drop', { dataTransfer: dt }))
        (remove holder inputs)

  Event sequence: drop (dataTransfer.files.length === 3)
  Concurrent upload window: YES - all three files arrive together
  Race conditions reproduced: YES
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## DropzoneTrait Implementation

### Overview
Added a new Behat trait that simulates real multi-file drag-and-drop gestures by firing a single native `drop` event with all files in a `DataTransfer`, enabling tests of concurrent-upload code paths that Mink's sequential `attachFile` cannot reproduce.

### Step Definitions
Two new `When` steps (compliant with CONTRIBUTING.md):
- `When I drop the file :path on the :selector dropzone` — single-file convenience wrapper
- `When I drop the following files on the :selector dropzone:` — multi-file step accepting a table with one fixture path per row

Placeholders, phrasing (`the following`), action-verb `When I drop`, tuple format, and method naming (trait-prefixed) conform to the repository's step rules. No CONTRIBUTING.md violations found.

### Implementation Details
- New trait: src/DropzoneTrait.php
  - dropzoneDropFile(string $path, string $selector): delegates to the multi-file step.
  - dropzoneDropFiles(string $selector, TableNode $paths): resolves fixture paths, injects temporary off-screen `<input type="file">` holders, uses Mink's attachFileToField to populate each holder, aggregates holder.files into a single `DataTransfer`, dispatches one browser-native `DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt })` on the resolved CSS target, and removes holders.
  - dropzoneResolvePath(string $path): trims and validates input, requires a configured Mink `files_path`, canonicalizes `files_path` with `realpath()` and validates it is a directory, constructs the full path, checks file existence, canonicalizes the fixture path and rejects paths outside the canonical `files_path` directory (prevents path traversal). Throws clear RuntimeExceptions for empty paths, missing/invalid `files_path`, missing fixtures, and out-of-bounds fixtures.
- All DOM/JS interactions run via Session::executeScript; temporary inputs are positioned off-screen (fixed left -9999px, opacity 0).
- Throws ElementNotFoundException when the CSS target is missing at resolution time and throws a JS Error if the target disappears between resolution and dispatch.

### Tests & Fixtures
- tests/behat/features/dropzone.feature: positive scenarios (single-file, multi-file verifying a single drop event, non-default selector, consecutive drops) and negative `@trait` scenarios (missing target, missing single fixture, missing file in multi-file list).
- tests/behat/fixtures/dropzone.html: two drop zones, event counter, and JS handlers that read `event.dataTransfer.files` and append filenames.
- tests/behat/bootstrap/FeatureContext.php: DropzoneTrait registered via use statement.

### Documentation & Misc
- README.md: added DropzoneTrait to the generic steps index.
- STEPS.md: added full DropzoneTrait documentation and examples.
- Docs regenerated via ahoy update-docs.

### Scope & Acceptance
- Trait only simulates the drop gesture; assertions about Dropzone behavior remain the consumer's responsibility.
- No folder-drop support, no retry/wait semantics.
- Acceptance criteria met: new src/DropzoneTrait.php with two #[When(...)] methods, robust fixture-path resolution and canonicalization, clear exceptions for missing targets/fixtures, feature tests (positive and negative), and documentation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->