### PR TITLE
[#673] Added automatic Drupal BigPipe placeholder wait for JavaScript scenarios.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ This ensures that the documentation remains in sync with the actual code impleme
 - Use descriptive tags (e.g., `@datetime`) to allow selective test execution
 - Negative tests using `@trait:FieldTrait` should use simple navigation (e.g., `I go to "node/add/page"`)
 - Avoid using custom steps in negative tests that may not be available in BehatCLI context
+- Test-only tags - ones consumed by the test harness (`FeatureContext` or the bootstrap traits) to configure a scenario, as opposed to the library's public tags registered in `docs.php`'s `tag_registry()` - must be prefixed with `test-` (e.g., `@test-bigpipe-timeout`) so they are clearly distinguishable from real library tags.
 
 ### Step Definition Constraints
 - Documentation tool (`docs.php`) does not support multiple `@When` annotations per method

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ from the community.
 
 | Class | Description |
 | --- | --- |
+| [Drupal\BigPipeTrait](STEPS.md#drupalbigpipetrait) | Wait for Drupal BigPipe placeholders to be replaced on JavaScript scenarios. |
 | [Drupal\BlockTrait](STEPS.md#drupalblocktrait) | Manage Drupal blocks. |
 | [Drupal\CacheTrait](STEPS.md#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
 | [Drupal\ConfigOverrideTrait](STEPS.md#drupalconfigoverridetrait) | Disable Drupal config overrides from settings.php during a scenario. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -30,6 +30,7 @@
 
 | Class | Description |
 | --- | --- |
+| [Drupal\BigPipeTrait](#drupalbigpipetrait) | Wait for Drupal BigPipe placeholders to be replaced on JavaScript scenarios. |
 | [Drupal\BlockTrait](#drupalblocktrait) | Manage Drupal blocks. |
 | [Drupal\CacheTrait](#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
 | [Drupal\ConfigOverrideTrait](#drupalconfigoverridetrait) | Disable Drupal config overrides from settings.php during a scenario. |
@@ -3070,6 +3071,31 @@ Then the response should be a valid Atom feed
 
 </details>
 
+
+
+## Drupal\BigPipeTrait
+
+[Source](src/Drupal/BigPipeTrait.php), [Example](tests/behat/features/drupal_big_pipe.feature)
+
+>  Wait for Drupal BigPipe placeholders to be replaced on JavaScript scenarios.
+>  <br/><br/>
+>  Drupal BigPipe streams parts of a page in after the initial response and
+>  replaces its `<span data-big-pipe-placeholder-id="...">` markers with the
+>  real markup using JavaScript. Assertions that run before those replacements
+>  land intermittently fail with "element not found". When this trait is
+>  included, every `@javascript` scenario waits - before each step - until no
+>  BigPipe placeholder markers remain in the DOM, removing that race without an
+>  explicit step.
+>  <br/><br/>
+>  The wait is best-effort: on timeout the step still runs, so a genuinely stuck
+>  placeholder surfaces as the real assertion failure rather than being masked
+>  here. Non-JavaScript scenarios are left untouched, where BigPipe renders
+>  server-side (see the drupal-extension `@bigpipe` cookie handling).
+>  <br/><br/>
+>  Skip processing with tag: `@behat-steps-skip:BigPipeTrait`.
+>  <br/><br/>
+>  Override `bigPipeGetWaitTimeout()` in your `FeatureContext` to change the
+>  maximum wait.
 
 
 ## Drupal\BlockTrait

--- a/STEPS.md
+++ b/STEPS.md
@@ -3094,8 +3094,8 @@ Then the response should be a valid Atom feed
 >  <br/><br/>
 >  Skip processing with tag: `@behat-steps-skip:BigPipeTrait`.
 >  <br/><br/>
->  Override `bigPipeGetWaitTimeout()` in your `FeatureContext` to change the
->  maximum wait.
+>  Override `bigPipeGetWaitTimeout()` (or set `$bigPipeWaitTimeout`) in your
+>  `FeatureContext` to change the maximum wait.
 
 
 ## Drupal\BlockTrait

--- a/src/Drupal/BigPipeTrait.php
+++ b/src/Drupal/BigPipeTrait.php
@@ -33,6 +33,11 @@ use Behat\Mink\Exception\DriverException;
 trait BigPipeTrait {
 
   /**
+   * Default maximum time to wait for BigPipe placeholders, in milliseconds.
+   */
+  protected const DEFAULT_WAIT_TIMEOUT = 10000;
+
+  /**
    * Whether the automatic BigPipe wait is active for the current scenario.
    */
   protected bool $bigPipeAutoWaitEnabled = FALSE;
@@ -40,7 +45,7 @@ trait BigPipeTrait {
   /**
    * Maximum time to wait for BigPipe placeholders to be replaced, in milliseconds.
    */
-  protected int $bigPipeWaitTimeout = 10000;
+  protected int $bigPipeWaitTimeout = self::DEFAULT_WAIT_TIMEOUT;
 
   /**
    * Resolve whether the automatic BigPipe wait applies to this scenario.

--- a/src/Drupal/BigPipeTrait.php
+++ b/src/Drupal/BigPipeTrait.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Drupal;
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Hook\BeforeScenario;
+use Behat\Hook\BeforeStep;
+use Behat\Mink\Exception\DriverException;
+
+/**
+ * Wait for Drupal BigPipe placeholders to be replaced on JavaScript scenarios.
+ *
+ * Drupal BigPipe streams parts of a page in after the initial response and
+ * replaces its `<span data-big-pipe-placeholder-id="...">` markers with the
+ * real markup using JavaScript. Assertions that run before those replacements
+ * land intermittently fail with "element not found". When this trait is
+ * included, every `@javascript` scenario waits - before each step - until no
+ * BigPipe placeholder markers remain in the DOM, removing that race without an
+ * explicit step.
+ *
+ * The wait is best-effort: on timeout the step still runs, so a genuinely stuck
+ * placeholder surfaces as the real assertion failure rather than being masked
+ * here. Non-JavaScript scenarios are left untouched, where BigPipe renders
+ * server-side (see the drupal-extension `@bigpipe` cookie handling).
+ *
+ * Skip processing with tag: `@behat-steps-skip:BigPipeTrait`.
+ *
+ * Override `bigPipeGetWaitTimeout()` in your `FeatureContext` to change the
+ * maximum wait.
+ */
+trait BigPipeTrait {
+
+  /**
+   * Whether the automatic BigPipe wait is active for the current scenario.
+   */
+  protected bool $bigPipeAutoWaitEnabled = FALSE;
+
+  /**
+   * Resolve whether the automatic BigPipe wait applies to this scenario.
+   */
+  #[BeforeScenario]
+  public function bigPipeBeforeScenario(BeforeScenarioScope $scope): void {
+    $scenario = $scope->getScenario();
+    $feature = $scope->getFeature();
+
+    // Resolved here, not in the BeforeStep hook, because a BeforeStep scope
+    // cannot read scenario-level tags.
+    $is_javascript = $feature->hasTag('javascript') || $scenario->hasTag('javascript');
+    $is_skipped = $feature->hasTag('behat-steps-skip:BigPipeTrait') || $scenario->hasTag('behat-steps-skip:BigPipeTrait');
+
+    $this->bigPipeAutoWaitEnabled = $is_javascript && !$is_skipped;
+  }
+
+  /**
+   * Wait for BigPipe placeholders to settle before each step runs.
+   *
+   * Named to avoid overriding the drupal-extension BigPipeTrait's own
+   * `bigPipeBeforeStep()` hook, inherited through `DrupalContext`.
+   */
+  #[BeforeStep]
+  public function bigPipeWaitBeforeStep(): void {
+    if (!$this->bigPipeAutoWaitEnabled) {
+      return;
+    }
+
+    $this->bigPipeWaitForPlaceholders($this->bigPipeGetWaitTimeout());
+  }
+
+  /**
+   * Wait until no BigPipe placeholder markers remain in the DOM.
+   *
+   * @param int $timeout_ms
+   *   Maximum time to wait, in milliseconds.
+   */
+  protected function bigPipeWaitForPlaceholders(int $timeout_ms): void {
+    try {
+      $this->getSession()->wait($timeout_ms, "document.querySelectorAll('[data-big-pipe-placeholder-id]').length === 0");
+    }
+    // @codeCoverageIgnoreStart
+    catch (DriverException) {
+      // The driver session is not ready (e.g. no page has been visited yet),
+      // so there is nothing to synchronise.
+    }
+    // @codeCoverageIgnoreEnd
+  }
+
+  /**
+   * Maximum time to wait for BigPipe placeholders, in milliseconds.
+   *
+   * @return int
+   *   The timeout in milliseconds.
+   */
+  protected function bigPipeGetWaitTimeout(): int {
+    return 10000;
+  }
+
+}

--- a/src/Drupal/BigPipeTrait.php
+++ b/src/Drupal/BigPipeTrait.php
@@ -27,8 +27,8 @@ use Behat\Mink\Exception\DriverException;
  *
  * Skip processing with tag: `@behat-steps-skip:BigPipeTrait`.
  *
- * Override `bigPipeGetWaitTimeout()` in your `FeatureContext` to change the
- * maximum wait.
+ * Override `bigPipeGetWaitTimeout()` (or set `$bigPipeWaitTimeout`) in your
+ * `FeatureContext` to change the maximum wait.
  */
 trait BigPipeTrait {
 
@@ -36,6 +36,11 @@ trait BigPipeTrait {
    * Whether the automatic BigPipe wait is active for the current scenario.
    */
   protected bool $bigPipeAutoWaitEnabled = FALSE;
+
+  /**
+   * Maximum time to wait for BigPipe placeholders to be replaced, in milliseconds.
+   */
+  protected int $bigPipeWaitTimeout = 10000;
 
   /**
    * Resolve whether the automatic BigPipe wait applies to this scenario.
@@ -93,7 +98,7 @@ trait BigPipeTrait {
    *   The timeout in milliseconds.
    */
   protected function bigPipeGetWaitTimeout(): int {
-    return 10000;
+    return $this->bigPipeWaitTimeout;
   }
 
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -156,7 +156,7 @@ class FeatureContext extends DrupalContext {
    */
   #[BeforeScenario]
   public function bigPipeSetWaitTimeout(BeforeScenarioScope $scope): void {
-    $this->bigPipeWaitTimeout = $scope->getScenario()->hasTag('bigpipe-timeout') ? 2000 : 10000;
+    $this->bigPipeWaitTimeout = $scope->getScenario()->hasTag('bigpipe-timeout') ? 2000 : self::DEFAULT_WAIT_TIMEOUT;
   }
 
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Hook\BeforeScenario;
 use DrevOps\BehatSteps\AccessibilityTrait;
 use DrevOps\BehatSteps\CookieTrait;
 use DrevOps\BehatSteps\DateTrait;
@@ -144,6 +146,17 @@ class FeatureContext extends DrupalContext {
    */
   protected function accessibilityGetReportDir(): string {
     return dirname((string) $this->getMinkParameter('files_path'), 3) . '/.logs/test_results/accessibility';
+  }
+
+  /**
+   * Shorten the BigPipe wait timeout for the timeout coverage scenario.
+   *
+   * Scenarios tagged '@bigpipe-timeout' use a short timeout so they can exercise
+   * the wait timing out quickly; every other scenario keeps the trait's default.
+   */
+  #[BeforeScenario]
+  public function bigPipeSetWaitTimeout(BeforeScenarioScope $scope): void {
+    $this->bigPipeWaitTimeout = $scope->getScenario()->hasTag('bigpipe-timeout') ? 2000 : 10000;
   }
 
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -151,12 +151,13 @@ class FeatureContext extends DrupalContext {
   /**
    * Shorten the BigPipe wait timeout for the timeout coverage scenario.
    *
-   * Scenarios tagged '@bigpipe-timeout' use a short timeout so they can exercise
-   * the wait timing out quickly; every other scenario keeps the trait's default.
+   * Scenarios tagged '@test-bigpipe-timeout' use a short timeout so they can
+   * exercise the wait timing out quickly; every other scenario keeps the trait's
+   * default.
    */
   #[BeforeScenario]
   public function bigPipeSetWaitTimeout(BeforeScenarioScope $scope): void {
-    $this->bigPipeWaitTimeout = $scope->getScenario()->hasTag('bigpipe-timeout') ? 2000 : self::DEFAULT_WAIT_TIMEOUT;
+    $this->bigPipeWaitTimeout = $scope->getScenario()->hasTag('test-bigpipe-timeout') ? 2000 : self::DEFAULT_WAIT_TIMEOUT;
   }
 
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 use DrevOps\BehatSteps\AccessibilityTrait;
 use DrevOps\BehatSteps\CookieTrait;
 use DrevOps\BehatSteps\DateTrait;
+use DrevOps\BehatSteps\Drupal\BigPipeTrait;
 use DrevOps\BehatSteps\Drupal\BlockTrait;
 use DrevOps\BehatSteps\Drupal\CacheTrait;
 use DrevOps\BehatSteps\Drupal\ConfigOverrideTrait;
@@ -61,6 +62,7 @@ use Drupal\DrupalExtension\Context\DrupalContext;
 class FeatureContext extends DrupalContext {
 
   use AccessibilityTrait;
+  use BigPipeTrait;
   use BlockTrait;
   use CacheTrait;
   use ConfigOverrideTrait;

--- a/tests/behat/features/drupal_big_pipe.feature
+++ b/tests/behat/features/drupal_big_pipe.feature
@@ -1,47 +1,15 @@
 Feature: Check that BigPipeTrait works
   As Behat Steps library developer
-  I want to provide tools to manage BigPipe cookies
-  So that users can test progressive rendering with and without JavaScript
-
-  @api @skipped
-  Scenario: Assert that Big Pipe cookie is set
-    Given I install a "big_pipe" module
-    When I visit "/"
-    Then cookie "big_pipe_nojs" exists
-
-  @api @behat-steps-skip:bigPipeBeforeScenario
-  Scenario: Assert that Big Pipe cookie is not set when skip tag is used
-    Given I install a "big_pipe" module
-    When I visit "/"
-    Then cookie "big_pipe_nojs" does not exist
-
-  @api @skipped
-  Scenario: Assert that Big Pipe cookie is preserved across multiple users in a scenario
-    Given the following users:
-      | name               | mail                             | roles         | status |
-      | administrator_user | administrator_user@myexample.com | administrator | 1      |
-    And I install a "big_pipe" module
-    When I visit "/"
-    Then cookie "big_pipe_nojs" exists
-    When I am logged in as "administrator_user"
-    And I visit "/"
-    Then cookie "big_pipe_nojs" exists
-
-  @api @behat-steps-skip:bigPipeBeforeStep @skipped
-  Scenario: Assert that Big Pipe cookie is not preserved across multiple users when skip tag is used
-    Given the following users:
-      | name               | mail                             | roles         | status |
-      | administrator_user | administrator_user@myexample.com | administrator | 1      |
-    And I install a "big_pipe" module
-    When I visit "/"
-    Then cookie "big_pipe_nojs" exists
-    # Logging in as a new user removes cookies.
-    When I am logged in as "administrator_user"
-    And I visit "/"
-    Then cookie "big_pipe_nojs" does not exist
+  I want the library to wait for Drupal BigPipe placeholders to be replaced
+  So that JavaScript assertions do not race progressive rendering
 
   @api @javascript
-  Scenario: Assert that Big Pipe cookie is not set when JavaScript is supported
-    Given I install a "big_pipe" module
-    When I visit "/"
-    Then cookie "big_pipe_nojs" does not exist
+  Scenario: BigPipe placeholders are awaited automatically before assertions
+    When I visit "/sites/default/files/bigpipe_wait.html"
+    Then I should see "BigPipe streamed content"
+
+  @api @javascript @behat-steps-skip:BigPipeTrait
+  Scenario: The automatic BigPipe wait can be skipped with a tag
+    When I visit "/sites/default/files/bigpipe_wait.html"
+    Then I should see an "span[data-big-pipe-placeholder-id]" element
+    And I should not see "BigPipe streamed content"

--- a/tests/behat/features/drupal_big_pipe.feature
+++ b/tests/behat/features/drupal_big_pipe.feature
@@ -1,7 +1,50 @@
 Feature: Check that BigPipeTrait works
   As Behat Steps library developer
-  I want the library to wait for Drupal BigPipe placeholders to be replaced
-  So that JavaScript assertions do not race progressive rendering
+  I want BigPipe handled for both non-JavaScript and JavaScript drivers
+  So that non-JS drivers bypass streaming via the nojs cookie and JS drivers wait for placeholders to be replaced before assertions
+
+  @api @skipped
+  Scenario: Assert that Big Pipe cookie is set
+    Given I install a "big_pipe" module
+    When I visit "/"
+    Then cookie "big_pipe_nojs" exists
+
+  @api @behat-steps-skip:bigPipeBeforeScenario
+  Scenario: Assert that Big Pipe cookie is not set when skip tag is used
+    Given I install a "big_pipe" module
+    When I visit "/"
+    Then cookie "big_pipe_nojs" does not exist
+
+  @api @skipped
+  Scenario: Assert that Big Pipe cookie is preserved across multiple users in a scenario
+    Given the following users:
+      | name               | mail                             | roles         | status |
+      | administrator_user | administrator_user@myexample.com | administrator | 1      |
+    And I install a "big_pipe" module
+    When I visit "/"
+    Then cookie "big_pipe_nojs" exists
+    When I am logged in as "administrator_user"
+    And I visit "/"
+    Then cookie "big_pipe_nojs" exists
+
+  @api @behat-steps-skip:bigPipeBeforeStep @skipped
+  Scenario: Assert that Big Pipe cookie is not preserved across multiple users when skip tag is used
+    Given the following users:
+      | name               | mail                             | roles         | status |
+      | administrator_user | administrator_user@myexample.com | administrator | 1      |
+    And I install a "big_pipe" module
+    When I visit "/"
+    Then cookie "big_pipe_nojs" exists
+    # Logging in as a new user removes cookies.
+    When I am logged in as "administrator_user"
+    And I visit "/"
+    Then cookie "big_pipe_nojs" does not exist
+
+  @api @javascript
+  Scenario: Assert that Big Pipe cookie is not set when JavaScript is supported
+    Given I install a "big_pipe" module
+    When I visit "/"
+    Then cookie "big_pipe_nojs" does not exist
 
   @javascript
   Scenario: BigPipe placeholders are awaited automatically before assertions
@@ -11,5 +54,11 @@ Feature: Check that BigPipeTrait works
   @javascript @behat-steps-skip:BigPipeTrait
   Scenario: The automatic BigPipe wait can be skipped with a tag
     When I visit "/sites/default/files/bigpipe_wait.html"
+    Then I should see an "span[data-big-pipe-placeholder-id]" element
+    And I should not see "BigPipe streamed content"
+
+  @javascript @bigpipe-timeout
+  Scenario: The automatic BigPipe wait times out without failing when placeholders never resolve
+    When I visit "/sites/default/files/bigpipe_stuck.html"
     Then I should see an "span[data-big-pipe-placeholder-id]" element
     And I should not see "BigPipe streamed content"

--- a/tests/behat/features/drupal_big_pipe.feature
+++ b/tests/behat/features/drupal_big_pipe.feature
@@ -57,7 +57,7 @@ Feature: Check that BigPipeTrait works
     Then I should see an "span[data-big-pipe-placeholder-id]" element
     And I should not see "BigPipe streamed content"
 
-  @javascript @bigpipe-timeout
+  @javascript @test-bigpipe-timeout
   Scenario: The automatic BigPipe wait times out without failing when placeholders never resolve
     When I visit "/sites/default/files/bigpipe_stuck.html"
     Then I should see an "span[data-big-pipe-placeholder-id]" element

--- a/tests/behat/features/drupal_big_pipe.feature
+++ b/tests/behat/features/drupal_big_pipe.feature
@@ -3,12 +3,12 @@ Feature: Check that BigPipeTrait works
   I want the library to wait for Drupal BigPipe placeholders to be replaced
   So that JavaScript assertions do not race progressive rendering
 
-  @api @javascript
+  @javascript
   Scenario: BigPipe placeholders are awaited automatically before assertions
     When I visit "/sites/default/files/bigpipe_wait.html"
     Then I should see "BigPipe streamed content"
 
-  @api @javascript @behat-steps-skip:BigPipeTrait
+  @javascript @behat-steps-skip:BigPipeTrait
   Scenario: The automatic BigPipe wait can be skipped with a tag
     When I visit "/sites/default/files/bigpipe_wait.html"
     Then I should see an "span[data-big-pipe-placeholder-id]" element

--- a/tests/behat/fixtures/bigpipe_stuck.html
+++ b/tests/behat/fixtures/bigpipe_stuck.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>BigPipe Stuck Test</title>
+</head>
+<body>
+    <h1>BigPipe Stuck Test Page</h1>
+    <p>This page keeps its BigPipe placeholder in the DOM and never replaces it,
+       so the automatic wait runs until its timeout.</p>
+
+    <span data-big-pipe-placeholder-id="placeholder-1">Loading...</span>
+</body>
+</html>

--- a/tests/behat/fixtures/bigpipe_wait.html
+++ b/tests/behat/fixtures/bigpipe_wait.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>BigPipe Wait Test</title>
+</head>
+<body>
+    <h1>BigPipe Wait Test Page</h1>
+    <p>This page simulates Drupal BigPipe replacing a placeholder after load.</p>
+
+    <span data-big-pipe-placeholder-id="placeholder-1"></span>
+
+    <script>
+        // Mimic Drupal BigPipe: swap the placeholder span for its real content
+        // after a delay, the way streamed BigPipe replacements arrive.
+        setTimeout(function () {
+            var placeholder = document.querySelector('[data-big-pipe-placeholder-id="placeholder-1"]');
+            if (placeholder) {
+                var content = document.createElement('div');
+                content.textContent = 'BigPipe streamed content';
+                placeholder.replaceWith(content);
+            }
+        }, 1500);
+    </script>
+</body>
+</html>

--- a/tests/behat/fixtures/bigpipe_wait.html
+++ b/tests/behat/fixtures/bigpipe_wait.html
@@ -12,7 +12,11 @@
 
     <script>
         // Mimic Drupal BigPipe: swap the placeholder span for its real content
-        // after a delay, the way streamed BigPipe replacements arrive.
+        // after a delay, the way streamed BigPipe replacements arrive. The delay
+        // is wide enough that the skip-tag scenario can observe the
+        // pre-replacement state without racing it on a slow CI runner, yet well
+        // under the trait's default wait timeout so the awaited scenario still
+        // completes.
         setTimeout(function () {
             var placeholder = document.querySelector('[data-big-pipe-placeholder-id="placeholder-1"]');
             if (placeholder) {
@@ -20,7 +24,7 @@
                 content.textContent = 'BigPipe streamed content';
                 placeholder.replaceWith(content);
             }
-        }, 1500);
+        }, 5000);
     </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #673

## Summary

Adds a new `Drupal\BigPipeTrait` that automatically waits for Drupal BigPipe placeholders to be replaced before every step on `@javascript` scenarios, removing the race where JS assertions run before BigPipe's progressive rendering has finished streaming in the real markup.

## Changes

- Added `src/Drupal/BigPipeTrait.php`: a `#[BeforeScenario]` hook resolves whether the automatic wait applies (feature or scenario tagged `@javascript`, and not `@behat-steps-skip:BigPipeTrait`), and a `#[BeforeStep]` hook then waits, best-effort, until `document.querySelectorAll('[data-big-pipe-placeholder-id]').length === 0` or the timeout elapses. The wait never throws on timeout, so a genuinely stuck placeholder still surfaces as the real assertion failure rather than being masked by this hook.
- The wait timeout is a settable `$bigPipeWaitTimeout` property (default 10000ms) exposed through the overridable `bigPipeGetWaitTimeout()` method.
- The hook method is named `bigPipeWaitBeforeStep()` rather than `bigPipeBeforeStep()` specifically to avoid overriding the drupal-extension `BigPipeTrait::bigPipeBeforeStep()` hook that `FeatureContext` already inherits via `DrupalContext`.
- Registered `BigPipeTrait` in `tests/behat/bootstrap/FeatureContext.php`.
- Broadened `tests/behat/features/drupal_big_pipe.feature` to cover BigPipe on both driver modes:
  - The existing non-JavaScript `big_pipe_nojs` cookie scenarios (the drupal-extension server-side bypass) are kept.
  - New `@javascript` scenarios assert that the hook awaits placeholders automatically, that the wait can be opted out with `@behat-steps-skip:BigPipeTrait`, and that the wait times out without failing when placeholders never resolve.
- Added two static fixtures: `tests/behat/fixtures/bigpipe_wait.html` (placeholder replaced after a delay, standing in for BigPipe's streamed replacement) and `tests/behat/fixtures/bigpipe_stuck.html` (placeholder never replaced, to exercise the timeout path). The timeout scenario is tagged `@test-bigpipe-timeout` (test-only tags carry a `test-` prefix to distinguish them from the library's public tags), and `FeatureContext` gives just that scenario a short 2s timeout so it runs quickly while every other scenario keeps the default.
- Regenerated `STEPS.md` and `README.md` via `ahoy update-docs`.

### Design deviation from the issue

Issue #673 proposed an explicit Behat step for waiting on BigPipe placeholders. This PR implements an automatic `#[BeforeStep]` hook instead, opted into simply by including the trait, so `@javascript` scenarios get the protection without any per-scenario step. This is a deliberate design decision that supersedes some of the issue's step-oriented acceptance criteria:

- On a non-JavaScript driver the hook silently no-ops (gated on the `@javascript` tag) rather than failing with a clear error message, since hard-failing every non-JS step would be wrong for an always-on hook.
- The timeout is configurable via the overridable `bigPipeGetWaitTimeout()` method (or the `$bigPipeWaitTimeout` property) rather than a per-call argument.
- There is no new entry in `STEPS.md` for a step, since a hook is not a step.

This is complementary to the drupal-extension `BigPipeTrait` already inherited via `DrupalContext`: that one sets the `big_pipe_nojs` cookie for non-JS drivers (BigPipe renders server-side, nothing to wait for), whereas this trait handles the JS driver path where BigPipe streams live and the race actually occurs. The feature file exercises both sides.

## Before / After

```
BEFORE (no wait - assertion races BigPipe's streamed replacement)

  Step: "I visit ... "          Step: "I should see ... "
        |                              |
        v                              v
  +-----------+                  +-----------------------+
  | Page load |----------------->| Assertion runs         |
  +-----------+                  | immediately             |
        |                        +-----------------------+
        | (async, in browser)              |
        v                                  v
  +-------------------------+      "element not found"
  | BigPipe streams in and  |      (flaky - placeholder
  | replaces placeholder    |       not replaced yet)
  | span (in progress...)   |
  +-------------------------+

AFTER (BigPipeTrait waits before every step on @javascript scenarios)

  Step: "I visit ... "          Step: "I should see ... "
        |                              |
        v                              v
  +-----------+   #[BeforeStep]   +-----------------------+
  | Page load |---- hook waits -->| No placeholders left?  |
  +-----------+     until:        | -> assertion runs      |
        |           no [data-big- +-----------------------+
        | (async)   pipe-placeholder-id]          |
        v           in the DOM (or timeout)       v
  +-------------------------+            Assertion passes
  | BigPipe streams in and  |            against the real,
  | replaces placeholder    |            streamed-in markup
  | span (settled)          |
  +-------------------------+
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Behat support for Drupal BigPipe so `@javascript` scenarios automatically wait for placeholder replacement before each step.

- Added `Drupal\BigPipeTrait` with scenario/step hooks and a configurable best-effort timeout.
- Registered the trait in `FeatureContext` and added a test-only timeout override tag (`@test-bigpipe-timeout`).
- Expanded Behat coverage with JS/non-JS scenarios plus delayed-replacement and stuck-placeholder fixtures.
- Regenerated `README.md` and `STEPS.md` documentation.
- Documented the harness tag prefix convention in `CLAUDE.md`.

No step-definition rule violations were apparent from the changes reviewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->