### PR TITLE
[#669] Added 'CommandTrait' for shell command execution and assertions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ from the community.
 | Class | Description |
 | --- | --- |
 | [AccessibilityTrait](STEPS.md#accessibilitytrait) | Assess accessibility of rendered pages. |
+| [CommandTrait](STEPS.md#commandtrait) | Run local shell commands and assert on their result. |
 | [CookieTrait](STEPS.md#cookietrait) | Verify and inspect browser cookies. |
 | [DateTrait](STEPS.md#datetrait) | Convert relative date expressions into timestamps or formatted dates. |
 | [DropzoneTrait](STEPS.md#dropzonetrait) | Simulate a real multi-file drag-and-drop gesture onto a Dropzone target. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -5,6 +5,7 @@
 | Class | Description |
 | --- | --- |
 | [AccessibilityTrait](#accessibilitytrait) | Assess accessibility of rendered pages. |
+| [CommandTrait](#commandtrait) | Run local shell commands and assert on their result. |
 | [CookieTrait](#cookietrait) | Verify and inspect browser cookies. |
 | [DateTrait](#datetrait) | Convert relative date expressions into timestamps or formatted dates. |
 | [DropzoneTrait](#dropzonetrait) | Simulate a real multi-file drag-and-drop gesture onto a Dropzone target. |
@@ -113,6 +114,171 @@ Assert that the current page passes accessibility checks for given rules
 
 ```gherkin
 Then the current page should pass accessibility checks for tags "wcag2a"
+
+```
+
+</details>
+
+## CommandTrait
+
+[Source](src/CommandTrait.php), [Example](tests/behat/features/command.feature)
+
+>  Run local shell commands and assert on their result.
+>  - Run a shell command and capture its output, error output, and exit code.
+>  - Assert that the command succeeded or failed.
+>  - Assert the exit code, standard output, and error output.
+>  - Assert how long the command took to complete.
+>  
+>  Commands run through the system shell with the privileges of the process
+>  that runs the tests. The command string is passed to the shell verbatim and
+>  is subject to shell expansion, so never interpolate untrusted input into it.
+
+
+<details>
+  <summary><code>@When I run the command :command</code></summary>
+
+<br/>
+Run a shell command
+<br/><br/>
+
+```gherkin
+When I run the command "php -v"
+When I run the command "./vendor/bin/phpunit --version"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the command should succeed</code></summary>
+
+<br/>
+Assert that the last command succeeded
+<br/><br/>
+
+```gherkin
+When I run the command "php -v"
+Then the command should succeed
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the command should fail</code></summary>
+
+<br/>
+Assert that the last command failed
+<br/><br/>
+
+```gherkin
+When I run the command "phpcs --standard=NonExisting"
+Then the command should fail
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the command exit code should be :code</code></summary>
+
+<br/>
+Assert that the last command exited with a specific code
+<br/><br/>
+
+```gherkin
+When I run the command "php -r 'exit(3);'"
+Then the command exit code should be 3
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the command output should contain :text</code></summary>
+
+<br/>
+Assert that the command output contains a string
+<br/><br/>
+
+```gherkin
+When I run the command "echo hello"
+Then the command output should contain "hello"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the command output should not contain :text</code></summary>
+
+<br/>
+Assert that the command output does not contain a string
+<br/><br/>
+
+```gherkin
+When I run the command "echo hello"
+Then the command output should not contain "goodbye"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the command output should be :text</code></summary>
+
+<br/>
+Assert that the command output equals a string
+<br/><br/>
+
+```gherkin
+When I run the command "echo hello"
+Then the command output should be "hello"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the command error output should contain :text</code></summary>
+
+<br/>
+Assert that the command error output contains a string
+<br/><br/>
+
+```gherkin
+When I run the command "ls /nonexistent"
+Then the command error output should contain "No such file"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the command should complete in less than :seconds second(s)</code></summary>
+
+<br/>
+Assert that the command completed in less than a number of seconds
+<br/><br/>
+
+```gherkin
+When I run the command "echo hello"
+Then the command should complete in less than 5 seconds
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the command should complete in more than :seconds second(s)</code></summary>
+
+<br/>
+Assert that the command completed in more than a number of seconds
+<br/><br/>
+
+```gherkin
+When I run the command "sleep 2"
+Then the command should complete in more than 1 second
 
 ```
 

--- a/src/CommandTrait.php
+++ b/src/CommandTrait.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps;
+
+use Behat\Hook\AfterScenario;
+use Behat\Hook\BeforeScenario;
+use Behat\Step\Then;
+use Behat\Step\When;
+
+/**
+ * Run local shell commands and assert on their result.
+ *
+ * - Run a shell command and capture its output, error output, and exit code.
+ * - Assert that the command succeeded or failed.
+ * - Assert the exit code, standard output, and error output.
+ * - Assert how long the command took to complete.
+ *
+ * Commands run through the system shell with the privileges of the process
+ * that runs the tests. The command string is passed to the shell verbatim and
+ * is subject to shell expansion, so never interpolate untrusted input into it.
+ */
+trait CommandTrait {
+
+  /**
+   * Standard output (stdout) captured from the last command.
+   */
+  protected string $commandStdout = '';
+
+  /**
+   * Error output (stderr) captured from the last command.
+   */
+  protected string $commandStderr = '';
+
+  /**
+   * Exit code of the last command, or NULL when no command has run yet.
+   */
+  protected ?int $commandExitCode = NULL;
+
+  /**
+   * Wall-clock duration of the last command, in seconds.
+   */
+  protected float $commandDuration = 0.0;
+
+  /**
+   * Clear captured command state before each scenario.
+   */
+  #[BeforeScenario]
+  public function commandBeforeScenario(): void {
+    $this->commandResetState();
+  }
+
+  /**
+   * Clear captured command state after each scenario.
+   */
+  #[AfterScenario]
+  public function commandAfterScenario(): void {
+    $this->commandResetState();
+  }
+
+  /**
+   * Run a shell command.
+   *
+   * The command runs through the system shell; its standard output, error
+   * output, and exit code are captured for subsequent assertions.
+   *
+   * @code
+   * When I run the command "php -v"
+   * When I run the command "./vendor/bin/phpunit --version"
+   * @endcode
+   */
+  #[When('I run the command :command')]
+  public function commandRun(string $command): void {
+    $descriptors = [
+      0 => ['pipe', 'r'],
+      1 => ['pipe', 'w'],
+      2 => ['pipe', 'w'],
+    ];
+
+    $this->commandResetState();
+
+    $started = microtime(TRUE);
+    $process = proc_open($command, $descriptors, $pipes);
+
+    if (!is_resource($process)) {
+      // @codeCoverageIgnoreStart
+      throw new \RuntimeException(sprintf('Unable to start the command "%s".', $command));
+      // @codeCoverageIgnoreEnd
+    }
+
+    fclose($pipes[0]);
+
+    // Drain both pipes concurrently. Reading one to completion before the other
+    // would deadlock when a command fills the buffer of the unread pipe (~64KB)
+    // and blocks before it can finish writing the pipe being read.
+    stream_set_blocking($pipes[1], FALSE);
+    stream_set_blocking($pipes[2], FALSE);
+
+    $stdout = '';
+    $stderr = '';
+
+    while (!feof($pipes[1]) || !feof($pipes[2])) {
+      $read = [];
+      if (!feof($pipes[1])) {
+        $read[] = $pipes[1];
+      }
+      if (!feof($pipes[2])) {
+        $read[] = $pipes[2];
+      }
+
+      $write = NULL;
+      $except = NULL;
+      if (stream_select($read, $write, $except, 1) === FALSE) {
+        // @codeCoverageIgnoreStart
+        break;
+        // @codeCoverageIgnoreEnd
+      }
+
+      foreach ($read as $stream) {
+        $chunk = fread($stream, 8192);
+        if ($chunk === FALSE) {
+          // @codeCoverageIgnoreStart
+          continue;
+          // @codeCoverageIgnoreEnd
+        }
+
+        if ($stream === $pipes[1]) {
+          $stdout .= $chunk;
+        }
+        else {
+          $stderr .= $chunk;
+        }
+      }
+    }
+
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+
+    $this->commandExitCode = proc_close($process);
+    $this->commandDuration = microtime(TRUE) - $started;
+    $this->commandStdout = $stdout;
+    $this->commandStderr = $stderr;
+  }
+
+  /**
+   * Assert that the last command succeeded.
+   *
+   * @code
+   * When I run the command "php -v"
+   * Then the command should succeed
+   * @endcode
+   */
+  #[Then('the command should succeed')]
+  public function commandAssertSuccess(): void {
+    $this->commandAssertHasRun();
+
+    $exit_code = (int) $this->commandExitCode;
+
+    if ($exit_code !== 0) {
+      throw new \Exception(sprintf('Expected the command to succeed, but it exited with code %d. Error output: %s', $exit_code, $this->commandStderr));
+    }
+  }
+
+  /**
+   * Assert that the last command failed.
+   *
+   * @code
+   * When I run the command "phpcs --standard=NonExisting"
+   * Then the command should fail
+   * @endcode
+   */
+  #[Then('the command should fail')]
+  public function commandAssertFailure(): void {
+    $this->commandAssertHasRun();
+
+    if ((int) $this->commandExitCode === 0) {
+      throw new \Exception('Expected the command to fail, but it exited with code 0.');
+    }
+  }
+
+  /**
+   * Assert that the last command exited with a specific code.
+   *
+   * @code
+   * When I run the command "php -r 'exit(3);'"
+   * Then the command exit code should be 3
+   * @endcode
+   */
+  #[Then('the command exit code should be :code')]
+  public function commandAssertExitCode(string $code): void {
+    $this->commandAssertHasRun();
+
+    $expected = (int) $code;
+    $exit_code = (int) $this->commandExitCode;
+
+    if ($exit_code !== $expected) {
+      throw new \Exception(sprintf('Expected the command to exit with code %d, but it exited with code %d.', $expected, $exit_code));
+    }
+  }
+
+  /**
+   * Assert that the command output contains a string.
+   *
+   * The output is the command's standard output (stdout).
+   *
+   * @code
+   * When I run the command "echo hello"
+   * Then the command output should contain "hello"
+   * @endcode
+   */
+  #[Then('the command output should contain :text')]
+  public function commandAssertOutputContains(string $text): void {
+    $this->commandAssertHasRun();
+
+    if (!str_contains($this->commandStdout, $text)) {
+      throw new \Exception(sprintf('Expected the command output to contain "%s", but it did not. Actual output: %s', $text, $this->commandStdout));
+    }
+  }
+
+  /**
+   * Assert that the command output does not contain a string.
+   *
+   * The output is the command's standard output (stdout).
+   *
+   * @code
+   * When I run the command "echo hello"
+   * Then the command output should not contain "goodbye"
+   * @endcode
+   */
+  #[Then('the command output should not contain :text')]
+  public function commandAssertOutputNotContains(string $text): void {
+    $this->commandAssertHasRun();
+
+    if (str_contains($this->commandStdout, $text)) {
+      throw new \Exception(sprintf('Expected the command output to not contain "%s", but it did. Actual output: %s', $text, $this->commandStdout));
+    }
+  }
+
+  /**
+   * Assert that the command output equals a string.
+   *
+   * The output is the command's standard output (stdout). Leading and trailing
+   * whitespace is ignored on both sides so a trailing newline emitted by the
+   * command does not cause a mismatch.
+   *
+   * @code
+   * When I run the command "echo hello"
+   * Then the command output should be "hello"
+   * @endcode
+   */
+  #[Then('the command output should be :text')]
+  public function commandAssertOutputEquals(string $text): void {
+    $this->commandAssertHasRun();
+
+    if (trim($this->commandStdout) !== trim($text)) {
+      throw new \Exception(sprintf('Expected the command output to be "%s", but got "%s".', trim($text), trim($this->commandStdout)));
+    }
+  }
+
+  /**
+   * Assert that the command error output contains a string.
+   *
+   * The error output is the command's standard error (stderr).
+   *
+   * @code
+   * When I run the command "ls /nonexistent"
+   * Then the command error output should contain "No such file"
+   * @endcode
+   */
+  #[Then('the command error output should contain :text')]
+  public function commandAssertErrorOutputContains(string $text): void {
+    $this->commandAssertHasRun();
+
+    if (!str_contains($this->commandStderr, $text)) {
+      throw new \Exception(sprintf('Expected the command error output to contain "%s", but it did not. Actual error output: %s', $text, $this->commandStderr));
+    }
+  }
+
+  /**
+   * Assert that the command completed in less than a number of seconds.
+   *
+   * @code
+   * When I run the command "echo hello"
+   * Then the command should complete in less than 5 seconds
+   * @endcode
+   */
+  #[Then('the command should complete in less than :seconds second(s)')]
+  public function commandAssertDurationLessThan(string $seconds): void {
+    $this->commandAssertHasRun();
+
+    $limit = (float) $seconds;
+
+    if ($this->commandDuration >= $limit) {
+      throw new \Exception(sprintf('Expected the command to complete in less than %s seconds, but it took %.3f seconds.', $seconds, $this->commandDuration));
+    }
+  }
+
+  /**
+   * Assert that the command completed in more than a number of seconds.
+   *
+   * @code
+   * When I run the command "sleep 2"
+   * Then the command should complete in more than 1 second
+   * @endcode
+   */
+  #[Then('the command should complete in more than :seconds second(s)')]
+  public function commandAssertDurationMoreThan(string $seconds): void {
+    $this->commandAssertHasRun();
+
+    $limit = (float) $seconds;
+
+    if ($this->commandDuration <= $limit) {
+      throw new \Exception(sprintf('Expected the command to complete in more than %s seconds, but it took %.3f seconds.', $seconds, $this->commandDuration));
+    }
+  }
+
+  /**
+   * Reset the captured command state.
+   */
+  protected function commandResetState(): void {
+    $this->commandStdout = '';
+    $this->commandStderr = '';
+    $this->commandExitCode = NULL;
+    $this->commandDuration = 0.0;
+  }
+
+  /**
+   * Assert that a command has been run in the current scenario.
+   *
+   * @throws \RuntimeException
+   *   When no command has been run yet.
+   */
+  protected function commandAssertHasRun(): void {
+    if ($this->commandExitCode === NULL) {
+      throw new \RuntimeException('No command has been run. Run a command before asserting on its result.');
+    }
+  }
+
+}

--- a/src/CommandTrait.php
+++ b/src/CommandTrait.php
@@ -99,8 +99,18 @@ trait CommandTrait {
 
     $stdout = '';
     $stderr = '';
+    $timeout = $this->commandTimeout();
 
     while (!feof($pipes[1]) || !feof($pipes[2])) {
+      if (microtime(TRUE) - $started > $timeout) {
+        proc_terminate($process, 9);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        throw new \RuntimeException(sprintf('The command "%s" timed out after %d seconds.', $command, $timeout));
+      }
+
       $read = [];
       if (!feof($pipes[1])) {
         $read[] = $pipes[1];
@@ -191,7 +201,7 @@ trait CommandTrait {
   public function commandAssertExitCode(string $code): void {
     $this->commandAssertHasRun();
 
-    $expected = (int) $code;
+    $expected = (int) $this->commandAssertNumeric($code, 'expected exit code');
     $exit_code = (int) $this->commandExitCode;
 
     if ($exit_code !== $expected) {
@@ -289,7 +299,7 @@ trait CommandTrait {
   public function commandAssertDurationLessThan(string $seconds): void {
     $this->commandAssertHasRun();
 
-    $limit = (float) $seconds;
+    $limit = $this->commandAssertNumeric($seconds, 'expected duration');
 
     if ($this->commandDuration >= $limit) {
       throw new \Exception(sprintf('Expected the command to complete in less than %s seconds, but it took %.3f seconds.', $seconds, $this->commandDuration));
@@ -308,7 +318,7 @@ trait CommandTrait {
   public function commandAssertDurationMoreThan(string $seconds): void {
     $this->commandAssertHasRun();
 
-    $limit = (float) $seconds;
+    $limit = $this->commandAssertNumeric($seconds, 'expected duration');
 
     if ($this->commandDuration <= $limit) {
       throw new \Exception(sprintf('Expected the command to complete in more than %s seconds, but it took %.3f seconds.', $seconds, $this->commandDuration));
@@ -335,6 +345,27 @@ trait CommandTrait {
     if ($this->commandExitCode === NULL) {
       throw new \RuntimeException('No command has been run. Run a command before asserting on its result.');
     }
+  }
+
+  /**
+   * Assert that a step argument is numeric and return it as a float.
+   *
+   * @throws \RuntimeException
+   *   When the value is not numeric.
+   */
+  protected function commandAssertNumeric(string $value, string $label): float {
+    if (!is_numeric($value)) {
+      throw new \RuntimeException(sprintf('The %s must be numeric, but got "%s".', $label, $value));
+    }
+
+    return (float) $value;
+  }
+
+  /**
+   * The maximum time, in seconds, a command may run before it is terminated.
+   */
+  protected function commandTimeout(): int {
+    return 300;
   }
 
 }

--- a/src/CommandTrait.php
+++ b/src/CommandTrait.php
@@ -201,7 +201,7 @@ trait CommandTrait {
   public function commandAssertExitCode(string $code): void {
     $this->commandAssertHasRun();
 
-    $expected = (int) $this->commandAssertNumeric($code, 'expected exit code');
+    $expected = $this->commandAssertInteger($code, 'expected exit code');
     $exit_code = (int) $this->commandExitCode;
 
     if ($exit_code !== $expected) {
@@ -359,6 +359,20 @@ trait CommandTrait {
     }
 
     return (float) $value;
+  }
+
+  /**
+   * Assert that a step argument is an integer and return it.
+   *
+   * @throws \RuntimeException
+   *   When the value is not an integer.
+   */
+  protected function commandAssertInteger(string $value, string $label): int {
+    if (!preg_match('/^-?\d+$/', $value)) {
+      throw new \RuntimeException(sprintf('The %s must be an integer, but got "%s".', $label, $value));
+    }
+
+    return (int) $value;
   }
 
   /**

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Hook\BeforeScenario;
 use DrevOps\BehatSteps\AccessibilityTrait;
+use DrevOps\BehatSteps\CommandTrait;
 use DrevOps\BehatSteps\CookieTrait;
 use DrevOps\BehatSteps\DateTrait;
 use DrevOps\BehatSteps\Drupal\BigPipeTrait;
@@ -67,6 +68,7 @@ class FeatureContext extends DrupalContext {
   use BigPipeTrait;
   use BlockTrait;
   use CacheTrait;
+  use CommandTrait;
   use ConfigOverrideTrait;
   use ContentBlockTrait;
   use ContentTrait;

--- a/tests/behat/features/command.feature
+++ b/tests/behat/features/command.feature
@@ -165,3 +165,31 @@ Feature: Check that CommandTrait works
       """
       No command has been run. Run a command before asserting on its result.
       """
+
+  @trait:CommandTrait
+  Scenario: Assert that a non-numeric exit code argument fails with a runtime exception
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "echo hello"
+      Then the command exit code should be "three"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      The expected exit code must be numeric, but got "three".
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that a non-numeric duration argument fails with a runtime exception
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "echo hello"
+      Then the command should complete in less than "three" seconds
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      The expected duration must be numeric, but got "three".
+      """

--- a/tests/behat/features/command.feature
+++ b/tests/behat/features/command.feature
@@ -167,7 +167,7 @@ Feature: Check that CommandTrait works
       """
 
   @trait:CommandTrait
-  Scenario: Assert that a non-numeric exit code argument fails with a runtime exception
+  Scenario: Assert that a non-integer exit code argument fails with a runtime exception
     Given some behat configuration
     And scenario steps:
       """
@@ -177,7 +177,7 @@ Feature: Check that CommandTrait works
     When I run "behat --no-colors"
     Then it should fail with an exception:
       """
-      The expected exit code must be numeric, but got "three".
+      The expected exit code must be an integer, but got "three".
       """
 
   @trait:CommandTrait

--- a/tests/behat/features/command.feature
+++ b/tests/behat/features/command.feature
@@ -1,0 +1,167 @@
+Feature: Check that CommandTrait works
+  As Behat Steps library developer
+  I want to provide tools to run shell commands and assert on their result
+  So that scenarios can shell out and verify command outcomes
+
+  Scenario: Assert that a successful command passes success, output, and exit code assertions
+    When I run the command "echo hello"
+    Then the command should succeed
+    And the command exit code should be 0
+    And the command output should contain "hello"
+    And the command output should be "hello"
+    And the command output should not contain "goodbye"
+
+  Scenario: Assert that a failing command passes failure and exit code assertions
+    When I run the command "exit 3"
+    Then the command should fail
+    And the command exit code should be 3
+
+  Scenario: Assert that error output is captured separately from standard output
+    When I run the command "echo oops >&2"
+    Then the command error output should contain "oops"
+    And the command output should not contain "oops"
+
+  Scenario: Assert that duration assertions pass and a second command replaces the first
+    When I run the command "echo fast"
+    Then the command should complete in less than 60 seconds
+    When I run the command "sleep 1"
+    Then the command should complete in more than 0 seconds
+
+  @trait:CommandTrait
+  Scenario: Assert that "the command should succeed" fails when the command failed
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "exit 1"
+      Then the command should succeed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the command to succeed, but it exited with code 1.
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that "the command should fail" fails when the command succeeded
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "echo hello"
+      Then the command should fail
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the command to fail, but it exited with code 0.
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that "the command exit code should be" fails on a mismatch
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "echo hello"
+      Then the command exit code should be 3
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the command to exit with code 3, but it exited with code 0.
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that "the command output should contain" fails when the text is absent
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "echo hello"
+      Then the command output should contain "goodbye"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the command output to contain "goodbye", but it did not.
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that "the command output should not contain" fails when the text is present
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "echo hello"
+      Then the command output should not contain "hello"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the command output to not contain "hello", but it did.
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that "the command output should be" fails on a mismatch
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "echo hello"
+      Then the command output should be "goodbye"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the command output to be "goodbye", but got "hello".
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that "the command error output should contain" fails when the text is absent
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "echo hello"
+      Then the command error output should contain "missing"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the command error output to contain "missing", but it did not.
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that "the command should complete in less than" fails when the command is slower
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "sleep 2"
+      Then the command should complete in less than 1 second
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the command to complete in less than 1 seconds, but it took
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that "the command should complete in more than" fails when the command is faster
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I run the command "echo fast"
+      Then the command should complete in more than 5 seconds
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the command to complete in more than 5 seconds, but it took
+      """
+
+  @trait:CommandTrait
+  Scenario: Assert that an assertion before any command fails with a runtime exception
+    Given some behat configuration
+    And scenario steps:
+      """
+      Then the command should succeed
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      No command has been run. Run a command before asserting on its result.
+      """

--- a/tests/phpunit/src/CommandTraitTest.php
+++ b/tests/phpunit/src/CommandTraitTest.php
@@ -121,7 +121,7 @@ class CommandTraitTest extends UnitTestCase {
       'output unexpectedly contains' => ['echo hello', 'commandAssertOutputNotContains', ['hello'], \Exception::class, 'Expected the command output to not contain "hello"'],
       'output does not equal' => ['echo hello', 'commandAssertOutputEquals', ['goodbye'], \Exception::class, 'Expected the command output to be "goodbye", but got "hello".'],
       'error output does not contain' => ['echo hello', 'commandAssertErrorOutputContains', ['missing'], \Exception::class, 'Expected the command error output to contain "missing"'],
-      'duration exceeds the limit' => ['sleep 2', 'commandAssertDurationLessThan', ['1'], \Exception::class, 'Expected the command to complete in less than 1 seconds'],
+      'duration exceeds the limit' => ['sleep 1', 'commandAssertDurationLessThan', ['0.5'], \Exception::class, 'Expected the command to complete in less than 0.5 seconds'],
       'duration below the floor' => ['echo fast', 'commandAssertDurationMoreThan', ['5'], \Exception::class, 'Expected the command to complete in more than 5 seconds'],
       'assertion before any command' => [NULL, 'commandAssertSuccess', [], \RuntimeException::class, 'No command has been run.'],
     ];

--- a/tests/phpunit/src/CommandTraitTest.php
+++ b/tests/phpunit/src/CommandTraitTest.php
@@ -93,6 +93,15 @@ class CommandTraitTest extends UnitTestCase {
     $this->assertSame(0.0, $this->testObject->duration());
   }
 
+  public function testTimeoutTerminatesLongRunningCommand(): void {
+    $this->testObject->timeoutOverride = 1;
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('timed out after 1 seconds');
+
+    $this->testObject->commandRun('sleep 30');
+  }
+
   #[DataProvider('dataProviderAssertionFailures')]
   public function testAssertionFailures(?string $command, string $method, array $args, string $exception_class, string $message_fragment): void {
     if ($command !== NULL) {
@@ -124,6 +133,9 @@ class CommandTraitTest extends UnitTestCase {
       'duration exceeds the limit' => ['sleep 1', 'commandAssertDurationLessThan', ['0.5'], \Exception::class, 'Expected the command to complete in less than 0.5 seconds'],
       'duration below the floor' => ['echo fast', 'commandAssertDurationMoreThan', ['5'], \Exception::class, 'Expected the command to complete in more than 5 seconds'],
       'assertion before any command' => [NULL, 'commandAssertSuccess', [], \RuntimeException::class, 'No command has been run.'],
+      'non-numeric exit code' => ['echo hello', 'commandAssertExitCode', ['three'], \RuntimeException::class, 'The expected exit code must be numeric, but got "three".'],
+      'non-numeric less-than duration' => ['echo hello', 'commandAssertDurationLessThan', ['three'], \RuntimeException::class, 'The expected duration must be numeric, but got "three".'],
+      'non-numeric more-than duration' => ['echo hello', 'commandAssertDurationMoreThan', ['three'], \RuntimeException::class, 'The expected duration must be numeric, but got "three".'],
     ];
   }
 
@@ -135,6 +147,18 @@ class CommandTraitTest extends UnitTestCase {
 class CommandTraitTestImplementation {
 
   use CommandTrait;
+
+  /**
+   * The command timeout, in seconds, used by the trait.
+   */
+  public int $timeoutOverride = 300;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function commandTimeout(): int {
+    return $this->timeoutOverride;
+  }
 
   /**
    * Expose the captured exit code.

--- a/tests/phpunit/src/CommandTraitTest.php
+++ b/tests/phpunit/src/CommandTraitTest.php
@@ -133,7 +133,8 @@ class CommandTraitTest extends UnitTestCase {
       'duration exceeds the limit' => ['sleep 1', 'commandAssertDurationLessThan', ['0.5'], \Exception::class, 'Expected the command to complete in less than 0.5 seconds'],
       'duration below the floor' => ['echo fast', 'commandAssertDurationMoreThan', ['5'], \Exception::class, 'Expected the command to complete in more than 5 seconds'],
       'assertion before any command' => [NULL, 'commandAssertSuccess', [], \RuntimeException::class, 'No command has been run.'],
-      'non-numeric exit code' => ['echo hello', 'commandAssertExitCode', ['three'], \RuntimeException::class, 'The expected exit code must be numeric, but got "three".'],
+      'non-integer exit code word' => ['echo hello', 'commandAssertExitCode', ['three'], \RuntimeException::class, 'The expected exit code must be an integer, but got "three".'],
+      'non-integer exit code float' => ['echo hello', 'commandAssertExitCode', ['3.5'], \RuntimeException::class, 'The expected exit code must be an integer, but got "3.5".'],
       'non-numeric less-than duration' => ['echo hello', 'commandAssertDurationLessThan', ['three'], \RuntimeException::class, 'The expected duration must be numeric, but got "three".'],
       'non-numeric more-than duration' => ['echo hello', 'commandAssertDurationMoreThan', ['three'], \RuntimeException::class, 'The expected duration must be numeric, but got "three".'],
     ];

--- a/tests/phpunit/src/CommandTraitTest.php
+++ b/tests/phpunit/src/CommandTraitTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests;
+
+use DrevOps\BehatSteps\CommandTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for CommandTrait.
+ */
+#[CoversClass(CommandTrait::class)]
+class CommandTraitTest extends UnitTestCase {
+
+  /**
+   * A test implementation of CommandTrait.
+   *
+   * @var \DrevOps\BehatSteps\Tests\CommandTraitTestImplementation
+   */
+  protected $testObject;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->testObject = new CommandTraitTestImplementation();
+  }
+
+  public function testRunCapturesOutputExitCodeAndDuration(): void {
+    $this->testObject->commandRun('echo hello');
+
+    $this->assertSame(0, $this->testObject->exitCode());
+    $this->assertStringContainsString('hello', $this->testObject->stdout());
+    $this->assertSame('', $this->testObject->stderr());
+    $this->assertGreaterThan(0.0, $this->testObject->duration());
+
+    // Pass-through assertions do not throw.
+    $this->testObject->commandAssertSuccess();
+    $this->testObject->commandAssertExitCode('0');
+    $this->testObject->commandAssertOutputContains('hello');
+    $this->testObject->commandAssertOutputEquals('hello');
+    $this->testObject->commandAssertOutputNotContains('goodbye');
+    $this->testObject->commandAssertDurationLessThan('60');
+    $this->testObject->commandAssertDurationMoreThan('0');
+  }
+
+  public function testRunCapturesErrorOutputSeparately(): void {
+    $this->testObject->commandRun('echo oops >&2');
+
+    $this->assertStringContainsString('oops', $this->testObject->stderr());
+    $this->assertSame('', trim($this->testObject->stdout()));
+
+    $this->testObject->commandAssertErrorOutputContains('oops');
+    $this->testObject->commandAssertOutputNotContains('oops');
+  }
+
+  public function testRunCapturesNonZeroExitCode(): void {
+    $this->testObject->commandRun('exit 3');
+
+    $this->assertSame(3, $this->testObject->exitCode());
+
+    $this->testObject->commandAssertFailure();
+    $this->testObject->commandAssertExitCode('3');
+  }
+
+  public function testRunReplacesPreviousState(): void {
+    $this->testObject->commandRun('echo one');
+    $this->testObject->commandRun('echo two');
+
+    $this->assertStringContainsString('two', $this->testObject->stdout());
+    $this->assertStringNotContainsString('one', $this->testObject->stdout());
+  }
+
+  public function testBeforeScenarioResetsState(): void {
+    $this->testObject->commandRun('echo hello');
+    $this->testObject->commandBeforeScenario();
+
+    $this->assertNull($this->testObject->exitCode());
+    $this->assertSame('', $this->testObject->stdout());
+  }
+
+  public function testAfterScenarioResetsState(): void {
+    $this->testObject->commandRun('echo hello');
+    $this->testObject->commandAfterScenario();
+
+    $this->assertNull($this->testObject->exitCode());
+    $this->assertSame('', $this->testObject->stdout());
+    $this->assertSame('', $this->testObject->stderr());
+    $this->assertSame(0.0, $this->testObject->duration());
+  }
+
+  #[DataProvider('dataProviderAssertionFailures')]
+  public function testAssertionFailures(?string $command, string $method, array $args, string $exception_class, string $message_fragment): void {
+    if ($command !== NULL) {
+      $this->testObject->commandRun($command);
+    }
+
+    try {
+      $this->testObject->{$method}(...$args);
+    }
+    catch (\Exception $e) {
+      $this->assertSame($exception_class, $e::class);
+      $this->assertStringContainsString($message_fragment, $e->getMessage());
+
+      return;
+    }
+
+    $this->fail(sprintf('Expected "%s" to throw an exception, but none was thrown.', $method));
+  }
+
+  public static function dataProviderAssertionFailures(): array {
+    return [
+      'succeed on a failed command' => ['exit 1', 'commandAssertSuccess', [], \Exception::class, 'Expected the command to succeed, but it exited with code 1.'],
+      'fail on a successful command' => ['echo hello', 'commandAssertFailure', [], \Exception::class, 'Expected the command to fail, but it exited with code 0.'],
+      'exit code mismatch' => ['echo hello', 'commandAssertExitCode', ['3'], \Exception::class, 'Expected the command to exit with code 3, but it exited with code 0.'],
+      'output does not contain' => ['echo hello', 'commandAssertOutputContains', ['goodbye'], \Exception::class, 'Expected the command output to contain "goodbye"'],
+      'output unexpectedly contains' => ['echo hello', 'commandAssertOutputNotContains', ['hello'], \Exception::class, 'Expected the command output to not contain "hello"'],
+      'output does not equal' => ['echo hello', 'commandAssertOutputEquals', ['goodbye'], \Exception::class, 'Expected the command output to be "goodbye", but got "hello".'],
+      'error output does not contain' => ['echo hello', 'commandAssertErrorOutputContains', ['missing'], \Exception::class, 'Expected the command error output to contain "missing"'],
+      'duration exceeds the limit' => ['sleep 2', 'commandAssertDurationLessThan', ['1'], \Exception::class, 'Expected the command to complete in less than 1 seconds'],
+      'duration below the floor' => ['echo fast', 'commandAssertDurationMoreThan', ['5'], \Exception::class, 'Expected the command to complete in more than 5 seconds'],
+      'assertion before any command' => [NULL, 'commandAssertSuccess', [], \RuntimeException::class, 'No command has been run.'],
+    ];
+  }
+
+}
+
+/**
+ * Test implementation of CommandTrait.
+ */
+class CommandTraitTestImplementation {
+
+  use CommandTrait;
+
+  /**
+   * Expose the captured exit code.
+   */
+  public function exitCode(): ?int {
+    return $this->commandExitCode;
+  }
+
+  /**
+   * Expose the captured standard output.
+   */
+  public function stdout(): string {
+    return $this->commandStdout;
+  }
+
+  /**
+   * Expose the captured error output.
+   */
+  public function stderr(): string {
+    return $this->commandStderr;
+  }
+
+  /**
+   * Expose the captured duration.
+   */
+  public function duration(): float {
+    return $this->commandDuration;
+  }
+
+}


### PR DESCRIPTION
Closes #669
Closes #347

## Summary

Adds a new generic `CommandTrait` under `src/` that runs a local shell command via `proc_open()` and asserts on its stdout, stderr, exit code, and duration. It has no Drupal or Mink dependency, so it can be used in any Behat suite, not only Drupal ones. This consolidates two duplicate issues, #669 and #347, into a single implementation.

## Changes

- Added `src/CommandTrait.php` with 10 steps: run a command; assert success/failure; assert exit code; assert output contains/not-contains/equals; assert error output contains; assert duration less-than/more-than a number of seconds.
- Drained stdout and stderr concurrently via non-blocking `stream_select()` to avoid a pipe-buffer deadlock when a command fills one pipe's ~64KB buffer while the other pipe is being read.
- Guarded against a hung command with an overridable `commandTimeout()` (default 300 seconds): when the limit is exceeded the process is killed with `proc_terminate($process, 9)`, reaped with `proc_close()`, and a `\RuntimeException` is thrown.
- Validated step arguments before casting: exit codes must be integers (`commandAssertInteger()`) and durations must be numeric (`commandAssertNumeric()`), so a malformed placeholder surfaces an explicit error instead of silently coercing to `0`.
- Assertion failures throw `\Exception`; misuse (asserting before any command has run, or passing a malformed argument) throws `\RuntimeException`.
- Documented in the trait's docblock that the command string is passed to the shell verbatim and is subject to shell expansion, so untrusted input must never be interpolated into it.
- Wired `CommandTrait` into `tests/behat/bootstrap/FeatureContext.php`.
- Added BDD coverage in `tests/behat/features/command.feature`, including positive scenarios and negative `@trait:CommandTrait` subprocess scenarios that assert on failure messages.
- Added a PHPUnit unit test at `tests/phpunit/src/CommandTraitTest.php` covering output/exit-code/duration capture, state reset before/after scenarios, timeout termination, and every assertion-failure path via a data provider.
- Regenerated `STEPS.md` and `README.md` to include the new trait.

## Before / After

```
Before                                   After
------------------------------           ------------------------------
Gherkin scenarios have no way to         Gherkin scenarios can run any
run an arbitrary shell command           shell command and assert on it:
and check its result.
                                         When I run the command "php -v"
                                         Then the command should succeed
                                         And the command output should
                                           contain "PHP"
                                         And the command should complete
                                           in less than 5 seconds
```
