### PR TITLE
[#657] [#659] Fixed accessibility report directory and report URL display.

### DIFF
--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -10,6 +10,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\AfterStep;
 use Behat\Hook\BeforeScenario;
+use Behat\Hook\BeforeSuite;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Step\Then;
 
@@ -58,6 +59,17 @@ trait AccessibilityTrait {
   protected static ?string $accessibilityCachedJs = NULL;
 
   /**
+   * Working directory captured before any test bootstrap can chdir().
+   *
+   * The default report directory anchors to this rather than a live
+   * `getcwd()` call, which an `@api` bootstrap mutates by chdir()-ing to the
+   * docroot - moving reports out of the path-anchored location used by the
+   * rest of the run. Captured once at `@BeforeSuite`, before the first
+   * scenario, so it records the directory the run was launched from.
+   */
+  protected static ?string $accessibilityBaseDir = NULL;
+
+  /**
    * Normalized results collected during the current scenario.
    *
    * @var array<int, array{url: string, rules: string, result: array<string, mixed>}>
@@ -98,6 +110,17 @@ trait AccessibilityTrait {
    * Whether the scenario is opted out of accessibility processing.
    */
   protected bool $accessibilitySkip = FALSE;
+
+  /**
+   * Capture the working directory once, before any scenario can chdir().
+   */
+  #[BeforeSuite]
+  public static function accessibilityCaptureBaseDir(): void {
+    if (self::$accessibilityBaseDir === NULL) {
+      $cwd = getcwd();
+      self::$accessibilityBaseDir = $cwd === FALSE ? '' : $cwd;
+    }
+  }
 
   /**
    * Initialize accessibility state for the scenario.
@@ -188,12 +211,14 @@ trait AccessibilityTrait {
     $messages = [];
 
     foreach ($this->accessibilityResults as $r) {
+      $display_url = $this->accessibilityFormatUrl((string) $r['url']);
+
       foreach ($this->accessibilityFilterViolations($r['result']['violations'] ?? [], $threshold) as $v) {
-        $messages[] = sprintf('  violation [%s] %s on %s', $v['impact'] ?? 'unknown', $v['id'] ?? '', $r['url']);
+        $messages[] = sprintf('  violation [%s] %s on %s', $v['impact'] ?? 'unknown', $v['id'] ?? '', $display_url);
       }
       if ($check_incomplete) {
         foreach ($r['result']['incomplete'] ?? [] as $i) {
-          $messages[] = sprintf('  incomplete [%s] %s on %s', $i['impact'] ?? 'unknown', $i['id'] ?? '', $r['url']);
+          $messages[] = sprintf('  incomplete [%s] %s on %s', $i['impact'] ?? 'unknown', $i['id'] ?? '', $display_url);
         }
       }
     }
@@ -284,11 +309,16 @@ trait AccessibilityTrait {
   /**
    * Return the absolute directory used to write per-scenario reports.
    *
-   * Default: `.logs/test_results/accessibility/` relative to the current
-   * working directory. Override to return an already-absolute path.
+   * Default: `.logs/test_results/accessibility/` under the directory the run
+   * was launched from (captured at `@BeforeSuite`, so it is stable even after
+   * an `@api` bootstrap chdir()s to the docroot), falling back to the live
+   * working directory when the suite hook has not run. Override to return an
+   * already-absolute path.
    */
   protected function accessibilityGetReportDir(): string {
-    return getcwd() . DIRECTORY_SEPARATOR . '.logs/test_results/accessibility';
+    $base = self::$accessibilityBaseDir ?? (getcwd() ?: '');
+
+    return $base . DIRECTORY_SEPARATOR . '.logs/test_results/accessibility';
   }
 
   /**
@@ -567,7 +597,7 @@ trait AccessibilityTrait {
     $this->accessibilityLastCheckedUrl = $url;
 
     fwrite(STDOUT, sprintf("\n[accessibility] %s: %d violations, %d passes, %d incomplete (rules: %s)\n",
-      $url,
+      $this->accessibilityFormatUrl($url),
       count($normalized['violations'] ?? []),
       count($normalized['passes'] ?? []),
       count($normalized['incomplete'] ?? []),
@@ -595,7 +625,7 @@ trait AccessibilityTrait {
    */
   protected function accessibilityFormatGateMessage(string $url, string $rules, string $threshold, bool $check_incomplete, array $violations, array $incomplete): string {
     $lines = [
-      sprintf('Accessibility gate failed on %s (rules: %s, threshold: %s, fail_on_incomplete: %s):', $url, $rules, $threshold, $check_incomplete ? 'yes' : 'no'),
+      sprintf('Accessibility gate failed on %s (rules: %s, threshold: %s, fail_on_incomplete: %s):', $this->accessibilityFormatUrl($url), $rules, $threshold, $check_incomplete ? 'yes' : 'no'),
     ];
 
     foreach ($violations as $v) {
@@ -629,6 +659,35 @@ trait AccessibilityTrait {
    */
   protected function accessibilityStringifyTarget(array $target): string {
     return implode(' > ', array_map(fn($t): string => is_array($t) ? implode(' ', $t) : (string) $t, $target));
+  }
+
+  /**
+   * Format a page URL for display in reports and gate messages.
+   *
+   * Default: strip the configured Mink `base_url` prefix so reports show the
+   * page path (`/contact`) rather than the internal host and port
+   * (`http://nginx:8080/contact`), which is noise and makes reports
+   * non-portable. The base URL itself maps to `/` and the query string is
+   * kept. Only the known `base_url` is stripped: a genuinely cross-origin URL
+   * captured during assessment stays absolute, so it remains distinguishable.
+   * Override to keep the absolute URL or to format it differently.
+   */
+  protected function accessibilityFormatUrl(string $url): string {
+    $base = rtrim((string) $this->getMinkParameter('base_url'), '/');
+
+    if ($base === '') {
+      return $url;
+    }
+
+    if ($url === $base) {
+      return '/';
+    }
+
+    if (str_starts_with($url, $base . '/')) {
+      return substr($url, strlen($base));
+    }
+
+    return $url;
   }
 
   /**
@@ -707,7 +766,7 @@ HTML;
     $body_sections = [];
 
     foreach ($this->accessibilityResults as $r) {
-      $url = htmlspecialchars((string) $r['url'], ENT_QUOTES);
+      $url = htmlspecialchars($this->accessibilityFormatUrl((string) $r['url']), ENT_QUOTES);
       $rules = htmlspecialchars((string) $r['rules'], ENT_QUOTES);
       $violations = $r['result']['violations'] ?? [];
       $incomplete = $r['result']['incomplete'] ?? [];
@@ -773,7 +832,7 @@ HTML;
     $total_failures = 0;
 
     foreach ($this->accessibilityResults as $r) {
-      $url = $r['url'];
+      $url = $this->accessibilityFormatUrl((string) $r['url']);
       $violations = $r['result']['violations'] ?? [];
       $passes = $r['result']['passes'] ?? [];
 

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -118,7 +118,11 @@ trait AccessibilityTrait {
   public static function accessibilityCaptureBaseDir(): void {
     if (self::$accessibilityBaseDir === NULL) {
       $cwd = getcwd();
-      self::$accessibilityBaseDir = $cwd === FALSE ? '' : $cwd;
+      // Leave the base unset when getcwd() fails so the report directory
+      // retries it later rather than locking in an empty, root-relative base.
+      if ($cwd !== FALSE) {
+        self::$accessibilityBaseDir = $cwd;
+      }
     }
   }
 
@@ -316,7 +320,7 @@ trait AccessibilityTrait {
    * already-absolute path.
    */
   protected function accessibilityGetReportDir(): string {
-    $base = self::$accessibilityBaseDir ?? (getcwd() ?: '');
+    $base = self::$accessibilityBaseDir ?? (getcwd() ?: '.');
 
     return $base . DIRECTORY_SEPARATOR . '.logs/test_results/accessibility';
   }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -127,4 +127,19 @@ class FeatureContext extends DrupalContext {
     return $this->testElementScrollCenter;
   }
 
+  /**
+   * Override accessibilityGetReportDir() to anchor reports to the base path.
+   *
+   * Behat is launched from the build directory but configured with the
+   * project-root behat.yml, so the captured working directory is not the
+   * base path. Deriving the base from the Mink files_path keeps accessibility
+   * reports in the same .logs tree as the other Behat artifacts.
+   *
+   * This cannot be moved to FeatureContextTrait because traits cannot override
+   * methods from other traits.
+   */
+  protected function accessibilityGetReportDir(): string {
+    return dirname((string) $this->getMinkParameter('files_path'), 3) . '/.logs/test_results/accessibility';
+  }
+
 }

--- a/tests/behat/features/accessibility.feature
+++ b/tests/behat/features/accessibility.feature
@@ -40,6 +40,10 @@ Feature: Check that AccessibilityTrait works
       """
     And the output should contain:
       """
+      Accessibility gate failed on /sites/default/files/accessibility_violations.html
+      """
+    And the output should contain:
+      """
       violation [critical] image-alt
       """
     And the output should contain:
@@ -62,7 +66,7 @@ Feature: Check that AccessibilityTrait works
       """
     And the output should contain:
       """
-      violation [critical] image-alt
+      violation [critical] image-alt on /sites/default/files/accessibility_violations.html
       """
 
   @trait:AccessibilityTrait

--- a/tests/phpunit/src/AccessibilityTraitTest.php
+++ b/tests/phpunit/src/AccessibilityTraitTest.php
@@ -80,7 +80,7 @@ class AccessibilityTraitTest extends UnitTestCase {
   public function testGetReportDirFallsBackToCwdWhenUnset(): void {
     AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
 
-    $expected = (getcwd() ?: '') . DIRECTORY_SEPARATOR . '.logs/test_results/accessibility';
+    $expected = (getcwd() ?: '.') . DIRECTORY_SEPARATOR . '.logs/test_results/accessibility';
 
     $this->assertSame($expected, $this->testObject->testGetReportDir());
   }

--- a/tests/phpunit/src/AccessibilityTraitTest.php
+++ b/tests/phpunit/src/AccessibilityTraitTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests;
+
+use DrevOps\BehatSteps\AccessibilityTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for AccessibilityTrait.
+ */
+#[CoversClass(AccessibilityTrait::class)]
+class AccessibilityTraitTest extends UnitTestCase {
+
+  /**
+   * A test implementation of AccessibilityTrait.
+   */
+  protected AccessibilityTraitTestImplementation $testObject;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->testObject = new AccessibilityTraitTestImplementation();
+    AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
+
+    parent::tearDown();
+  }
+
+  #[DataProvider('dataProviderFormatUrl')]
+  public function testFormatUrl(string $base_url, string $url, string $expected): void {
+    $this->testObject->baseUrl = $base_url;
+
+    $this->assertSame($expected, $this->testObject->testFormatUrl($url));
+  }
+
+  public static function dataProviderFormatUrl(): array {
+    return [
+      'path under base' => ['http://nginx:8080', 'http://nginx:8080/contact', '/contact'],
+      'base root with trailing slash' => ['http://nginx:8080', 'http://nginx:8080/', '/'],
+      'base root without trailing slash' => ['http://nginx:8080', 'http://nginx:8080', '/'],
+      'nested path' => ['http://nginx:8080', 'http://nginx:8080/a/b/c', '/a/b/c'],
+      'query string preserved' => ['http://nginx:8080', 'http://nginx:8080/search?q=x', '/search?q=x'],
+      'base configured with trailing slash' => ['http://nginx:8080/', 'http://nginx:8080/contact', '/contact'],
+      'cross-origin kept absolute' => ['http://nginx:8080', 'https://example.com/page', 'https://example.com/page'],
+      'similar prefix not stripped' => ['http://nginx:8080', 'http://nginx:8080extra/foo', 'http://nginx:8080extra/foo'],
+      'no base url returns input unchanged' => ['', 'http://nginx:8080/contact', 'http://nginx:8080/contact'],
+    ];
+  }
+
+  public function testGetReportDirUsesCapturedBaseDir(): void {
+    AccessibilityTraitTestImplementation::testSetBaseDir('/sentinel/base');
+
+    // chdir() to a different directory to prove the report directory anchors to
+    // the captured base rather than the live working directory.
+    $original = getcwd();
+    chdir(static::locationsTmp());
+
+    try {
+      $this->assertSame('/sentinel/base' . DIRECTORY_SEPARATOR . '.logs/test_results/accessibility', $this->testObject->testGetReportDir());
+    }
+    finally {
+      if (is_string($original)) {
+        chdir($original);
+      }
+    }
+  }
+
+  public function testGetReportDirFallsBackToCwdWhenUnset(): void {
+    AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
+
+    $expected = (getcwd() ?: '') . DIRECTORY_SEPARATOR . '.logs/test_results/accessibility';
+
+    $this->assertSame($expected, $this->testObject->testGetReportDir());
+  }
+
+  public function testCaptureBaseDirSetsWhenUnset(): void {
+    AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
+
+    AccessibilityTraitTestImplementation::accessibilityCaptureBaseDir();
+
+    $this->assertSame(getcwd(), AccessibilityTraitTestImplementation::testGetBaseDir());
+  }
+
+  public function testCaptureBaseDirDoesNotOverwrite(): void {
+    AccessibilityTraitTestImplementation::testSetBaseDir('/sentinel/base');
+
+    AccessibilityTraitTestImplementation::accessibilityCaptureBaseDir();
+
+    $this->assertSame('/sentinel/base', AccessibilityTraitTestImplementation::testGetBaseDir());
+  }
+
+}
+
+/**
+ * Test implementation of AccessibilityTrait.
+ */
+class AccessibilityTraitTestImplementation {
+
+  use AccessibilityTrait;
+
+  /**
+   * Base URL returned by the stubbed Mink parameter accessor.
+   */
+  public string $baseUrl = '';
+
+  public function getMinkParameter(string $name): mixed {
+    return $name === 'base_url' ? $this->baseUrl : NULL;
+  }
+
+  public function testFormatUrl(string $url): string {
+    return $this->accessibilityFormatUrl($url);
+  }
+
+  public function testGetReportDir(): string {
+    return $this->accessibilityGetReportDir();
+  }
+
+  public static function testSetBaseDir(?string $dir): void {
+    self::$accessibilityBaseDir = $dir;
+  }
+
+  public static function testGetBaseDir(): ?string {
+    return self::$accessibilityBaseDir;
+  }
+
+}


### PR DESCRIPTION
Closes #657
Closes #659

## Summary

`AccessibilityTrait` built its report directory from a live `getcwd()` call, but the Drupal Extension `@api` bootstrap calls `chdir()` to the docroot before the first scenario runs, silently moving reports into `web/.logs/...` instead of the project-root `.logs/` tree. A new `#[BeforeSuite]` hook captures the launch directory into a static `$accessibilityBaseDir` once before any scenario can alter it, anchoring the default report path to that stable base. Per-scenario reports and console/gate messages also printed the full internal URL including host and port (e.g. `http://nginx:8080/contact`), which is noise and non-portable across environments. A new `accessibilityFormatUrl()` method strips the configured Mink `base_url` prefix so display paths show as `/contact`; the base URL itself maps to `/`, query strings are preserved, and genuinely cross-origin URLs remain absolute.

## Changes

**`src/AccessibilityTrait.php`**
- Added `$accessibilityBaseDir` static property to hold the captured launch directory.
- Added `#[BeforeSuite]` hook `accessibilityCaptureBaseDir()` that sets `$accessibilityBaseDir` from `getcwd()` once before any scenario runs.
- Updated `accessibilityGetReportDir()` to anchor the default `.logs/test_results/accessibility` path to `$accessibilityBaseDir`, falling back to the live `getcwd()` when the hook has not run.
- Added `accessibilityFormatUrl(string $url): string` that strips the `base_url` prefix for display, mapping the base root to `/` and preserving query strings; cross-origin URLs are left absolute.
- Applied `accessibilityFormatUrl()` at all five rendering sites: auto-mode gate violation lines, auto-mode gate incomplete lines, console output line, explicit gate message header, HTML `<h2>` heading, and JUnit `testsuite name` + `URL:` detail line.

**`tests/behat/bootstrap/FeatureContext.php`**
- Added `accessibilityGetReportDir()` override that derives the base from the Mink `files_path` parameter, keeping accessibility reports in the same `.logs` tree as coverage and screenshots when Behat is launched from `build/` with a project-root `behat.yml`.

**`tests/behat/features/accessibility.feature`**
- Strengthened `@trait` scenario assertions to verify that the stripped page path (`/sites/default/files/accessibility_violations.html`) appears in gate output rather than just checking the gate prefix.

**`tests/phpunit/src/AccessibilityTraitTest.php`** (new)
- Data-provider unit tests for `accessibilityFormatUrl()` covering path stripping, root mapping, query-string preservation, cross-origin safety, similar-prefix safety, and empty base URL passthrough.
- Unit tests for `accessibilityGetReportDir()` verifying it anchors to the captured base dir and falls back to the live cwd when unset.
- Unit tests for `accessibilityCaptureBaseDir()` verifying it sets the property when unset and does not overwrite an existing value.

## Before / After

**Report directory (with `@api` bootstrap)**

```
Before:  web/.logs/test_results/accessibility/scenario-name.html
After:   .logs/test_results/accessibility/scenario-name.html
```

**Gate / console output URL display**

```
Before:  [accessibility] http://nginx:8080/contact: 3 violations ...
After:   [accessibility] /contact: 3 violations ...

Before:  Accessibility gate failed on http://nginx:8080/contact (rules: ...)
After:   Accessibility gate failed on /contact (rules: ...)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes two issues in `AccessibilityTrait` output stability and portability:

1. **Report directory placement after Drupal `@api` bootstrap**
   - The Drupal Extension’s `drupal` API driver calls `chdir()` to the docroot during bootstrap, shifting `getcwd()` away from the project root.
   - Accessibility reports were therefore written under `web/.logs/test_results/accessibility/` instead of the expected project-root `.logs/test_results/accessibility/`.
   - The fix adds a suite-level `#[BeforeSuite]` hook `accessibilityCaptureBaseDir()` that captures the initial working directory into a static `$accessibilityBaseDir` before scenarios can change it. `accessibilityGetReportDir()` now builds paths from this captured base (falling back to live `getcwd()` for backward compatibility). If base capture encounters a transient failure, the captured base is left unset so the fallback can still retry rather than persisting stale state.

2. **Environment-specific absolute URLs in reports and console output**
   - Per-scenario reports and gate failure messages previously displayed full internal container URLs like `http://nginx:8080/contact`, polluting output and breaking portability.
   - A new `accessibilityFormatUrl()` normalizes displayed URLs by stripping the Mink `base_url` prefix (mapping the base itself to `/`, preserving query strings, and keeping genuinely cross-origin absolute URLs unchanged).
   - Rendering points updated include gate failure messages, STDOUT/console accessibility summaries, HTML headings, and JUnit XML details.

## Changes

- **`src/AccessibilityTrait.php`**
  - Added `$accessibilityBaseDir` and `#[BeforeSuite] accessibilityCaptureBaseDir()` capture logic.
  - Updated `accessibilityGetReportDir()` to anchor to `$accessibilityBaseDir` (with fallback to `getcwd()`).
  - Added `accessibilityFormatUrl()` and updated five output/rendering sites to use it.

- **`tests/behat/bootstrap/FeatureContext.php`**
  - Overrode `accessibilityGetReportDir()` to derive the base directory from the Mink `files_path`, keeping accessibility reports in the same `.logs` tree as other Behat artifacts.

- **`tests/behat/features/accessibility.feature`**
  - Updated expectations to match formatted URL output (e.g., asserting `/sites/default/files/accessibility_violations.html` and including it in auto/explicit gate failure lines).

- **`tests/phpunit/src/AccessibilityTraitTest.php`**
  - Added unit tests covering:
    - URL formatting across base-root vs nested paths, trailing slash normalization, query string preservation, cross-origin absolute URL handling, and empty base URL behavior.
    - Report directory resolution using the captured base and fallback behavior when unset.
    - Capture semantics (sets when unset, does not overwrite existing captured base).

## Step definition / CONTRIBUTING.md compliance

- No step definitions were added or modified; Behat changes are limited to feature expectations and a context method override, so no CONTRIBUTING.md step-format violations are introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->