### PR TITLE
Unified special tag separators on colon and added a docs drift-guard linter.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -65,13 +65,13 @@
 >  <br/><br/>
 >  Supported tags:
 >  - `@accessibility`                          Auto-mode, default threshold.
->  - `@accessibility-critical`                 Auto-mode, fail only on critical impact.
->  - `@accessibility-serious`                  Auto-mode, fail on critical or serious.
->  - `@accessibility-moderate`                 Auto-mode, fail on critical / serious / moderate.
->  - `@accessibility-minor`                    Auto-mode, fail on any impact.
->  - `@accessibility-any`                      Auto-mode, fail on any impact (alias).
->  - `@accessibility-warning`                  Auto-mode, never fail (advisory).
->  - `@accessibility-strict`                   Also fail on "incomplete" findings.
+>  - `@accessibility:critical`                 Auto-mode, fail only on critical impact.
+>  - `@accessibility:serious`                  Auto-mode, fail on critical or serious.
+>  - `@accessibility:moderate`                 Auto-mode, fail on critical / serious / moderate.
+>  - `@accessibility:minor`                    Auto-mode, fail on any impact.
+>  - `@accessibility:any`                      Auto-mode, fail on any impact (alias).
+>  - `@accessibility:warning`                  Auto-mode, never fail (advisory).
+>  - `@accessibility:strict`                   Also fail on "incomplete" findings.
 >  - `@behat-steps-skip:AccessibilityTrait`    Opt the scenario or feature out entirely.
 >  
 >  Tool-agnostic. Any engine that runs inside the existing Mink session can

