### PR TITLE
[#665] Fixed 'XmlTrait' XML-format assertions ignoring fixture content.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -2399,6 +2399,10 @@ Assert that a response is valid XML
 ```gherkin
 Then the response should be in XML format
 
+# Content set by a fixture step is validated instead of the page content.
+Given the response content from the file "xml_valid.xml"
+Then the response should be in XML format
+
 ```
 
 </details>
@@ -2411,6 +2415,10 @@ Assert that a response is not valid XML
 <br/><br/>
 
 ```gherkin
+Then the response should not be in XML format
+
+# Content set by a fixture step is validated instead of the page content.
+Given the response content from the file "xml_invalid.xml"
 Then the response should not be in XML format
 
 ```

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -124,12 +124,15 @@ trait XmlTrait {
    *
    * @code
    * Then the response should be in XML format
+   *
+   * # Content set by a fixture step is validated instead of the page content.
+   * Given the response content from the file "xml_valid.xml"
+   * Then the response should be in XML format
    * @endcode
    */
   #[Then('the response should be in XML format')]
   public function xmlAssertResponseIsXml(): void {
-    $content = $this->getSession()->getPage()->getContent();
-    $this->xmlLoadDocument($content);
+    $this->xmlEnsureDocument();
   }
 
   /**
@@ -137,11 +140,17 @@ trait XmlTrait {
    *
    * @code
    * Then the response should not be in XML format
+   *
+   * # Content set by a fixture step is validated instead of the page content.
+   * Given the response content from the file "xml_invalid.xml"
+   * Then the response should not be in XML format
    * @endcode
    */
   #[Then('the response should not be in XML format')]
   public function xmlAssertResponseIsNotXml(): void {
-    $content = $this->getSession()->getPage()->getContent();
+    // Resolve content the same way as xmlEnsureDocument(): prefer content set
+    // by the fixture steps, falling back to the live page content.
+    $content = $this->xmlTestContent ?? $this->getSession()->getPage()->getContent();
 
     $doc = new \DOMDocument();
     libxml_clear_errors();

--- a/tests/behat/features/xml.feature
+++ b/tests/behat/features/xml.feature
@@ -11,6 +11,22 @@ Feature: Check that XmlTrait works
     When I go to "/sites/default/files/xml_with_warnings.xml"
     Then the response should be in XML format
 
+  Scenario: Assert "Then the response should be in XML format" honours content set from a fixture file over the page content
+    When I go to "/sites/default/files/xml_invalid.xml"
+    And the response content from the file "xml_valid.xml"
+    Then the response should be in XML format
+
+  Scenario: Assert "Then the response should be in XML format" honours content set from a PyString over the page content
+    When I go to "/sites/default/files/xml_invalid.xml"
+    And the response content is the following:
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <catalog>
+        <product id="p1">Blue Widget</product>
+      </catalog>
+      """
+    Then the response should be in XML format
+
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be in XML format" fails with an exception
     Given some behat configuration
@@ -27,6 +43,11 @@ Feature: Check that XmlTrait works
 
   Scenario: Assert "Then the response should not be in XML format" works
     When I go to "/sites/default/files/xml_invalid.xml"
+    Then the response should not be in XML format
+
+  Scenario: Assert "Then the response should not be in XML format" honours content set from a fixture file over the page content
+    When I go to "/sites/default/files/xml_valid.xml"
+    And the response content from the file "xml_invalid.xml"
     Then the response should not be in XML format
 
   @trait:XmlTrait


### PR DESCRIPTION
Closes #665

## Summary

`XmlTrait` provides two fixture steps, `Given the response content from the file :filename` and `Given the response content is the following:`, that store content in `$xmlTestContent` so assertions can run without an HTTP request. Every other assertion in the trait resolves content through `xmlEnsureDocument()`, which prefers `$xmlTestContent` and falls back to the live page - except the two format-validity assertions, `Then the response should be in XML format` and `Then the response should not be in XML format`, which read `$this->getSession()->getPage()->getContent()` directly and therefore ignored fixture-set content, validating only the live page (and throwing a Mink `DriverException` when no page had been visited yet).

## Changes

- `xmlAssertResponseIsXml()` now delegates to `$this->xmlEnsureDocument()`, reusing the same fixture-or-page resolution and document cache as every other assertion, while still throwing the existing "Failed to load XML" error on invalid content.
- `xmlAssertResponseIsNotXml()` now resolves content as `$this->xmlTestContent ?? $this->getSession()->getPage()->getContent()`, keeping its "expect invalid" behaviour and the "The response is valid XML, but it should not be." exception.
- Added 3 scenarios to `tests/behat/features/xml.feature` that visit a page with one validity, then override it with a fixture holding the other, asserting the fixture wins - covering both assertions via the file fixture plus one via a PyString.
- Enhanced the `@code` docblock examples on both methods to show fixture usage, and regenerated `STEPS.md` via the docs generator.

## Screenshots

N/A - internal Behat trait change with no rendered UI.

## Before / After

```
Before: the two format-validity assertions bypass xmlEnsureDocument()
and read the live page directly, so fixture content is invisible to them.

  Given the response content from the file "xml_valid.xml"
  Given the response content is the following: """<xml>...</xml>"""
                          |
                          v
                  $xmlTestContent  ─ ─ ─ ─ ─ ┐
                                              ┊ (ignored by these two)
  ┌────────────────────────────────────┐     ┊
  │ Then the response should be         │     ┊
  │ in / not in XML format              │<╌╌╌╌┘  reads page content directly
  └────────────────────────────────────┘
                          ^
                          |
              getSession()->getPage()->getContent()

  ┌────────────────────────────────────┐
  │ Then the XML element "..." should   │
  │ exist / equal / contain / ...       │──> xmlEnsureDocument()
  └────────────────────────────────────┘        │
                                                 ├─ $xmlTestContent set? use it
                                                 └─ else use page content


After: every assertion, including the two format-validity ones, resolves
content the same way - fixture content wins when a fixture step set it.

  Given the response content from the file "xml_valid.xml"
  Given the response content is the following: """<xml>...</xml>"""
                          |
                          v
                  $xmlTestContent
                          |
      ┌───────────────────┼───────────────────────────┐
      v                   v                            v
┌───────────────┐  ┌───────────────────┐   ┌────────────────────────┐
│ Then the       │  │ Then the response │   │ Then the XML element   │
│ response       │  │ should not be in  │   │ "..." should exist /   │
│ should be in   │  │ XML format        │   │ equal / contain / ...  │
│ XML format     │  │                   │   │                        │
└───────┬────────┘  └─────────┬─────────┘   └───────────┬────────────┘
        v                     v                          v
  xmlEnsureDocument()   $xmlTestContent ??        xmlEnsureDocument()
                        getSession()->getPage()->getContent()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `XmlTrait` so XML format assertions now honor fixture-provided content first, then fall back to the live page when no fixture content is set. Added Behat coverage for fixture-driven valid/invalid XML checks, clarified the step examples in docblocks, and regenerated `STEPS.md`.

No step-definition rule violations were identified in the reviewed changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->