### PR TITLE
[#664] Gated advisory accessibility violations out of JUnit failures.

### DIFF
--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -895,8 +895,18 @@ HTML;
 
   /**
    * Render the scenario-level JUnit XML report from collected results.
+   *
+   * Violations are gated by the scenario's effective threshold, exactly as the
+   * pass/fail gate is: only violations meeting the threshold are serialised as
+   * `<failure>` cases, so an advisory run (threshold `never`) writes a report
+   * with zero failures instead of one that reddens a JUnit-consuming CI check.
+   * Violations below the threshold are recorded as passing cases carrying the
+   * finding in `<system-out>`, so they stay visible without failing the report.
+   * The `tests` and `failures` counts reflect the actual emitted `<testcase>`
+   * elements, one per affected node.
    */
   protected function accessibilityRenderJunit(): string {
+    $threshold = $this->accessibilityEffectiveThreshold();
     $suites_xml = '';
     $total_tests = 0;
     $total_failures = 0;
@@ -906,13 +916,12 @@ HTML;
       $violations = $r['result']['violations'] ?? [];
       $passes = $r['result']['passes'] ?? [];
 
-      $tests = count($violations) + count($passes);
-      $failures = count($violations);
-      $total_tests += $tests;
-      $total_failures += $failures;
-
       $cases_xml = '';
+      $tests = 0;
+      $failures = 0;
+
       foreach ($violations as $v) {
+        $failing = $this->accessibilityFilterViolations([$v], $threshold) !== [];
         $rule_id = (string) ($v['id'] ?? 'unknown');
         $impact = (string) ($v['impact'] ?? 'unknown');
         $help = (string) ($v['help'] ?? '');
@@ -921,25 +930,29 @@ HTML;
         foreach ($v['nodes'] ?? [] as $node) {
           $target = static::accessibilityStringifyTarget($node['target'] ?? []);
           $html = trim((string) ($node['html'] ?? ''));
-
-          $message = sprintf('[%s] %s', $impact, $help);
           $details = sprintf("URL: %s\nRule: %s\nTarget: %s\nHTML: %s\nDocs: %s", $url, $rule_id, $target, $html, $help_url);
+          $classname = htmlspecialchars('accessibility.' . $rule_id, ENT_XML1 | ENT_QUOTES);
+          $name = htmlspecialchars($target ?: $rule_id, ENT_XML1 | ENT_QUOTES);
+          $tests++;
 
-          $cases_xml .= sprintf(
-            '<testcase classname="accessibility.%s" name="%s"><failure type="%s" message="%s">%s</failure></testcase>',
-            htmlspecialchars($rule_id, ENT_XML1 | ENT_QUOTES),
-            htmlspecialchars($target ?: $rule_id, ENT_XML1 | ENT_QUOTES),
-            htmlspecialchars($impact, ENT_XML1 | ENT_QUOTES),
-            htmlspecialchars($message, ENT_XML1 | ENT_QUOTES),
-            htmlspecialchars($details, ENT_XML1 | ENT_QUOTES)
-          );
+          if (!$failing) {
+            $cases_xml .= sprintf('<testcase classname="%s" name="%s"><system-out>%s</system-out></testcase>', $classname, $name, htmlspecialchars('[advisory] ' . $details, ENT_XML1 | ENT_QUOTES));
+            continue;
+          }
+
+          $failures++;
+          $cases_xml .= sprintf('<testcase classname="%s" name="%s"><failure type="%s" message="%s">%s</failure></testcase>', $classname, $name, htmlspecialchars($impact, ENT_XML1 | ENT_QUOTES), htmlspecialchars(sprintf('[%s] %s', $impact, $help), ENT_XML1 | ENT_QUOTES), htmlspecialchars($details, ENT_XML1 | ENT_QUOTES));
         }
       }
 
       foreach ($passes as $p) {
         $rule_id = (string) ($p['id'] ?? 'unknown');
+        $tests++;
         $cases_xml .= sprintf('<testcase classname="accessibility.%s" name="%s passed"/>', htmlspecialchars($rule_id, ENT_XML1 | ENT_QUOTES), htmlspecialchars($rule_id, ENT_XML1 | ENT_QUOTES));
       }
+
+      $total_tests += $tests;
+      $total_failures += $failures;
 
       $suites_xml .= sprintf('<testsuite name="%s" tests="%d" failures="%d" errors="0">%s</testsuite>', htmlspecialchars((string) $url, ENT_XML1 | ENT_QUOTES), $tests, $failures, $cases_xml);
     }

--- a/tests/behat/bootstrap/BehatCliContext.php
+++ b/tests/behat/bootstrap/BehatCliContext.php
@@ -216,6 +216,44 @@ EOL;
   }
 
   /**
+   * Checks that the first file matching a glob pattern contains a substring.
+   */
+  #[Then('a file matching :pattern should contain:')]
+  public function fileMatchingShouldContain(string $pattern, PyStringNode $text): void
+  {
+    $matches = glob($this->workingDir . DIRECTORY_SEPARATOR . $pattern) ?: [];
+    Assert::assertNotEmpty($matches, sprintf('No file matching "%s" was found in the working directory.', $pattern));
+
+    $content = (string) file_get_contents($matches[0]);
+    $needle = trim((string) $text);
+
+    if (str_contains($content, $needle)) {
+      return;
+    }
+
+    throw new UnexpectedValueException(sprintf('File "%s" does not contain "%s".', $matches[0], $needle));
+  }
+
+  /**
+   * Checks that the first file matching a glob pattern lacks a substring.
+   */
+  #[Then('a file matching :pattern should not contain:')]
+  public function fileMatchingShouldNotContain(string $pattern, PyStringNode $text): void
+  {
+    $matches = glob($this->workingDir . DIRECTORY_SEPARATOR . $pattern) ?: [];
+    Assert::assertNotEmpty($matches, sprintf('No file matching "%s" was found in the working directory.', $pattern));
+
+    $content = (string) file_get_contents($matches[0]);
+    $needle = trim((string) $text);
+
+    if (!str_contains($content, $needle)) {
+      return;
+    }
+
+    throw new UnexpectedValueException(sprintf('File "%s" unexpectedly contains "%s".', $matches[0], $needle));
+  }
+
+  /**
    * Sets specified ENV variable.
    *
    * @When /^the "([^"]*)" environment variable is set to "([^"]*)"$/

--- a/tests/behat/bootstrap/BehatCliContext.php
+++ b/tests/behat/bootstrap/BehatCliContext.php
@@ -221,17 +221,7 @@ EOL;
   #[Then('a file matching :pattern should contain:')]
   public function fileMatchingShouldContain(string $pattern, PyStringNode $text): void
   {
-    $matches = glob($this->workingDir . DIRECTORY_SEPARATOR . $pattern) ?: [];
-    Assert::assertNotEmpty($matches, sprintf('No file matching "%s" was found in the working directory.', $pattern));
-
-    $content = (string) file_get_contents($matches[0]);
-    $needle = trim((string) $text);
-
-    if (str_contains($content, $needle)) {
-      return;
-    }
-
-    throw new UnexpectedValueException(sprintf('File "%s" does not contain "%s".', $matches[0], $needle));
+    $this->assertFileMatchingContains($pattern, $text, true);
   }
 
   /**
@@ -240,17 +230,28 @@ EOL;
   #[Then('a file matching :pattern should not contain:')]
   public function fileMatchingShouldNotContain(string $pattern, PyStringNode $text): void
   {
+    $this->assertFileMatchingContains($pattern, $text, false);
+  }
+
+  /**
+   * Asserts the first matching file does or does not contain a substring.
+   */
+  protected function assertFileMatchingContains(string $pattern, PyStringNode $text, bool $shouldContain): void
+  {
     $matches = glob($this->workingDir . DIRECTORY_SEPARATOR . $pattern) ?: [];
     Assert::assertNotEmpty($matches, sprintf('No file matching "%s" was found in the working directory.', $pattern));
+    // Sort so the file inspected is deterministic when several patterns match.
+    sort($matches);
 
     $content = (string) file_get_contents($matches[0]);
     $needle = trim((string) $text);
 
-    if (!str_contains($content, $needle)) {
+    if (str_contains($content, $needle) === $shouldContain) {
       return;
     }
 
-    throw new UnexpectedValueException(sprintf('File "%s" unexpectedly contains "%s".', $matches[0], $needle));
+    $message = $shouldContain ? 'File "%s" does not contain "%s".' : 'File "%s" unexpectedly contains "%s".';
+    throw new UnexpectedValueException(sprintf($message, $matches[0], $needle));
   }
 
   /**

--- a/tests/behat/features/accessibility.feature
+++ b/tests/behat/features/accessibility.feature
@@ -100,3 +100,26 @@ Feature: Check that AccessibilityTrait works
     When I run "behat --no-colors"
     Then it should pass
     And a file matching ".logs/test_results/accessibility/accessibility_report_*.html" should exist
+
+  @trait:AccessibilityTrait
+  Scenario: Warning mode writes a JUnit report with no failures
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @accessibility:warning":
+      """
+      Given I visit "/sites/default/files/accessibility_violations.html"
+      Then I should see "Inaccessible Page"
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+    And a file matching ".logs/test_results/accessibility/junit-*.xml" should contain:
+      """
+      failures="0"
+      """
+    And a file matching ".logs/test_results/accessibility/junit-*.xml" should not contain:
+      """
+      <failure
+      """
+    And a file matching ".logs/test_results/accessibility/junit-*.xml" should contain:
+      """
+      <system-out>
+      """

--- a/tests/phpunit/src/AccessibilityTraitTest.php
+++ b/tests/phpunit/src/AccessibilityTraitTest.php
@@ -350,13 +350,17 @@ class AccessibilityTraitTest extends UnitTestCase {
   public function testRenderJunitFailuresByThreshold(?string $threshold, int $expected_failures): void {
     $xml = $this->testObject->testRenderJunit(static::createJunitResults(), 'Feature', 'Scenario', $threshold);
 
+    $doc = simplexml_load_string($xml);
+    $this->assertInstanceOf(\SimpleXMLElement::class, $doc, 'The rendered report is well-formed XML.');
     // Only violations meeting the effective threshold become <failure> cases.
-    $this->assertSame($expected_failures, substr_count($xml, '<failure type='), 'Number of <failure> elements reflects the threshold.');
+    $this->assertCount($expected_failures, $doc->xpath('//failure') ?: []);
     // Every emitted testcase is counted, so tests stays 5 (3 violations + 2
-    // passes) regardless of how many are failures versus advisory.
-    $this->assertStringContainsString(sprintf('<testsuites name="Feature &gt; Scenario" tests="5" failures="%d">', $expected_failures), $xml);
-    // The suite-level and file-level failure counts agree.
-    $this->assertSame(2, substr_count($xml, sprintf('failures="%d"', $expected_failures)));
+    // passes) whether a violation is a failure or advisory.
+    $this->assertCount(5, $doc->xpath('//testcase') ?: []);
+    $this->assertSame('5', (string) $doc['tests']);
+    // The file-level and suite-level failure counts agree.
+    $this->assertSame((string) $expected_failures, (string) $doc['failures']);
+    $this->assertSame((string) $expected_failures, (string) $doc->testsuite['failures']);
   }
 
   public static function dataProviderRenderJunitFailuresByThreshold(): array {
@@ -373,11 +377,13 @@ class AccessibilityTraitTest extends UnitTestCase {
   public function testRenderJunitWarningKeepsAdvisoryViolationsVisibleWithoutFailing(): void {
     $xml = $this->testObject->testRenderJunit(static::createJunitResults(), 'Feature', 'Scenario', 'never');
 
-    // Advisory mode: no violation is serialised as a failure.
+    $doc = simplexml_load_string($xml);
+    $this->assertInstanceOf(\SimpleXMLElement::class, $doc);
+    // Advisory mode: no violation is serialised as a failure...
+    $this->assertCount(0, $doc->xpath('//failure') ?: []);
     $this->assertStringNotContainsString('<failure', $xml);
-    $this->assertStringContainsString('failures="0"', $xml);
-    // The findings stay visible as passing testcases carrying <system-out>.
-    $this->assertStringContainsString('<system-out>', $xml);
+    // ...but every finding stays visible as a passing testcase with <system-out>.
+    $this->assertCount(3, $doc->xpath('//system-out') ?: []);
     $this->assertStringContainsString('classname="accessibility.image-alt"', $xml);
     $this->assertStringContainsString('classname="accessibility.link-name"', $xml);
   }
@@ -399,10 +405,14 @@ class AccessibilityTraitTest extends UnitTestCase {
 
     $xml = $this->testObject->testRenderJunit($results, 'Feature', 'Scenario', 'any');
 
-    // One <failure> per affected node (2), plus three passing testcases: the
-    // tests and failures attributes count actual emitted <testcase> elements.
-    $this->assertSame(2, substr_count($xml, '<failure type='));
-    $this->assertStringContainsString('tests="5" failures="2"', $xml);
+    $doc = simplexml_load_string($xml);
+    $this->assertInstanceOf(\SimpleXMLElement::class, $doc);
+    // One <failure> per affected node (2), plus three passing testcases: tests
+    // and failures count actual emitted <testcase> elements, not violations.
+    $this->assertCount(2, $doc->xpath('//failure') ?: []);
+    $this->assertCount(5, $doc->xpath('//testcase') ?: []);
+    $this->assertSame('5', (string) $doc['tests']);
+    $this->assertSame('2', (string) $doc['failures']);
   }
 
   /**

--- a/tests/phpunit/src/AccessibilityTraitTest.php
+++ b/tests/phpunit/src/AccessibilityTraitTest.php
@@ -346,6 +346,65 @@ class AccessibilityTraitTest extends UnitTestCase {
     $this->assertSame('/captured/dir', AccessibilityTraitTestImplementation::testGetAggregateReportDir());
   }
 
+  #[DataProvider('dataProviderRenderJunitFailuresByThreshold')]
+  public function testRenderJunitFailuresByThreshold(?string $threshold, int $expected_failures): void {
+    $xml = $this->testObject->testRenderJunit(static::createJunitResults(), 'Feature', 'Scenario', $threshold);
+
+    // Only violations meeting the effective threshold become <failure> cases.
+    $this->assertSame($expected_failures, substr_count($xml, '<failure type='), 'Number of <failure> elements reflects the threshold.');
+    // Every emitted testcase is counted, so tests stays 5 (3 violations + 2
+    // passes) regardless of how many are failures versus advisory.
+    $this->assertStringContainsString(sprintf('<testsuites name="Feature &gt; Scenario" tests="5" failures="%d">', $expected_failures), $xml);
+    // The suite-level and file-level failure counts agree.
+    $this->assertSame(2, substr_count($xml, sprintf('failures="%d"', $expected_failures)));
+  }
+
+  public static function dataProviderRenderJunitFailuresByThreshold(): array {
+    return [
+      'warning (never) fails on nothing' => ['never', 0],
+      'default (null) resolves to any and fails on all' => [NULL, 3],
+      'any fails on all' => ['any', 3],
+      'critical fails on the critical only' => ['critical', 1],
+      'serious fails on critical and serious' => ['serious', 2],
+      'moderate fails on all three' => ['moderate', 3],
+    ];
+  }
+
+  public function testRenderJunitWarningKeepsAdvisoryViolationsVisibleWithoutFailing(): void {
+    $xml = $this->testObject->testRenderJunit(static::createJunitResults(), 'Feature', 'Scenario', 'never');
+
+    // Advisory mode: no violation is serialised as a failure.
+    $this->assertStringNotContainsString('<failure', $xml);
+    $this->assertStringContainsString('failures="0"', $xml);
+    // The findings stay visible as passing testcases carrying <system-out>.
+    $this->assertStringContainsString('<system-out>', $xml);
+    $this->assertStringContainsString('classname="accessibility.image-alt"', $xml);
+    $this->assertStringContainsString('classname="accessibility.link-name"', $xml);
+  }
+
+  public function testRenderJunitCountsEveryEmittedTestcase(): void {
+    $results = [
+      [
+        'url' => '/',
+        'rules' => 'wcag2a',
+        'result' => [
+          'violations' => [
+            ['id' => 'image-alt', 'impact' => 'critical', 'help' => 'Images must have alternative text', 'helpUrl' => 'https://example.com/image-alt', 'nodes' => [['target' => ['img.a'], 'html' => '<img class="a">'], ['target' => ['img.b'], 'html' => '<img class="b">']]],
+          ],
+          'incomplete' => [],
+          'passes' => [['id' => 'document-title'], ['id' => 'html-has-lang'], ['id' => 'region']],
+        ],
+      ],
+    ];
+
+    $xml = $this->testObject->testRenderJunit($results, 'Feature', 'Scenario', 'any');
+
+    // One <failure> per affected node (2), plus three passing testcases: the
+    // tests and failures attributes count actual emitted <testcase> elements.
+    $this->assertSame(2, substr_count($xml, '<failure type='));
+    $this->assertStringContainsString('tests="5" failures="2"', $xml);
+  }
+
   /**
    * Render a sample accumulator through the full data + render pipeline.
    *
@@ -479,6 +538,31 @@ class AccessibilityTraitTest extends UnitTestCase {
     ];
   }
 
+  /**
+   * Build a scenario result with one violation per impact plus two passes.
+   *
+   * @return array<int, array{url: string, rules: string, result: array<string, mixed>}>
+   *   A single-page result: critical, serious and moderate violations (one
+   *   affected node each) alongside two passing rules.
+   */
+  protected static function createJunitResults(): array {
+    return [
+      [
+        'url' => '/',
+        'rules' => 'wcag2a,wcag2aa',
+        'result' => [
+          'violations' => [
+            ['id' => 'image-alt', 'impact' => 'critical', 'help' => 'Images must have alternative text', 'helpUrl' => 'https://example.com/image-alt', 'nodes' => [['target' => ['img'], 'html' => '<img src="x">']]],
+            ['id' => 'link-name', 'impact' => 'serious', 'help' => 'Links must have discernible text', 'helpUrl' => 'https://example.com/link-name', 'nodes' => [['target' => ['a'], 'html' => '<a href="#"></a>']]],
+            ['id' => 'region', 'impact' => 'moderate', 'help' => 'All page content should be contained by landmarks', 'helpUrl' => 'https://example.com/region', 'nodes' => [['target' => ['div'], 'html' => '<div></div>']]],
+          ],
+          'incomplete' => [],
+          'passes' => [['id' => 'document-title'], ['id' => 'html-has-lang']],
+        ],
+      ],
+    ];
+  }
+
 }
 
 /**
@@ -558,6 +642,15 @@ class AccessibilityTraitTestImplementation {
     $this->accessibilityFeatureName = $feature;
     $this->accessibilityScenarioName = $scenario;
     $this->accessibilityAggregateCapture($dir);
+  }
+
+  public function testRenderJunit(array $results, string $feature, string $scenario, ?string $threshold = NULL): string {
+    $this->accessibilityResults = $results;
+    $this->accessibilityFeatureName = $feature;
+    $this->accessibilityScenarioName = $scenario;
+    $this->accessibilityScenarioThreshold = $threshold;
+
+    return $this->accessibilityRenderJunit();
   }
 
 }


### PR DESCRIPTION
Closes #664

## Summary

`AccessibilityTrait::accessibilityRenderJunit()` wrote a `<failure>` for every raw violation regardless of the scenario's threshold, while the pass/fail gate filtered the same violations through `accessibilityFilterViolations()`. As a result, a `@accessibility:warning` scenario (threshold `never`) passed in Behat but its JUnit report still declared failures, turning JUnit-consuming CI reporters red. The renderer now consults `accessibilityEffectiveThreshold()` and gates `<failure>` output through `accessibilityFilterViolations()`, so advisory findings are recorded as passing `<testcase>` elements with the finding in `<system-out>` instead of a `<failure>`.

## Changes

- `src/AccessibilityTrait.php`: `accessibilityRenderJunit()` resolves the scenario's effective threshold and filters each violation through `accessibilityFilterViolations()` before deciding whether it becomes a `<failure>`. Violations below the threshold are still emitted as `<testcase>` elements carrying the finding in `<system-out>`, keeping them visible without failing the report. `tests` and `failures` are now accumulated per emitted `<testcase>` (one per affected node) rather than derived up front from `count($violations)` and `count($passes)`, which also fixes a pre-existing mismatch for violations that affect multiple nodes.
- `tests/behat/bootstrap/BehatCliContext.php`: Added `a file matching :pattern should contain:` and `should not contain:` steps backed by a shared `assertFileMatchingContains()` helper. Glob matches are sorted before the first one is inspected, so the assertion target is deterministic when several files match the pattern.
- `tests/behat/features/accessibility.feature`: Added a `@trait:AccessibilityTrait` scenario that runs a nested `@accessibility:warning` Behat scenario and asserts the generated JUnit report has `failures="0"`, contains no `<failure>` element, and still contains a `<system-out>` entry for the advisory finding.
- `tests/phpunit/src/AccessibilityTraitTest.php`: Added coverage for `accessibilityRenderJunit()` across thresholds (`never`/`any`/`critical`/`serious`/`moderate`), parsed with `SimpleXML` rather than substring matching, plus a dedicated test for per-node failure counting and one confirming advisory findings surface in `<system-out>` without a `<failure>`.

## Before / After

```
BEFORE - @accessibility:warning scenario (threshold: never)
┌──────────────────────────────────────────────────────────────────────┐
│ Behat pass/fail gate      -> PASS (violations filtered by threshold) │
│ accessibilityRenderJunit() -> ignores the threshold entirely         │
│                                                                        │
│ <testsuites tests="5" failures="3">                                  │
│   <testsuite failures="3">                                           │
│     <testcase name="img.logo">                                       │
│       <failure type="critical" message="[critical] ...">...</failure>│
│     </testcase>                                                      │
│     ... 2 more <failure> cases                                       │
│   </testsuite>                                                       │
│ </testsuites>                                                        │
│                                                                        │
│ JUnit-consuming CI reporter -> FAILED (3 failures for a passing run)  │
└──────────────────────────────────────────────────────────────────────┘

AFTER - @accessibility:warning scenario (threshold: never)
┌──────────────────────────────────────────────────────────────────────┐
│ Behat pass/fail gate      -> PASS (violations filtered by threshold) │
│ accessibilityRenderJunit() -> filters through the same threshold via │
│                                accessibilityFilterViolations()        │
│                                                                        │
│ <testsuites tests="5" failures="0">                                  │
│   <testsuite failures="0">                                           │
│     <testcase name="img.logo">                                       │
│       <system-out>[advisory] Rule: image-alt ...</system-out>        │
│     </testcase>                                                      │
│     ... 2 more advisory <testcase> entries                           │
│   </testsuite>                                                       │
│ </testsuites>                                                        │
│                                                                        │
│ JUnit-consuming CI reporter -> PASSED (findings stay visible in      │
│ system-out; report stays green)                                      │
└──────────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

I’m checking the repo’s contribution rules first so I can flag any step-definition issues accurately in the summary, especially since you asked for Critical marking on violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->