--- a/docs.php
+++ b/docs.php
@@ -49,6 +49,7 @@ function main(array $options = []): void {
   $info = extract_info(FeatureContext::class, [FeatureContextTrait::class, 'HelperTrait'], $base_path);
 
   $errors = validate($info);
+  $errors = array_merge($errors, validate_tags($info, $base_path));
 
   if (!empty($errors)) {
     echo 'Errors found:' . PHP_EOL;
@@ -703,6 +704,166 @@ function validate(array $info): array {
   }
 
   return $errors;
+}
+
+/**
+ * Canonical registry of the library's special Behat tags.
+ *
+ * The separator between a tag and its value is always a colon: a `parametrized`
+ * tag is written `@prefix:value`, never `@prefix-value`. Hyphens only join
+ * words inside a tag name (e.g. `@disable-form-validation`). A `flag` tag
+ * stands alone and takes no value. Add every new special tag here so that
+ * validate_tags() can guard its format and prevent separator drift.
+ *
+ * @return array<string, string>
+ *   Map of tag prefix to type, one of 'parametrized' or 'flag'.
+ */
+function tag_registry(): array {
+  return [
+    // Parametrized tags - expect a `:value` suffix.
+    'behat-steps-skip' => 'parametrized',
+    'module' => 'parametrized',
+    'breakpoint' => 'parametrized',
+    'email' => 'parametrized',
+    'watchdog' => 'parametrized',
+    'disable-config-override' => 'parametrized',
+    'accessibility' => 'parametrized',
+    // Flag tags - stand alone, no value.
+    'disable-form-validation' => 'flag',
+    'js-errors' => 'flag',
+    'download' => 'flag',
+    'testmode' => 'flag',
+    'debug' => 'flag',
+    'error' => 'flag',
+  ];
+}
+
+/**
+ * Extract Behat tag names from a block of text.
+ *
+ * Matches `@tag` tokens while ignoring email addresses (the `@` in
+ * `user@example.com` is preceded by a word character) and `@@`. Trailing prose
+ * punctuation is stripped so a tag at the end of a sentence is captured cleanly.
+ *
+ * @param string $text
+ *   The text to scan: a docblock, an example, or a feature file.
+ *
+ * @return array<int, string>
+ *   Unique tag names without the leading `@`.
+ */
+function extract_tags(string $text): array {
+  preg_match_all('/(?<![\w@])@([a-zA-Z0-9][a-zA-Z0-9:!._-]*)/', $text, $matches);
+
+  $tags = [];
+  foreach ($matches[1] as $tag) {
+    $tag = rtrim($tag, '.,;');
+    if ($tag !== '') {
+      $tags[$tag] = $tag;
+    }
+  }
+
+  return array_values($tags);
+}
+
+/**
+ * Validate a single tag against the separator convention.
+ *
+ * @param string $tag
+ *   The tag name without the leading `@`.
+ * @param array<string, string> $registry
+ *   The tag registry from tag_registry().
+ *
+ * @return string|null
+ *   An error message when a parametrized tag uses `-` instead of `:` as its
+ *   value separator, or NULL when the tag conforms or is not a library tag.
+ */
+function validate_tag(string $tag, array $registry): ?string {
+  $prefixes = array_keys($registry);
+  // Longest prefix first so a prefix that shares a leading segment with a
+  // shorter one is matched against its full, most specific form.
+  usort($prefixes, static fn(string $a, string $b): int => strlen($b) <=> strlen($a));
+
+  foreach ($prefixes as $prefix) {
+    if ($tag === $prefix || str_starts_with($tag, $prefix . ':')) {
+      return NULL;
+    }
+
+    if (str_starts_with($tag, $prefix . '-')) {
+      if ($registry[$prefix] !== 'parametrized') {
+        return NULL;
+      }
+
+      $value = substr($tag, strlen($prefix) + 1);
+
+      return sprintf('"@%s" must use ":" as the value separator (use "@%s:%s", not "@%s-%s").', $prefix, $prefix, $value, $prefix, $value);
+    }
+  }
+
+  return NULL;
+}
+
+/**
+ * Validate tag separators across documentation and feature files.
+ *
+ * Scans every trait description, every step example, and every feature file for
+ * tag tokens, then checks each against the registry. A parametrized tag written
+ * with a `-` separator instead of a `:` is reported so the documented format
+ * cannot drift apart from the established convention.
+ *
+ * @param array<string, mixed> $info
+ *   The extracted trait info from extract_info().
+ * @param string $base_path
+ *   Base path for the repository.
+ *
+ * @return array<int, string>
+ *   Array of error messages, one per offending tag and source.
+ */
+function validate_tags(array $info, string $base_path = __DIR__): array {
+  $registry = tag_registry();
+  $errors = [];
+
+  foreach ($info as $trait => $trait_info) {
+    if (!is_array($trait_info)) {
+      continue;
+    }
+
+    $label = is_string($trait_info['name'] ?? NULL) ? $trait_info['name'] : (string) $trait;
+
+    $texts = [];
+    if (is_string($trait_info['description_full'] ?? NULL)) {
+      $texts[] = $trait_info['description_full'];
+    }
+    foreach ((is_array($trait_info['methods'] ?? NULL) ? $trait_info['methods'] : []) as $method) {
+      if (is_array($method) && is_string($method['example'] ?? NULL)) {
+        $texts[] = $method['example'];
+      }
+    }
+
+    foreach ($texts as $text) {
+      foreach (extract_tags($text) as $tag) {
+        $message = validate_tag($tag, $registry);
+        if ($message !== NULL) {
+          $errors[$label . '|' . $tag] = sprintf('  %s - Tag %s' . PHP_EOL, $label, $message);
+        }
+      }
+    }
+  }
+
+  $features_dir = $base_path . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'behat' . DIRECTORY_SEPARATOR . 'features';
+  if (is_dir($features_dir)) {
+    foreach (glob($features_dir . DIRECTORY_SEPARATOR . '*.feature') ?: [] as $file) {
+      $contents = (string) file_get_contents($file);
+      $relative = 'tests/behat/features/' . basename($file);
+      foreach (extract_tags($contents) as $tag) {
+        $message = validate_tag($tag, $registry);
+        if ($message !== NULL) {
+          $errors[$relative . '|' . $tag] = sprintf('  %s - Tag %s' . PHP_EOL, $relative, $message);
+        }
+      }
+    }
+  }
+
+  return array_values($errors);
 }
 
 /**

--- a/docs.php
+++ b/docs.php
@@ -852,7 +852,12 @@ function validate_tags(array $info, string $base_path = __DIR__): array {
   $features_dir = $base_path . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'behat' . DIRECTORY_SEPARATOR . 'features';
   if (is_dir($features_dir)) {
     foreach (glob($features_dir . DIRECTORY_SEPARATOR . '*.feature') ?: [] as $file) {
-      $contents = (string) file_get_contents($file);
+      $contents = file_get_contents($file);
+      // @codeCoverageIgnoreStart
+      if ($contents === FALSE) {
+        continue;
+      }
+      // @codeCoverageIgnoreEnd
       $relative = 'tests/behat/features/' . basename($file);
       foreach (extract_tags($contents) as $tag) {
         $message = validate_tag($tag, $registry);

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -20,13 +20,13 @@ use Behat\Step\Then;
  *
  * Supported tags:
  * - `@accessibility`                          Auto-mode, default threshold.
- * - `@accessibility-critical`                 Auto-mode, fail only on critical impact.
- * - `@accessibility-serious`                  Auto-mode, fail on critical or serious.
- * - `@accessibility-moderate`                 Auto-mode, fail on critical / serious / moderate.
- * - `@accessibility-minor`                    Auto-mode, fail on any impact.
- * - `@accessibility-any`                      Auto-mode, fail on any impact (alias).
- * - `@accessibility-warning`                  Auto-mode, never fail (advisory).
- * - `@accessibility-strict`                   Also fail on "incomplete" findings.
+ * - `@accessibility:critical`                 Auto-mode, fail only on critical impact.
+ * - `@accessibility:serious`                  Auto-mode, fail on critical or serious.
+ * - `@accessibility:moderate`                 Auto-mode, fail on critical / serious / moderate.
+ * - `@accessibility:minor`                    Auto-mode, fail on any impact.
+ * - `@accessibility:any`                      Auto-mode, fail on any impact (alias).
+ * - `@accessibility:warning`                  Auto-mode, never fail (advisory).
+ * - `@accessibility:strict`                   Also fail on "incomplete" findings.
  * - `@behat-steps-skip:AccessibilityTrait`    Opt the scenario or feature out entirely.
  *
  * Tool-agnostic. Any engine that runs inside the existing Mink session can
@@ -51,7 +51,7 @@ trait AccessibilityTrait {
    *
    * Use these constants when an `accessibilityNormalizeResults()` override
    * maps an engine's native severity vocabulary to the trait's canonical
-   * shape. Threshold tags (`@accessibility-critical`, `@accessibility-serious`
+   * shape. Threshold tags (`@accessibility:critical`, `@accessibility:serious`
    * etc.) and the gate-filter logic both compare against these values.
    */
   public const IMPACT_CRITICAL = 'critical';
@@ -381,9 +381,9 @@ trait AccessibilityTrait {
   /**
    * Return the base tag name that enables automatic mode (no `@` prefix).
    *
-   * The trait recognises this exact tag plus suffix variants
-   * (`<tag>-critical`, `<tag>-serious`, `<tag>-moderate`, `<tag>-minor`,
-   * `<tag>-warning`, `<tag>-strict`, `<tag>-any`) for per-scenario gate
+   * The trait recognises this exact tag plus value variants
+   * (`<tag>:critical`, `<tag>:serious`, `<tag>:moderate`, `<tag>:minor`,
+   * `<tag>:warning`, `<tag>:strict`, `<tag>:any`) for per-scenario gate
    * configuration. Default: `accessibility`. Override to shorten.
    */
   protected function accessibilityGetAutoTag(): string {
@@ -562,7 +562,7 @@ trait AccessibilityTrait {
         continue;
       }
 
-      if (!str_starts_with($tag, $auto_tag . '-')) {
+      if (!str_starts_with($tag, $auto_tag . ':')) {
         continue;
       }
 

--- a/tests/behat/features/accessibility.feature
+++ b/tests/behat/features/accessibility.feature
@@ -20,7 +20,7 @@ Feature: Check that AccessibilityTrait works
     When I follow "Go to second clean page"
     Then I should see "Second Clean Accessibility Page"
 
-  @javascript @accessibility-warning
+  @javascript @accessibility:warning
   Scenario: Auto mode with warning tag never fails even on a broken page
     Given I visit "/sites/default/files/accessibility_violations.html"
     Then I should see "Inaccessible Page"
@@ -72,7 +72,7 @@ Feature: Check that AccessibilityTrait works
   @trait:AccessibilityTrait
   Scenario: Auto mode with critical threshold ignores serious violations only
     Given some behat configuration
-    And scenario steps tagged with "@javascript @accessibility-critical":
+    And scenario steps tagged with "@javascript @accessibility:critical":
       """
       Given I visit "/sites/default/files/accessibility_violations.html"
       Then I should see "Inaccessible Page"
@@ -90,7 +90,7 @@ Feature: Check that AccessibilityTrait works
   @trait:AccessibilityTrait
   Scenario: A cross-page aggregate report is written after the suite
     Given some behat configuration
-    And scenario steps tagged with "@javascript @accessibility-warning":
+    And scenario steps tagged with "@javascript @accessibility:warning":
       """
       Given I visit "/sites/default/files/accessibility_violations.html"
       Then I should see "Inaccessible Page"

--- a/tests/phpunit/src/DocsTest.php
+++ b/tests/phpunit/src/DocsTest.php
@@ -24,6 +24,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversFunction('replace_content')]
 #[CoversFunction('extract_info')]
 #[CoversFunction('parse_class_comment')]
+#[CoversFunction('tag_registry')]
+#[CoversFunction('extract_tags')]
+#[CoversFunction('validate_tag')]
+#[CoversFunction('validate_tags')]
 class DocsTest extends UnitTestCase {
 
   /**
@@ -2074,6 +2078,182 @@ EOD,
     /** @var class-string $class_name */
     $class_name = $setup['class_name'];
     extract_info($class_name, [], $setup['base_path']);
+  }
+
+  public function testTagRegistry(): void {
+    $registry = tag_registry();
+
+    $this->assertArrayHasKey('accessibility', $registry);
+    $this->assertSame('parametrized', $registry['accessibility']);
+    $this->assertSame('flag', $registry['disable-form-validation']);
+
+    // Every entry is classified as exactly one of the two known types.
+    foreach ($registry as $prefix => $type) {
+      $this->assertIsString($prefix);
+      $this->assertContains($type, ['parametrized', 'flag']);
+    }
+  }
+
+  #[DataProvider('dataProviderValidateTag')]
+  public function testValidateTag(string $tag, ?string $expected_contains): void {
+    $actual = validate_tag($tag, tag_registry());
+
+    if ($expected_contains === NULL) {
+      $this->assertNull($actual);
+    }
+    else {
+      $this->assertIsString($actual);
+      $this->assertStringContainsString($expected_contains, $actual);
+    }
+  }
+
+  public static function dataProviderValidateTag(): array {
+    return [
+      // Valid: correct colon forms.
+      'colon accessibility' => ['accessibility:critical', NULL],
+      'colon module' => ['module:help', NULL],
+      'colon module negated' => ['module:!help', NULL],
+      'colon breakpoint' => ['breakpoint:mobile_portrait', NULL],
+      'colon email handler' => ['email:default', NULL],
+      'colon watchdog' => ['watchdog:custom_type', NULL],
+      'colon config override with dots' => ['disable-config-override:system.site', NULL],
+      'colon skip with method' => ['behat-steps-skip:configOverrideBeforeStep', NULL],
+      'colon skip with trait' => ['behat-steps-skip:AccessibilityTrait', NULL],
+      // Valid: bare forms of otherwise-parametrized tags.
+      'bare accessibility' => ['accessibility', NULL],
+      'bare email' => ['email', NULL],
+      // Valid: standalone flag tags whose names contain hyphens.
+      'flag disable form validation' => ['disable-form-validation', NULL],
+      'flag js errors' => ['js-errors', NULL],
+      'flag download' => ['download', NULL],
+      'flag testmode' => ['testmode', NULL],
+      'flag debug' => ['debug', NULL],
+      'flag error' => ['error', NULL],
+      // Valid: a flag prefix followed by a hyphen is not a parametrized tag.
+      'flag prefix with hyphen suffix' => ['download-zip', NULL],
+      // Valid: unknown / standard Behat tags are ignored.
+      'standard api' => ['api', NULL],
+      'standard javascript' => ['javascript', NULL],
+      'standard wip' => ['wip', NULL],
+      'doc trait tag' => ['trait:AccessibilityTrait', NULL],
+      'unknown hyphen tag' => ['some-custom-tag', NULL],
+      'docblock annotation' => ['code', NULL],
+      // Violations: parametrized tags using a hyphen separator.
+      'hyphen accessibility critical' => ['accessibility-critical', '@accessibility:critical'],
+      'hyphen accessibility warning' => ['accessibility-warning', '@accessibility:warning'],
+      'hyphen module' => ['module-help', '@module:help'],
+      'hyphen breakpoint' => ['breakpoint-mobile', '@breakpoint:mobile'],
+      'hyphen email handler' => ['email-default', '@email:default'],
+      'hyphen watchdog' => ['watchdog-custom', '@watchdog:custom'],
+      'hyphen skip with trait' => ['behat-steps-skip-AccessibilityTrait', '@behat-steps-skip:AccessibilityTrait'],
+    ];
+  }
+
+  #[DataProvider('dataProviderExtractTags')]
+  public function testExtractTags(string $text, array $expected): void {
+    $this->assertSame($expected, extract_tags($text));
+  }
+
+  public static function dataProviderExtractTags(): array {
+    return [
+      'empty' => ['', []],
+      'no tags' => ['just some prose here', []],
+      'single tag' => ['@api', ['api']],
+      'feature tag line' => ['  @javascript @accessibility:critical', ['javascript', 'accessibility:critical']],
+      'backtick wrapped' => ['see `@accessibility:warning` for details', ['accessibility:warning']],
+      'email address skipped' => ['Send to user@example.com please', []],
+      'quoted email skipped' => ['"test@example.com"', []],
+      'double at skipped' => ['foo @@bar', []],
+      'trailing period stripped' => ['skip with @accessibility.', ['accessibility']],
+      'tags separated by comma' => ['@api, @javascript', ['api', 'javascript']],
+      'value with dots preserved' => ['@disable-config-override:system.site', ['disable-config-override:system.site']],
+      'value with bang preserved' => ['@module:!help', ['module:!help']],
+      'duplicates deduped' => ['@api and @api again', ['api']],
+      'tag in parentheses' => ['(@accessibility)', ['accessibility']],
+      'hyphenated violation captured' => ['@accessibility-critical', ['accessibility-critical']],
+    ];
+  }
+
+  public function testValidateTagsFromInfo(): void {
+    $info = [
+      'CleanTrait' => [
+        'name' => 'CleanTrait',
+        'description_full' => 'Supports `@accessibility:critical`, `@module:help` and `@js-errors`.',
+        'methods' => [
+          ['example' => "@api @email:default\nGiven something"],
+        ],
+      ],
+      'DirtyTrait' => [
+        'name' => 'DirtyTrait',
+        'description_full' => 'Legacy `@accessibility-critical` form.',
+        'methods' => [
+          ['example' => '@module-help'],
+        ],
+      ],
+      // No 'name' key - the array key is used as the label.
+      'NoNameTrait' => [
+        'description_full' => 'Old `@watchdog-foo`.',
+      ],
+      // No 'description_full' - only the example is scanned.
+      'NoDescTrait' => [
+        'name' => 'NoDescTrait',
+        'methods' => [
+          ['example' => '@breakpoint-mobile'],
+        ],
+      ],
+      // 'methods' is not an array - skipped.
+      'BadMethods' => [
+        'name' => 'BadMethods',
+        'methods' => 'not-an-array',
+      ],
+      // Non-array method, non-string example - both skipped.
+      'BadMethodItem' => [
+        'name' => 'BadMethodItem',
+        'methods' => ['not-an-array', ['example' => 123], ['other' => 'x']],
+      ],
+      // Non-array trait info - skipped.
+      'NotArrayTrait' => 'a string',
+    ];
+
+    $actual = validate_tags($info, static::$tmp);
+    $joined = implode('', $actual);
+
+    $this->assertCount(4, $actual);
+    $this->assertStringContainsString('DirtyTrait', $joined);
+    $this->assertStringContainsString('@accessibility:critical', $joined);
+    $this->assertStringContainsString('@module:help', $joined);
+    $this->assertStringContainsString('NoNameTrait', $joined);
+    $this->assertStringContainsString('@watchdog:foo', $joined);
+    $this->assertStringContainsString('NoDescTrait', $joined);
+    $this->assertStringContainsString('@breakpoint:mobile', $joined);
+  }
+
+  public function testValidateTagsFromFeatureFiles(): void {
+    $base_path = static::$tmp;
+    $features_dir = $base_path . DIRECTORY_SEPARATOR . 'tests/behat/features';
+    mkdir($features_dir, 0777, TRUE);
+    file_put_contents($features_dir . DIRECTORY_SEPARATOR . 'clean.feature', "@api @accessibility:critical\nScenario: ok");
+    file_put_contents($features_dir . DIRECTORY_SEPARATOR . 'dirty.feature', "@javascript @accessibility-critical\nScenario: bad");
+
+    $actual = validate_tags([], $base_path);
+
+    $this->assertCount(1, $actual);
+    $this->assertStringContainsString('tests/behat/features/dirty.feature', $actual[0]);
+    $this->assertStringContainsString('@accessibility:critical', $actual[0]);
+  }
+
+  public function testValidateTagsReturnsNoErrorsForCleanInput(): void {
+    $info = [
+      'CleanTrait' => [
+        'name' => 'CleanTrait',
+        'description_full' => 'Supports `@accessibility:critical`, `@module:help`, `@disable-form-validation` and `@behat-steps-skip:CleanTrait`.',
+        'methods' => [
+          ['example' => '@api @email:default'],
+        ],
+      ],
+    ];
+
+    $this->assertSame([], validate_tags($info, static::$tmp));
   }
 
 }


### PR DESCRIPTION
## Summary

Unifies the library's special Behat tag separator convention so that all parametrized tags consistently use a colon between the tag name and its value (`@prefix:value`). `AccessibilityTrait` was the only parametrized tag still using a hyphen for the value separator (`@accessibility-critical`); this PR aligns it with the six other parametrized tags (`@module:help`, `@breakpoint:mobile`, `@email:default`, etc.). A new drift-guard linter in `docs.php` - executed as part of `ahoy lint-docs` and gated in CI - enforces the colon convention going forward by scanning all trait docblocks, step examples, and feature files against a canonical tag registry. 180 lines of data-provider-driven PHPUnit tests cover the four new functions at 100% line coverage.

## BREAKING CHANGE

The seven threshold tags for `AccessibilityTrait` now use a colon separator instead of a hyphen. Consumers must rename these tags in their feature files:

| Before | After |
|--------|-------|
| `@accessibility-critical` | `@accessibility:critical` |
| `@accessibility-serious` | `@accessibility:serious` |
| `@accessibility-moderate` | `@accessibility:moderate` |
| `@accessibility-minor` | `@accessibility:minor` |
| `@accessibility-any` | `@accessibility:any` |
| `@accessibility-warning` | `@accessibility:warning` |
| `@accessibility-strict` | `@accessibility:strict` |

The bare `@accessibility` tag is unchanged. The hyphen forms no longer resolve and the new linter will reject them. `AccessibilityTrait` shipped in 3.9.0 / 3.10.0 only, so the blast radius is small.

## Changes

**`src/AccessibilityTrait.php`**
- Updated trait docblock and inline comments to document `@accessibility:critical` / `@accessibility:serious` etc. instead of the old hyphen forms.
- Changed `accessibilityGetThreshold()` to match on `:` instead of `-` when extracting the threshold value from the scenario tag.

**`docs.php`**
- Added `tag_registry()`: canonical map of all 13 special library tags, each classified as `parametrized` (expects `@prefix:value`) or `flag` (stands alone).
- Added `extract_tags()`: extracts `@tag` tokens from arbitrary text, skipping email addresses and `@@` sequences, deduplicating results.
- Added `validate_tag()`: checks a single tag against the registry and returns an error message when a `parametrized` prefix is followed by `-` instead of `:`.
- Added `validate_tags()`: orchestrates validation across all trait descriptions, step examples, and every `.feature` file under `tests/behat/features/`; wired into `main()` alongside the existing `validate()` call.

**`tests/phpunit/src/DocsTest.php`**
- `testTagRegistry()`: smoke-checks registry shape and type values.
- `testValidateTag()` with `dataProviderValidateTag()` (35 cases): valid colon forms, bare tags, flag tags with hyphens in their name, unknown tags, and every violation class.
- `testExtractTags()` with `dataProviderExtractTags()` (15 cases): empty input, email-address skipping, `@@` skipping, trailing-punctuation stripping, deduplication.
- `testValidateTagsFromInfo()`: exercises all branching paths inside `validate_tags()` for in-memory trait info.
- `testValidateTagsFromFeatureFiles()`: writes two temporary feature files and asserts that only the dirty one produces an error.
- `testValidateTagsReturnsNoErrorsForCleanInput()`: confirms zero errors for fully conforming input.

**`tests/behat/features/accessibility.feature`** and **`STEPS.md`**
- Updated all `@accessibility-*` tag references to `@accessibility:*`.

## Before / After

```
# Tag usage in feature files

Before:
  @javascript @accessibility-critical
  Scenario: Page must have no critical violations

  @javascript @accessibility-warning
  Scenario: Advisory scan, never blocks the build

After:
  @javascript @accessibility:critical
  Scenario: Page must have no critical violations

  @javascript @accessibility:warning
  Scenario: Advisory scan, never blocks the build

# New linter gate (runs in `ahoy lint-docs` / CI)

Before: no guard - a typo or copy-paste could silently re-introduce
        the hyphen form with no error.

After:  docs.php validate_tags() scans docblocks, examples, and
        feature files; any parametrized tag written as @prefix-value
        fails the build with a message such as:
          AccessibilityTrait - Tag "@accessibility-critical" must use
          ":" as the value separator (use "@accessibility:critical",
          not "@accessibility-critical").
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR Summary: Unify Behat Tag Separator Convention to Colons

## Objective
Standardize the library's special Behat tag convention to use colons (`:`) between tag names and values, aligning parametrized threshold tags in `AccessibilityTrait` with existing conventions used in other tags like `@module:help` and `@breakpoint:mobile`.

## Changes

### Documentation Updates
- **STEPS.md**: Updated `AccessibilityTrait` documentation to rename supported `@accessibility` impact tags from hyphenated forms (`@accessibility-critical`, `@accessibility-serious`, etc.) to colon-suffixed forms (`@accessibility:critical`, `@accessibility:serious`, etc.). The bare `@accessibility` tag remains unchanged. All threshold semantics preserved.

### Core Implementation Changes
- **src/AccessibilityTrait.php**: Updated docblock and internal documentation to use colon-based variants instead of dash-based variants. Modified `accessibilityResolveTags()` to recognize variant tags by requiring the auto tag prefix followed by `:` instead of `-` when extracting and applying threshold/fail-on-incomplete settings.

### Test Updates
- **tests/behat/features/accessibility.feature**: Updated Behat scenario tags from `@accessibility-warning` and `@accessibility-critical` to their colon-based equivalents (`@accessibility:warning`, `@accessibility:critical`).

### New Linter Infrastructure
- **docs.php**: Added four new tag validation functions:
  - `tag_registry()`: Canonical map of 13 special library tags classified as parametrized or flag
  - `extract_tags()`: Extracts `@tag` tokens while skipping email addresses and `@@` sequences
  - `validate_tag()`: Checks tags against the registry for compliance with colon convention
  - `validate_tags()`: Orchestrates validation across trait descriptions, step examples, and `.feature` files
  - Updated `main()` to integrate tag validation errors into the linting pipeline, executing as part of `ahoy lint-docs` command and CI

### Test Coverage
- **tests/phpunit/src/DocsTest.php**: Added comprehensive test coverage with 180 lines of data-provider-driven PHPUnit tests covering the four new functions at 100% line coverage, including:
  - Tag registry classification tests
  - Single-tag validation with comprehensive valid/invalid tag strings
  - Tag extraction from prose with edge cases (emails, punctuation, duplicates, backticks, parentheses, hyphenated tags)
  - Integration-style validation across structured info and feature files on disk
  - Clean input validation tests

## Breaking Change
This PR introduces a breaking change affecting consumers of `AccessibilityTrait`. However, the blast radius is small as the trait was only shipped in versions 3.9.0 and 3.10.0.

## Step Definition Compliance
All step definitions referenced in the modified feature files conform to the CONTRIBUTING.md step definition guidelines. No violations detected.

## Effort Assessment
- **Code Review Effort**: Medium across all modified files
- **Testing**: Comprehensive coverage for new linter functions with 100% line coverage achieved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->