### PR TITLE
[#670] Added XML schema and feed validation to 'XmlTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -2944,6 +2944,132 @@ Then the XML should not use the namespace "http://example.com/nonexistent"
 
 </details>
 
+<details>
+  <summary><code>@Then the response should match the following XSD schema:</code></summary>
+
+<br/>
+Assert that the response validates against an inline XSD schema
+<br/><br/>
+
+```gherkin
+Then the response should match the following XSD schema:
+  """
+  <?xml version="1.0"?>
+  <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="note" type="xs:string"/>
+  </xs:schema>
+  """
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the response should match the XSD schema in the file :filename</code></summary>
+
+<br/>
+Assert that the response validates against an XSD schema from a file
+<br/><br/>
+
+```gherkin
+Then the response should match the XSD schema in the file "xml_schema.xsd"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the response should match the following DTD:</code></summary>
+
+<br/>
+Assert that the response validates against an inline DTD
+<br/><br/>
+
+```gherkin
+Then the response should match the following DTD:
+  """
+  <!ELEMENT note (#PCDATA)>
+  """
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the response should match the DTD in the file :filename</code></summary>
+
+<br/>
+Assert that the response validates against a DTD from a file
+<br/><br/>
+
+```gherkin
+Then the response should match the DTD in the file "xml_schema.dtd"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the response should match the following RelaxNG schema:</code></summary>
+
+<br/>
+Assert that the response validates against an inline RelaxNG schema
+<br/><br/>
+
+```gherkin
+Then the response should match the following RelaxNG schema:
+  """
+  <element name="note" xmlns="http://relaxng.org/ns/structure/1.0">
+    <text/>
+  </element>
+  """
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the response should match the RelaxNG schema in the file :filename</code></summary>
+
+<br/>
+Assert that the response validates against a RelaxNG schema from a file
+<br/><br/>
+
+```gherkin
+Then the response should match the RelaxNG schema in the file "xml_schema.rng"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the response should be a valid RSS feed</code></summary>
+
+<br/>
+Assert that the response is a valid RSS 2.0 feed
+<br/><br/>
+
+```gherkin
+Then the response should be a valid RSS feed
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the response should be a valid Atom feed</code></summary>
+
+<br/>
+Assert that the response is a valid Atom feed
+<br/><br/>
+
+```gherkin
+Then the response should be a valid Atom feed
+
+```
+
+</details>
+
 
 
 ## Drupal\BlockTrait

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -81,21 +81,7 @@ trait XmlTrait {
    */
   #[Given('the response content from the file :filename')]
   public function xmlSetResponseContentFromFile(string $filename): void {
-    $files_path = rtrim((string) $this->getMinkParameter('files_path'), '/');
-    $file_path = $files_path . '/' . $filename;
-
-    if (!file_exists($file_path)) {
-      throw new \RuntimeException(sprintf('The file "%s" does not exist.', $file_path));
-    }
-
-    $content = file_get_contents($file_path);
-    if ($content === FALSE) {
-      // @codeCoverageIgnoreStart
-      throw new \RuntimeException(sprintf('Failed to read the file "%s".', $file_path));
-      // @codeCoverageIgnoreEnd
-    }
-
-    $this->xmlTestContent = $content;
+    $this->xmlTestContent = $this->xmlReadFile($filename);
     $this->xmlDocument = NULL;
     $this->xmlXpath = NULL;
     $this->xmlContentHash = NULL;
@@ -552,6 +538,124 @@ trait XmlTrait {
   }
 
   /**
+   * Assert that the response validates against an inline XSD schema.
+   *
+   * @code
+   * Then the response should match the following XSD schema:
+   *   """
+   *   <?xml version="1.0"?>
+   *   <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+   *     <xs:element name="note" type="xs:string"/>
+   *   </xs:schema>
+   *   """
+   * @endcode
+   */
+  #[Then('the response should match the following XSD schema:')]
+  public function xmlAssertMatchesXsd(PyStringNode $schema): void {
+    $this->xmlValidateXsd($schema->getRaw());
+  }
+
+  /**
+   * Assert that the response validates against an XSD schema from a file.
+   *
+   * @code
+   * Then the response should match the XSD schema in the file "xml_schema.xsd"
+   * @endcode
+   */
+  #[Then('the response should match the XSD schema in the file :filename')]
+  public function xmlAssertMatchesXsdFromFile(string $filename): void {
+    $this->xmlValidateXsd($this->xmlReadFile($filename));
+  }
+
+  /**
+   * Assert that the response validates against an inline DTD.
+   *
+   * @code
+   * Then the response should match the following DTD:
+   *   """
+   *   <!ELEMENT note (#PCDATA)>
+   *   """
+   * @endcode
+   */
+  #[Then('the response should match the following DTD:')]
+  public function xmlAssertMatchesDtd(PyStringNode $dtd): void {
+    $this->xmlValidateDtd($dtd->getRaw());
+  }
+
+  /**
+   * Assert that the response validates against a DTD from a file.
+   *
+   * @code
+   * Then the response should match the DTD in the file "xml_schema.dtd"
+   * @endcode
+   */
+  #[Then('the response should match the DTD in the file :filename')]
+  public function xmlAssertMatchesDtdFromFile(string $filename): void {
+    $this->xmlValidateDtd($this->xmlReadFile($filename));
+  }
+
+  /**
+   * Assert that the response validates against an inline RelaxNG schema.
+   *
+   * @code
+   * Then the response should match the following RelaxNG schema:
+   *   """
+   *   <element name="note" xmlns="http://relaxng.org/ns/structure/1.0">
+   *     <text/>
+   *   </element>
+   *   """
+   * @endcode
+   */
+  #[Then('the response should match the following RelaxNG schema:')]
+  public function xmlAssertMatchesRelaxNg(PyStringNode $schema): void {
+    $this->xmlValidateRelaxNg($schema->getRaw());
+  }
+
+  /**
+   * Assert that the response validates against a RelaxNG schema from a file.
+   *
+   * @code
+   * Then the response should match the RelaxNG schema in the file "xml_schema.rng"
+   * @endcode
+   */
+  #[Then('the response should match the RelaxNG schema in the file :filename')]
+  public function xmlAssertMatchesRelaxNgFromFile(string $filename): void {
+    $this->xmlValidateRelaxNg($this->xmlReadFile($filename));
+  }
+
+  /**
+   * Assert that the response is a valid RSS 2.0 feed.
+   *
+   * Checks the required RSS 2.0 structure: an `rss` root with a `version` of
+   * `2.0`, a single `channel` with `title`, `link` and `description`, and an
+   * `item` with at least a `title` or a `description`.
+   *
+   * @code
+   * Then the response should be a valid RSS feed
+   * @endcode
+   */
+  #[Then('the response should be a valid RSS feed')]
+  public function xmlAssertValidRssFeed(): void {
+    $this->xmlValidateRssFeed();
+  }
+
+  /**
+   * Assert that the response is a valid Atom feed.
+   *
+   * Checks the required Atom structure: a `feed` root in the Atom namespace
+   * with `id`, `title` and `updated`, and each `entry` with `id`, `title`
+   * and `updated`.
+   *
+   * @code
+   * Then the response should be a valid Atom feed
+   * @endcode
+   */
+  #[Then('the response should be a valid Atom feed')]
+  public function xmlAssertValidAtomFeed(): void {
+    $this->xmlValidateAtomFeed();
+  }
+
+  /**
    * Print the last XML response.
    *
    * @code
@@ -681,6 +785,208 @@ trait XmlTrait {
     }
 
     return implode('; ', $messages);
+  }
+
+  /**
+   * Read a fixture file's contents.
+   *
+   * @param string $filename
+   *   The fixture file name relative to the Mink files path.
+   *
+   * @return string
+   *   The file contents.
+   */
+  protected function xmlReadFile(string $filename): string {
+    $files_path = rtrim((string) $this->getMinkParameter('files_path'), '/');
+    $file_path = $files_path . '/' . $filename;
+
+    if (!file_exists($file_path)) {
+      throw new \RuntimeException(sprintf('The file "%s" does not exist.', $file_path));
+    }
+
+    $content = file_get_contents($file_path);
+    if ($content === FALSE) {
+      // @codeCoverageIgnoreStart
+      throw new \RuntimeException(sprintf('Failed to read the file "%s".', $file_path));
+      // @codeCoverageIgnoreEnd
+    }
+
+    return $content;
+  }
+
+  /**
+   * Validate the response against an XSD schema.
+   *
+   * @param string $schema
+   *   The XSD schema source.
+   */
+  protected function xmlValidateXsd(string $schema): void {
+    $this->xmlEnsureDocument();
+
+    libxml_clear_errors();
+    $valid = @$this->xmlDocument->schemaValidateSource($schema);
+    $errors = libxml_get_errors();
+    libxml_clear_errors();
+
+    if (!$valid) {
+      throw new ExpectationException(sprintf('The response does not match the XSD schema: %s', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Validate the response against a RelaxNG schema.
+   *
+   * @param string $schema
+   *   The RelaxNG schema source.
+   */
+  protected function xmlValidateRelaxNg(string $schema): void {
+    $this->xmlEnsureDocument();
+
+    libxml_clear_errors();
+    $valid = @$this->xmlDocument->relaxNGValidateSource($schema);
+    $errors = libxml_get_errors();
+    libxml_clear_errors();
+
+    if (!$valid) {
+      throw new ExpectationException(sprintf('The response does not match the RelaxNG schema: %s', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Validate the response against a DTD.
+   *
+   * The DTD is embedded as an internal subset and the response reloaded with
+   * validation enabled, so a DTD from a file and an inline DTD share one code
+   * path without exposing external-entity loading.
+   *
+   * @param string $dtd
+   *   The DTD source (element, attribute and entity declarations).
+   */
+  protected function xmlValidateDtd(string $dtd): void {
+    $this->xmlEnsureDocument();
+
+    $root = $this->xmlDocument->documentElement;
+    if (!$root instanceof \DOMElement) {
+      // @codeCoverageIgnoreStart
+      throw new ExpectationException('The response has no root element to validate against the DTD.', $this->getSession()->getDriver());
+      // @codeCoverageIgnoreEnd
+    }
+
+    $body = $this->xmlDocument->saveXML($root);
+    if ($body === FALSE) {
+      // @codeCoverageIgnoreStart
+      throw new ExpectationException('Failed to serialise the response for DTD validation.', $this->getSession()->getDriver());
+      // @codeCoverageIgnoreEnd
+    }
+
+    $combined = sprintf("<?xml version=\"1.0\"?>\n<!DOCTYPE %s [\n%s\n]>\n%s", $root->nodeName, $dtd, $body);
+
+    $document = new \DOMDocument();
+    libxml_clear_errors();
+    $loaded = @$document->loadXML($combined, LIBXML_DTDVALID);
+    $errors = libxml_get_errors();
+    libxml_clear_errors();
+
+    if (!$loaded || $errors !== []) {
+      throw new ExpectationException(sprintf('The response does not match the DTD: %s', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Validate the response as an RSS 2.0 feed.
+   */
+  protected function xmlValidateRssFeed(): void {
+    $this->xmlEnsureDocument();
+
+    $root = $this->xmlDocument->documentElement;
+    if (!$root instanceof \DOMElement || $root->localName !== 'rss') {
+      throw new ExpectationException('The response is not a valid RSS feed: the root element must be "rss".', $this->getSession()->getDriver());
+    }
+
+    if ($root->getAttribute('version') !== '2.0') {
+      throw new ExpectationException('The response is not a valid RSS feed: the "rss" element must have a "version" attribute of "2.0".', $this->getSession()->getDriver());
+    }
+
+    $channels = $this->xmlDirectChildElements($root, 'channel');
+    if (count($channels) !== 1) {
+      throw new ExpectationException('The response is not a valid RSS feed: the "rss" element must contain exactly one "channel" element.', $this->getSession()->getDriver());
+    }
+
+    $channel = $channels[0];
+
+    foreach (['title', 'link', 'description'] as $required) {
+      if ($this->xmlDirectChildElements($channel, $required) === []) {
+        throw new ExpectationException(sprintf('The response is not a valid RSS feed: the "channel" element is missing the required "%s" element.', $required), $this->getSession()->getDriver());
+      }
+    }
+
+    foreach ($this->xmlDirectChildElements($channel, 'item') as $item) {
+      $has_title = $this->xmlDirectChildElements($item, 'title') !== [];
+      $has_description = $this->xmlDirectChildElements($item, 'description') !== [];
+
+      if (!$has_title && !$has_description) {
+        throw new ExpectationException('The response is not a valid RSS feed: each "item" element must contain a "title" or a "description" element.', $this->getSession()->getDriver());
+      }
+    }
+  }
+
+  /**
+   * Validate the response as an Atom feed.
+   */
+  protected function xmlValidateAtomFeed(): void {
+    $this->xmlEnsureDocument();
+
+    $namespace = 'http://www.w3.org/2005/Atom';
+
+    $root = $this->xmlDocument->documentElement;
+    if (!$root instanceof \DOMElement || $root->localName !== 'feed' || $root->namespaceURI !== $namespace) {
+      throw new ExpectationException('The response is not a valid Atom feed: the root element must be "feed" in the Atom namespace.', $this->getSession()->getDriver());
+    }
+
+    foreach (['id', 'title', 'updated'] as $required) {
+      if ($this->xmlDirectChildElements($root, $required, $namespace) === []) {
+        throw new ExpectationException(sprintf('The response is not a valid Atom feed: the "feed" element is missing the required "%s" element.', $required), $this->getSession()->getDriver());
+      }
+    }
+
+    foreach ($this->xmlDirectChildElements($root, 'entry', $namespace) as $entry) {
+      foreach (['id', 'title', 'updated'] as $required) {
+        if ($this->xmlDirectChildElements($entry, $required, $namespace) === []) {
+          throw new ExpectationException(sprintf('The response is not a valid Atom feed: an "entry" element is missing the required "%s" element.', $required), $this->getSession()->getDriver());
+        }
+      }
+    }
+  }
+
+  /**
+   * Get direct child elements matching a local name and optional namespace.
+   *
+   * @param \DOMNode $parent
+   *   The parent node.
+   * @param string $name
+   *   The local element name to match.
+   * @param string|null $namespace
+   *   The namespace URI to match, or NULL to match elements in any namespace.
+   *
+   * @return array<int, \DOMElement>
+   *   The matching direct child elements.
+   */
+  protected function xmlDirectChildElements(\DOMNode $parent, string $name, ?string $namespace = NULL): array {
+    $matches = [];
+
+    foreach ($parent->childNodes as $child) {
+      if (!$child instanceof \DOMElement || $child->localName !== $name) {
+        continue;
+      }
+
+      if ($namespace !== NULL && $child->namespaceURI !== $namespace) {
+        continue;
+      }
+
+      $matches[] = $child;
+    }
+
+    return $matches;
   }
 
 }

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -570,6 +570,9 @@ trait XmlTrait {
   /**
    * Assert that the response validates against an inline DTD.
    *
+   * DTDs are namespace-unaware: to validate a namespaced document, the DTD must
+   * declare the prefixed element names and the `xmlns` attributes.
+   *
    * @code
    * Then the response should match the following DTD:
    *   """
@@ -584,6 +587,9 @@ trait XmlTrait {
 
   /**
    * Assert that the response validates against a DTD from a file.
+   *
+   * DTDs are namespace-unaware: to validate a namespaced document, the DTD must
+   * declare the prefixed element names and the `xmlns` attributes.
    *
    * @code
    * Then the response should match the DTD in the file "xml_schema.dtd"
@@ -858,6 +864,10 @@ trait XmlTrait {
    * The DTD is embedded as an internal subset and the response reloaded with
    * validation enabled, so a DTD from a file and an inline DTD share one code
    * path without exposing external-entity loading.
+   *
+   * DTDs are namespace-unaware, so a namespaced response is validated verbatim
+   * and its `xmlns` attributes must be declared in the DTD, matching native DTD
+   * validation semantics.
    *
    * @param string $dtd
    *   The DTD source (element, attribute and entity declarations).

--- a/tests/behat/features/xml.feature
+++ b/tests/behat/features/xml.feature
@@ -647,3 +647,264 @@ Feature: Check that XmlTrait works
       """
       Unable to access the response before visiting a page
       """
+
+  Scenario: Assert "Then the response should match the following XSD schema:" works
+    Given the response content is the following:
+      """
+      <?xml version="1.0"?><note><to>World</to></note>
+      """
+    Then the response should match the following XSD schema:
+      """
+      <?xml version="1.0"?>
+      <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="note">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="to" type="xs:string"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:schema>
+      """
+
+  Scenario: Assert "Then the response should match the XSD schema in the file :filename" works
+    When I go to "/sites/default/files/xml_valid.xml"
+    Then the response should match the XSD schema in the file "xml_schema.xsd"
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should match the XSD schema in the file :filename" fails with an error
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_simple.xml"
+      Then the response should match the XSD schema in the file "xml_schema.xsd"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The response does not match the XSD schema
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that "Then the response should match the XSD schema in the file :filename" fails with an exception for missing file
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      Then the response should match the XSD schema in the file "nonexistent.xsd"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      does not exist
+      """
+
+  Scenario: Assert "Then the response should match the following DTD:" works
+    Given the response content is the following:
+      """
+      <?xml version="1.0"?><note>Hello</note>
+      """
+    Then the response should match the following DTD:
+      """
+      <!ELEMENT note (#PCDATA)>
+      """
+
+  Scenario: Assert "Then the response should match the DTD in the file :filename" works
+    When I go to "/sites/default/files/xml_valid.xml"
+    Then the response should match the DTD in the file "xml_schema.dtd"
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should match the DTD in the file :filename" fails with an error
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_simple.xml"
+      Then the response should match the DTD in the file "xml_schema.dtd"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The response does not match the DTD
+      """
+
+  Scenario: Assert "Then the response should match the following RelaxNG schema:" works
+    Given the response content is the following:
+      """
+      <?xml version="1.0"?><note>Hello</note>
+      """
+    Then the response should match the following RelaxNG schema:
+      """
+      <element name="note" xmlns="http://relaxng.org/ns/structure/1.0">
+        <text/>
+      </element>
+      """
+
+  Scenario: Assert "Then the response should match the RelaxNG schema in the file :filename" works
+    When I go to "/sites/default/files/xml_valid.xml"
+    Then the response should match the RelaxNG schema in the file "xml_schema.rng"
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should match the RelaxNG schema in the file :filename" fails with an error
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_simple.xml"
+      Then the response should match the RelaxNG schema in the file "xml_schema.rng"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The response does not match the RelaxNG schema
+      """
+
+  Scenario: Assert "Then the response should be a valid RSS feed" works
+    When I go to "/sites/default/files/rss_valid.xml"
+    Then the response should be a valid RSS feed
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for a non-rss root
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      And the response content is the following:
+        '''
+        <?xml version="1.0"?><catalog></catalog>
+        '''
+      Then the response should be a valid RSS feed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      the root element must be "rss"
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for a wrong version
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      And the response content is the following:
+        '''
+        <?xml version="1.0"?><rss version="1.0"><channel><title>t</title><link>l</link><description>d</description></channel></rss>
+        '''
+      Then the response should be a valid RSS feed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      must have a "version" attribute of "2.0"
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for a missing channel
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      And the response content is the following:
+        '''
+        <?xml version="1.0"?><rss version="2.0"></rss>
+        '''
+      Then the response should be a valid RSS feed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      must contain exactly one "channel" element
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for a missing required channel element
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      And the response content is the following:
+        '''
+        <?xml version="1.0"?><rss version="2.0"><channel><title>t</title><link>l</link></channel></rss>
+        '''
+      Then the response should be a valid RSS feed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      is missing the required "description" element
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for an item without a title or description
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      And the response content is the following:
+        '''
+        <?xml version="1.0"?><rss version="2.0"><channel><title>t</title><link>l</link><description>d</description><item><link>x</link></item></channel></rss>
+        '''
+      Then the response should be a valid RSS feed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      each "item" element must contain a "title" or a "description"
+      """
+
+  Scenario: Assert "Then the response should be a valid Atom feed" works
+    When I go to "/sites/default/files/atom_valid.xml"
+    Then the response should be a valid Atom feed
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should be a valid Atom feed" fails with an error for a non-atom root
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      And the response content is the following:
+        '''
+        <?xml version="1.0"?><feed><id>x</id><title>t</title><updated>u</updated></feed>
+        '''
+      Then the response should be a valid Atom feed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      the root element must be "feed" in the Atom namespace
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should be a valid Atom feed" fails with an error for a missing required feed element
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      And the response content is the following:
+        '''
+        <?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><id>x</id><title>t</title></feed>
+        '''
+      Then the response should be a valid Atom feed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      the "feed" element is missing the required "updated" element
+      """
+
+  @trait:XmlTrait
+  Scenario: Assert that negative assertion for "Then the response should be a valid Atom feed" fails with an error for an entry missing a required element
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I go to "/sites/default/files/xml_valid.xml"
+      And the response content is the following:
+        '''
+        <?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom" xmlns:other="http://example.com/other"><id>x</id><title>t</title><updated>u</updated><entry><id>e</id><title>et</title><other:updated>2024</other:updated></entry></feed>
+        '''
+      Then the response should be a valid Atom feed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      an "entry" element is missing the required "updated" element
+      """

--- a/tests/behat/fixtures/atom_valid.xml
+++ b/tests/behat/fixtures/atom_valid.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>urn:uuid:example-feed</id>
+  <title>Example Feed</title>
+  <updated>2024-01-01T00:00:00Z</updated>
+  <entry>
+    <id>urn:uuid:example-entry-1</id>
+    <title>First entry</title>
+    <updated>2024-01-01T00:00:00Z</updated>
+  </entry>
+  <entry>
+    <id>urn:uuid:example-entry-2</id>
+    <title>Second entry</title>
+    <updated>2024-01-02T00:00:00Z</updated>
+  </entry>
+</feed>

--- a/tests/behat/fixtures/rss_valid.xml
+++ b/tests/behat/fixtures/rss_valid.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Feed</title>
+    <link>https://example.com/</link>
+    <description>An example RSS 2.0 feed.</description>
+    <item>
+      <title>First item</title>
+      <link>https://example.com/first</link>
+      <description>The first item description.</description>
+    </item>
+    <item>
+      <title>Second item</title>
+      <link>https://example.com/second</link>
+    </item>
+  </channel>
+</rss>

--- a/tests/behat/fixtures/xml_schema.dtd
+++ b/tests/behat/fixtures/xml_schema.dtd
@@ -1,0 +1,9 @@
+<!ELEMENT library (book+)>
+<!ELEMENT book (title, author, description?, published?)>
+<!ATTLIST book
+  id CDATA #REQUIRED
+  category CDATA #REQUIRED>
+<!ELEMENT title (#PCDATA)>
+<!ELEMENT author (#PCDATA)>
+<!ELEMENT description (#PCDATA)>
+<!ELEMENT published (#PCDATA)>

--- a/tests/behat/fixtures/xml_schema.rng
+++ b/tests/behat/fixtures/xml_schema.rng
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="library">
+      <oneOrMore>
+        <element name="book">
+          <attribute name="id"/>
+          <attribute name="category"/>
+          <element name="title"><text/></element>
+          <element name="author"><text/></element>
+          <optional>
+            <element name="description"><text/></element>
+          </optional>
+          <optional>
+            <element name="published"><text/></element>
+          </optional>
+        </element>
+      </oneOrMore>
+    </element>
+  </start>
+</grammar>

--- a/tests/behat/fixtures/xml_schema.xsd
+++ b/tests/behat/fixtures/xml_schema.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="library">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="book" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="title" type="xs:string"/>
+              <xs:element name="author" type="xs:string"/>
+              <xs:element name="description" type="xs:string" minOccurs="0"/>
+              <xs:element name="published" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="id" type="xs:string" use="required"/>
+            <xs:attribute name="category" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
Closes #670

## Summary

Extends `XmlTrait` with whole-document schema validation (XSD, DTD, and RelaxNG, each usable inline via a PyString or loaded from a fixture file) and structural validity assertions for RSS 2.0 and Atom feeds, so a response body can be checked against a formal schema or a feed's required elements instead of only individual elements, attributes, or namespaces. All validation runs through native libxml/DOM APIs (`DOMDocument::schemaValidateSource()`, `relaxNGValidateSource()`, and `LIBXML_DTDVALID`), so no new Composer dependency is introduced.

## Changes

- Added six step definitions to `src/XmlTrait.php`: `xmlAssertMatchesXsd`/`xmlAssertMatchesXsdFromFile` for XSD, `xmlAssertMatchesDtd`/`xmlAssertMatchesDtdFromFile` for DTD, and `xmlAssertMatchesRelaxNg`/`xmlAssertMatchesRelaxNgFromFile` for RelaxNG, plus `xmlAssertValidRssFeed` and `xmlAssertValidAtomFeed` for feed structure.
- Added the protected validation helpers backing those steps: `xmlValidateXsd` and `xmlValidateRelaxNg` delegate to `DOMDocument::schemaValidateSource()`/`relaxNGValidateSource()`; `xmlValidateDtd` embeds the DTD as an internal subset and reloads the document with `LIBXML_DTDVALID` so a file-based and an inline DTD share one code path; `xmlValidateRssFeed` and `xmlValidateAtomFeed` walk the DOM to check the required elements for each feed format; `xmlDirectChildElements` is a namespace-aware direct-child lookup shared by both feed validators.
- Extracted `xmlReadFile()` from the existing `xmlSetResponseContentFromFile` step so the new "from file" schema assertions reuse the same fixture-reading logic.
- Documented inline, next to `xmlValidateDtd` and the DTD step definitions, that DTDs are namespace-unaware: a namespaced response must declare its `xmlns` attributes and prefixed element names directly in the DTD.
- Added fixtures `tests/behat/fixtures/xml_schema.xsd`, `xml_schema.dtd`, and `xml_schema.rng` describing the same "library of books" shape, plus `rss_valid.xml` and `atom_valid.xml` as valid feed samples.
- Added 20 scenarios to `tests/behat/features/xml.feature` covering positive matches and negative/error paths (invalid documents, missing schema files, malformed feed structure) for every new assertion.
- Regenerated `STEPS.md` to document the eight new step definitions.

## Before / After

```
┌──────────────────────────────────────┐
│ BEFORE: XmlTrait assertion surface   │
├──────────────────────────────────────┤
│ - element exists / contains text     │
│ - attribute exists / equals value    │
│ - namespace declared on the document │
└──────────────────────────────────────┘
                    │
                    ▼  extended by this PR
┌─────────────────────────────────────────────┐
│ AFTER: XmlTrait assertion surface           │
├─────────────────────────────────────────────┤
│ - element exists / contains text            │
│ - attribute exists / equals value           │
│ - namespace declared on the document        │
│ - matches an XSD schema (inline or file)    │
│ - matches a DTD (inline or file)            │
│ - matches a RelaxNG schema (inline or file) │
│ - is a structurally valid RSS 2.0 feed      │
│ - is a structurally valid Atom feed         │
└─────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added full-document XML validation to `XmlTrait`, including native XSD, DTD, and Relax NG checks from either inline schema text or fixture files.

Also added structural assertions for valid RSS 2.0 and Atom feeds, with clearer validation failures surfaced from the first libxml/DOM error.

Documentation and coverage were updated accordingly:
- new/expanded Behat scenarios for valid and invalid XML validation cases
- new XML, DTD, Relax NG, RSS, and Atom fixtures
- regenerated `STEPS.md`
- extracted shared fixture-reading logic in `XmlTrait`

No CONTRIBUTING.md step-definition rule violations were identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->