### PR TITLE
[#671] Added 'DiagnosticsTrait' for automatic on-failure diagnostics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ from the community.
 | [CommandTrait](STEPS.md#commandtrait) | Run local shell commands and assert on their result. |
 | [CookieTrait](STEPS.md#cookietrait) | Verify and inspect browser cookies. |
 | [DateTrait](STEPS.md#datetrait) | Convert relative date expressions into timestamps or formatted dates. |
+| [DiagnosticsTrait](STEPS.md#diagnosticstrait) | Append on-failure diagnostics to the failure message of any failed step. |
 | [DropzoneTrait](STEPS.md#dropzonetrait) | Simulate a real multi-file drag-and-drop gesture onto a Dropzone target. |
 | [ElementTrait](STEPS.md#elementtrait) | Interact with HTML elements using CSS selectors and DOM attributes. |
 | [FieldTrait](STEPS.md#fieldtrait) | Manipulate form fields and verify widget functionality. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -8,6 +8,7 @@
 | [CommandTrait](#commandtrait) | Run local shell commands and assert on their result. |
 | [CookieTrait](#cookietrait) | Verify and inspect browser cookies. |
 | [DateTrait](#datetrait) | Convert relative date expressions into timestamps or formatted dates. |
+| [DiagnosticsTrait](#diagnosticstrait) | Append on-failure diagnostics to the failure message of any failed step. |
 | [DropzoneTrait](#dropzonetrait) | Simulate a real multi-file drag-and-drop gesture onto a Dropzone target. |
 | [ElementTrait](#elementtrait) | Interact with HTML elements using CSS selectors and DOM attributes. |
 | [FieldTrait](#fieldtrait) | Manipulate form fields and verify widget functionality. |
@@ -480,6 +481,44 @@ Then a cookie with a name containing "user" and a value containing "guest" shoul
 >  Examples:
 >  - `[relative:-1 day]` converted to `1893456000`
 >  - `[relative:-1 day#Y-m-d]` converted to `2017-11-5`
+
+
+## DiagnosticsTrait
+
+[Source](src/DiagnosticsTrait.php), [Example](tests/behat/features/diagnostics.feature)
+
+>  Append on-failure diagnostics to the failure message of any failed step.
+>  <br/><br/>
+>  When a step fails, the exception message alone is often not enough to
+>  diagnose a red CI run. This trait hooks every step and, only when the step
+>  failed, appends a compact diagnostics block to the failure message:
+>  - `URL` - the current page URL.
+>  - `HTTP status` - the last response status code.
+>  - `Mink driver` - the active Mink driver class.
+>  - `JS console errors` - collected JavaScript errors, when a JavaScript-capable
+>  driver is active and errors were captured. Reads the buffer maintained by
+>  `JavascriptTrait` when the context also uses it, and the live browser buffer.
+>  - `Re-run` - a ready-to-paste command that re-runs just the failing scenario.
+>  
+>  The trait is opt-in: `use` it in the context and it is active with no further
+>  configuration. Every field is individually toggleable by overriding its
+>  `diagnosticsShow*()` method to return FALSE, and each value source degrades
+>  gracefully to nothing when the driver cannot provide it - a failed step is
+>  never turned into a different failure by this trait.
+>  <br/><br/>
+>  Skip processing with tags: `@behat-steps-skip:DiagnosticsTrait`.
+>  <br/><br/>
+>  ```
+>  Scenario: A failing step prints diagnostics
+>    Given I am on "/some-page"
+>    Then I should see "text that is not there"
+>    # On failure the message gains:
+>    # --- Failure diagnostics ---
+>    # URL: http://example.com/some-page
+>    # HTTP status: 200
+>    # Mink driver: Behat\Mink\Driver\BrowserKitDriver
+>    # Re-run: vendor/bin/behat features/example.feature:3
+>  ```
 
 
 ## DropzoneTrait

--- a/src/DiagnosticsTrait.php
+++ b/src/DiagnosticsTrait.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps;
+
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Hook\AfterStep;
+use Behat\Hook\BeforeScenario;
+use Behat\Testwork\Tester\Result\ExceptionResult;
+
+/**
+ * Append on-failure diagnostics to the failure message of any failed step.
+ *
+ * When a step fails, the exception message alone is often not enough to
+ * diagnose a red CI run. This trait hooks every step and, only when the step
+ * failed, appends a compact diagnostics block to the failure message:
+ *
+ * - `URL` - the current page URL.
+ * - `HTTP status` - the last response status code.
+ * - `Mink driver` - the active Mink driver class.
+ * - `JS console errors` - collected JavaScript errors, when a JavaScript-capable
+ *   driver is active and errors were captured. Reads the buffer maintained by
+ *   `JavascriptTrait` when the context also uses it, and the live browser buffer.
+ * - `Re-run` - a ready-to-paste command that re-runs just the failing scenario.
+ *
+ * The trait is opt-in: `use` it in the context and it is active with no further
+ * configuration. Every field is individually toggleable by overriding its
+ * `diagnosticsShow*()` method to return FALSE, and each value source degrades
+ * gracefully to nothing when the driver cannot provide it - a failed step is
+ * never turned into a different failure by this trait.
+ *
+ * Skip processing with tags: `@behat-steps-skip:DiagnosticsTrait`.
+ *
+ * @code
+ * Scenario: A failing step prints diagnostics
+ *   Given I am on "/some-page"
+ *   Then I should see "text that is not there"
+ *   # On failure the message gains:
+ *   # --- Failure diagnostics ---
+ *   # URL: http://example.com/some-page
+ *   # HTTP status: 200
+ *   # Mink driver: Behat\Mink\Driver\BrowserKitDriver
+ *   # Re-run: vendor/bin/behat features/example.feature:3
+ * @endcode
+ */
+trait DiagnosticsTrait {
+
+  /**
+   * Absolute path to the current feature file, captured for the re-run command.
+   */
+  protected ?string $diagnosticsFeatureFile = NULL;
+
+  /**
+   * Line of the current scenario, captured for the re-run command.
+   */
+  protected ?int $diagnosticsScenarioLine = NULL;
+
+  /**
+   * Whether the current scenario is opted out of diagnostics.
+   */
+  protected bool $diagnosticsSkip = FALSE;
+
+  /**
+   * Capture re-run coordinates and resolve the opt-out for the scenario.
+   *
+   * The opt-out is resolved here, rather than in the step hook, because the
+   * after-step scope exposes no scenario to read a scenario-level skip tag from.
+   */
+  #[BeforeScenario]
+  public function diagnosticsBeforeScenario(BeforeScenarioScope $scope): void {
+    $this->diagnosticsSkip = $scope->getFeature()->hasTag('behat-steps-skip:DiagnosticsTrait')
+      || $scope->getScenario()->hasTag('behat-steps-skip:DiagnosticsTrait');
+
+    $this->diagnosticsFeatureFile = $scope->getFeature()->getFile();
+    $this->diagnosticsScenarioLine = $scope->getScenario()->getLine();
+  }
+
+  /**
+   * Append the diagnostics block to the message of a failed step.
+   */
+  #[AfterStep]
+  public function diagnosticsAfterStep(AfterStepScope $scope): void {
+    if ($this->diagnosticsSkip) {
+      return;
+    }
+
+    $result = $scope->getTestResult();
+    $exception = $result instanceof ExceptionResult ? $result->getException() : NULL;
+
+    // A passing, undefined or pending step carries no exception to annotate.
+    if (!$exception instanceof \Exception) {
+      return;
+    }
+
+    $this->diagnosticsAppendToException($exception);
+  }
+
+  /**
+   * Append the diagnostics block to an exception's message in place.
+   *
+   * The exception is the same instance the formatter later prints, so mutating
+   * its message here surfaces the block in the output without re-throwing.
+   *
+   * @param \Exception $exception
+   *   The exception raised by the failed step.
+   */
+  protected function diagnosticsAppendToException(\Exception $exception): void {
+    $block = $this->diagnosticsBuildBlock();
+
+    if ($block === '') {
+      return;
+    }
+
+    $property = new \ReflectionProperty(\Exception::class, 'message');
+    $property->setValue($exception, $exception->getMessage() . PHP_EOL . PHP_EOL . $block);
+  }
+
+  /**
+   * Build the diagnostics block from the enabled fields.
+   *
+   * @return string
+   *   The rendered block, or an empty string when no field yielded a value.
+   */
+  protected function diagnosticsBuildBlock(): string {
+    $lines = [];
+
+    if ($this->diagnosticsShowUrl()) {
+      $url = $this->diagnosticsGetUrl();
+      if ($url !== NULL) {
+        $lines[] = 'URL: ' . $url;
+      }
+    }
+
+    if ($this->diagnosticsShowStatusCode()) {
+      $status = $this->diagnosticsGetStatusCode();
+      if ($status !== NULL) {
+        $lines[] = 'HTTP status: ' . $status;
+      }
+    }
+
+    if ($this->diagnosticsShowDriver()) {
+      $driver = $this->diagnosticsGetDriverName();
+      if ($driver !== NULL) {
+        $lines[] = 'Mink driver: ' . $driver;
+      }
+    }
+
+    if ($this->diagnosticsShowJsErrors()) {
+      $errors = $this->diagnosticsGetJsErrors();
+      if ($errors !== []) {
+        $lines[] = 'JS console errors: ' . implode('; ', $errors);
+      }
+    }
+
+    if ($this->diagnosticsShowRerun()) {
+      $rerun = $this->diagnosticsGetRerunCommand();
+      if ($rerun !== NULL) {
+        $lines[] = 'Re-run: ' . $rerun;
+      }
+    }
+
+    if ($lines === []) {
+      return '';
+    }
+
+    return $this->diagnosticsHeader() . PHP_EOL . implode(PHP_EOL, $lines);
+  }
+
+  /**
+   * Return the current page URL, or NULL when it cannot be determined.
+   */
+  protected function diagnosticsGetUrl(): ?string {
+    try {
+      $url = $this->getSession()->getCurrentUrl();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+
+    return $url === '' ? NULL : $url;
+  }
+
+  /**
+   * Return the last response status code, or NULL when it is unavailable.
+   */
+  protected function diagnosticsGetStatusCode(): ?int {
+    try {
+      return $this->getSession()->getStatusCode();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Return the active Mink driver class, or NULL when it is unavailable.
+   */
+  protected function diagnosticsGetDriverName(): ?string {
+    try {
+      return $this->getSession()->getDriver()::class;
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Return collected JavaScript console error messages.
+   *
+   * Sources, merged and de-duplicated: the registry maintained by
+   * `JavascriptTrait` when the context also uses it (detected at runtime, so
+   * there is no hard dependency on that trait), and the live browser buffer
+   * populated by its collector. Both are best-effort and yield nothing under a
+   * driver that cannot evaluate JavaScript.
+   *
+   * @return array<int, string>
+   *   Distinct error messages, in the order first seen.
+   */
+  protected function diagnosticsGetJsErrors(): array {
+    $messages = [];
+
+    $registry = get_object_vars($this)['javascriptErrorRegistry'] ?? NULL;
+    if (is_array($registry)) {
+      foreach ($registry as $errors) {
+        foreach (is_array($errors) ? $errors : [] as $error) {
+          if (is_array($error) && isset($error['message'])) {
+            $messages[] = (string) $error['message'];
+          }
+        }
+      }
+    }
+
+    try {
+      $live = $this->getSession()->evaluateScript('return (typeof window.jsErrors !== "undefined") ? window.jsErrors : [];');
+      foreach (is_array($live) ? $live : [] as $error) {
+        if (is_array($error) && isset($error['message'])) {
+          $messages[] = (string) $error['message'];
+        }
+      }
+    }
+    catch (\Throwable) {
+      // A non-JavaScript driver or an unstarted session has no buffer to read.
+    }
+
+    return array_values(array_unique($messages));
+  }
+
+  /**
+   * Return the command that re-runs just the failing scenario.
+   *
+   * @return string|null
+   *   The re-run command, or NULL when the scenario coordinates are unknown.
+   */
+  protected function diagnosticsGetRerunCommand(): ?string {
+    if ($this->diagnosticsFeatureFile === NULL || $this->diagnosticsScenarioLine === NULL) {
+      return NULL;
+    }
+
+    return sprintf('%s %s:%d', $this->diagnosticsRerunBinary(), $this->diagnosticsRelativePath($this->diagnosticsFeatureFile), $this->diagnosticsScenarioLine);
+  }
+
+  /**
+   * Shorten a path to be relative to the working directory when possible.
+   *
+   * @param string $path
+   *   Absolute path to shorten.
+   *
+   * @return string
+   *   The path relative to the working directory, or the input unchanged when
+   *   it does not sit under it.
+   */
+  protected function diagnosticsRelativePath(string $path): string {
+    $cwd = getcwd();
+
+    if ($cwd !== FALSE && str_starts_with($path, $cwd . DIRECTORY_SEPARATOR)) {
+      return substr($path, strlen($cwd) + 1);
+    }
+
+    return $path;
+  }
+
+  /**
+   * Return the header line that precedes the diagnostics block.
+   */
+  protected function diagnosticsHeader(): string {
+    return '--- Failure diagnostics ---';
+  }
+
+  /**
+   * Return the binary used in the re-run command. Override to customise.
+   */
+  protected function diagnosticsRerunBinary(): string {
+    return 'vendor/bin/behat';
+  }
+
+  /**
+   * Return TRUE to include the current URL. Override to suppress.
+   */
+  protected function diagnosticsShowUrl(): bool {
+    return TRUE;
+  }
+
+  /**
+   * Return TRUE to include the HTTP status code. Override to suppress.
+   */
+  protected function diagnosticsShowStatusCode(): bool {
+    return TRUE;
+  }
+
+  /**
+   * Return TRUE to include the Mink driver class. Override to suppress.
+   */
+  protected function diagnosticsShowDriver(): bool {
+    return TRUE;
+  }
+
+  /**
+   * Return TRUE to include JavaScript console errors. Override to suppress.
+   */
+  protected function diagnosticsShowJsErrors(): bool {
+    return TRUE;
+  }
+
+  /**
+   * Return TRUE to include the re-run command. Override to suppress.
+   */
+  protected function diagnosticsShowRerun(): bool {
+    return TRUE;
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -13,6 +13,7 @@ use DrevOps\BehatSteps\AccessibilityTrait;
 use DrevOps\BehatSteps\CommandTrait;
 use DrevOps\BehatSteps\CookieTrait;
 use DrevOps\BehatSteps\DateTrait;
+use DrevOps\BehatSteps\DiagnosticsTrait;
 use DrevOps\BehatSteps\Drupal\BigPipeTrait;
 use DrevOps\BehatSteps\Drupal\BlockTrait;
 use DrevOps\BehatSteps\Drupal\CacheTrait;
@@ -74,6 +75,7 @@ class FeatureContext extends DrupalContext {
   use ContentTrait;
   use CookieTrait;
   use DateTrait;
+  use DiagnosticsTrait;
   use DraggableviewsTrait;
   use DropzoneTrait;
   use EckTrait;

--- a/tests/behat/features/diagnostics.feature
+++ b/tests/behat/features/diagnostics.feature
@@ -1,0 +1,53 @@
+Feature: Check that DiagnosticsTrait works
+  As Behat Steps library developer
+  I want on-failure diagnostics appended to the failed step message
+  So that a red CI run is self-explanatory without a re-run
+
+  @trait:DiagnosticsTrait
+  Scenario: Diagnostics are appended to the message of a failed step
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      Then I should see "TextThatIsDefinitelyNotOnThisPage"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with:
+      """
+      --- Failure diagnostics ---
+      """
+    And the output should contain:
+      """
+      URL: http
+      """
+    And the output should contain:
+      """
+      HTTP status:
+      """
+    And the output should contain:
+      """
+      Mink driver:
+      """
+    And the output should contain:
+      """
+      Re-run: vendor/bin/behat
+      """
+    And the output should contain:
+      """
+      stub.feature:
+      """
+
+  @trait:DiagnosticsTrait
+  Scenario: Diagnostics are suppressed for an opted-out scenario
+    Given some behat configuration
+    And scenario steps tagged with "@behat-steps-skip:DiagnosticsTrait":
+      """
+      Given I go to "/"
+      Then I should see "TextThatIsDefinitelyNotOnThisPage"
+      """
+    When I run "behat --no-colors"
+    Then it should fail
+    And the output should not contain:
+      """
+      --- Failure diagnostics ---
+      """

--- a/tests/phpunit/src/DiagnosticsTraitTest.php
+++ b/tests/phpunit/src/DiagnosticsTraitTest.php
@@ -26,7 +26,6 @@ class DiagnosticsTraitTest extends UnitTestCase {
     parent::setUp();
 
     $this->testObject = new DiagnosticsTraitTestImplementation();
-    $this->testObject->session = new DiagnosticsFakeSession();
     $this->testObject->setRerunCoordinates('/app/tests/behat/features/example.feature', 12);
   }
 
@@ -52,7 +51,7 @@ class DiagnosticsTraitTest extends UnitTestCase {
     $block = $this->testObject->buildBlock();
 
     $this->assertStringNotContainsString($absent_label, $block);
-    // The block itself is still produced from the remaining fields.
+    // The block is still produced from the remaining fields.
     $this->assertStringContainsString('--- Failure diagnostics ---', $block);
   }
 
@@ -66,27 +65,37 @@ class DiagnosticsTraitTest extends UnitTestCase {
     ];
   }
 
-  #[DataProvider('dataProviderUnavailableFieldIsOmitted')]
-  public function testUnavailableFieldIsOmitted(string $property, mixed $value, string $absent_label): void {
-    $this->testObject->session->{$property} = $value;
+  public function testBlankUrlIsOmitted(): void {
+    $this->testObject->session->url = '';
 
-    $block = $this->testObject->buildBlock();
-
-    $this->assertStringNotContainsString($absent_label, $block);
+    $this->assertStringNotContainsString('URL:', $this->testObject->buildBlock());
   }
 
-  public static function dataProviderUnavailableFieldIsOmitted(): array {
-    return [
-      'blank url' => ['url', '', 'URL:'],
-      'url driver error' => ['url', new \RuntimeException('unsupported'), 'URL:'],
-      'status driver error' => ['status', new \RuntimeException('unsupported'), 'HTTP status:'],
-      'driver error' => ['driver', new \RuntimeException('unsupported'), 'Mink driver:'],
-      'no js errors' => ['script', [], 'JS console errors:'],
-    ];
+  public function testUrlIsOmittedWhenDriverErrors(): void {
+    $this->testObject->session->urlError = new \RuntimeException('unsupported');
+
+    $this->assertStringNotContainsString('URL:', $this->testObject->buildBlock());
+  }
+
+  public function testStatusIsOmittedWhenDriverErrors(): void {
+    $this->testObject->session->statusError = new \RuntimeException('unsupported');
+
+    $this->assertStringNotContainsString('HTTP status:', $this->testObject->buildBlock());
+  }
+
+  public function testDriverIsOmittedWhenDriverErrors(): void {
+    $this->testObject->session->driverError = new \RuntimeException('unsupported');
+
+    $this->assertStringNotContainsString('Mink driver:', $this->testObject->buildBlock());
+  }
+
+  public function testJsErrorsAreOmittedWhenNoneCaptured(): void {
+    // The default session carries an empty buffer and there is no registry.
+    $this->assertStringNotContainsString('JS console errors:', $this->testObject->buildBlock());
   }
 
   public function testBuildBlockIsEmptyWhenNothingIsAvailable(): void {
-    $this->testObject->session = NULL;
+    $this->testObject->sessionAvailable = FALSE;
     $this->testObject->setRerunCoordinates(NULL, NULL);
 
     $this->assertSame('', $this->testObject->buildBlock());
@@ -103,7 +112,7 @@ class DiagnosticsTraitTest extends UnitTestCase {
   }
 
   public function testAppendLeavesMessageUnchangedWhenBlockIsEmpty(): void {
-    $this->testObject->session = NULL;
+    $this->testObject->sessionAvailable = FALSE;
     $this->testObject->setRerunCoordinates(NULL, NULL);
     $exception = new \Exception('Original failure.');
 
@@ -112,41 +121,40 @@ class DiagnosticsTraitTest extends UnitTestCase {
     $this->assertSame('Original failure.', $exception->getMessage());
   }
 
-  #[DataProvider('dataProviderGetUrl')]
-  public function testGetUrl(mixed $value, ?string $expected): void {
-    $this->testObject->session->url = $value;
-
-    $this->assertSame($expected, $this->testObject->getUrl());
+  public function testGetUrlReturnsValue(): void {
+    $this->assertSame('http://example.com/page', $this->testObject->getUrl());
   }
 
-  public static function dataProviderGetUrl(): array {
-    return [
-      'value' => ['http://example.com/page', 'http://example.com/page'],
-      'blank returns null' => ['', NULL],
-      'driver error returns null' => [new \RuntimeException('unsupported'), NULL],
-    ];
+  public function testGetUrlReturnsNullWhenBlank(): void {
+    $this->testObject->session->url = '';
+
+    $this->assertNull($this->testObject->getUrl());
   }
 
-  #[DataProvider('dataProviderGetStatusCode')]
-  public function testGetStatusCode(mixed $value, ?int $expected): void {
-    $this->testObject->session->status = $value;
+  public function testGetUrlReturnsNullWhenDriverErrors(): void {
+    $this->testObject->session->urlError = new \RuntimeException('unsupported');
 
-    $this->assertSame($expected, $this->testObject->getStatusCode());
+    $this->assertNull($this->testObject->getUrl());
   }
 
-  public static function dataProviderGetStatusCode(): array {
-    return [
-      'value' => [500, 500],
-      'driver error returns null' => [new \RuntimeException('unsupported'), NULL],
-    ];
+  public function testGetStatusCodeReturnsValue(): void {
+    $this->testObject->session->status = 500;
+
+    $this->assertSame(500, $this->testObject->getStatusCode());
+  }
+
+  public function testGetStatusCodeReturnsNullWhenDriverErrors(): void {
+    $this->testObject->session->statusError = new \RuntimeException('unsupported');
+
+    $this->assertNull($this->testObject->getStatusCode());
   }
 
   public function testGetDriverNameReturnsClass(): void {
     $this->assertSame(DiagnosticsFakeDriver::class, $this->testObject->getDriverName());
   }
 
-  public function testGetDriverNameReturnsNullOnError(): void {
-    $this->testObject->session->driver = new \RuntimeException('unsupported');
+  public function testGetDriverNameReturnsNullWhenDriverErrors(): void {
+    $this->testObject->session->driverError = new \RuntimeException('unsupported');
 
     $this->assertNull($this->testObject->getDriverName());
   }
@@ -161,9 +169,8 @@ class DiagnosticsTraitTest extends UnitTestCase {
     $this->assertSame(['TypeError: a', 'ReferenceError: b'], $this->testObject->getJsErrors());
   }
 
-  public function testGetJsErrorsReadsJavascriptTraitRegistryAndDeduplicates(): void {
+  public function testGetJsErrorsReadsRegistryAndDeduplicates(): void {
     $object = new DiagnosticsTraitJsRegistryImplementation();
-    $object->session = new DiagnosticsFakeSession();
     $object->javascriptErrorRegistry = [
       'http://example.com/a' => [['message' => 'TypeError: a'], ['no-message' => 'skip']],
       'http://example.com/b' => 'not-an-array',
@@ -175,7 +182,7 @@ class DiagnosticsTraitTest extends UnitTestCase {
   }
 
   public function testGetJsErrorsIsEmptyWhenUnavailable(): void {
-    $this->testObject->session->script = new \RuntimeException('unsupported');
+    $this->testObject->session->scriptError = new \RuntimeException('unsupported');
 
     $this->assertSame([], $this->testObject->getJsErrors());
   }
@@ -213,9 +220,14 @@ class DiagnosticsTraitTestImplementation {
   use DiagnosticsTrait;
 
   /**
-   * The fake session returned by getSession(), or NULL to simulate its absence.
+   * The fake session returned by getSession().
    */
-  public ?DiagnosticsFakeSession $session = NULL;
+  public DiagnosticsFakeSession $session;
+
+  /**
+   * Whether getSession() yields the session or throws to simulate its absence.
+   */
+  public bool $sessionAvailable = TRUE;
 
   /**
    * Per-field toggle state, keyed to match the diagnosticsShow*() overrides.
@@ -230,8 +242,12 @@ class DiagnosticsTraitTestImplementation {
     'rerun' => TRUE,
   ];
 
+  public function __construct() {
+    $this->session = new DiagnosticsFakeSession();
+  }
+
   public function getSession(): DiagnosticsFakeSession {
-    if (!$this->session instanceof DiagnosticsFakeSession) {
+    if (!$this->sessionAvailable) {
       throw new \RuntimeException('Session is not available.');
     }
 
@@ -263,6 +279,10 @@ class DiagnosticsTraitTestImplementation {
     return $this->diagnosticsGetDriverName();
   }
 
+  /**
+   * @return array<int, string>
+   *   Collected JavaScript error messages.
+   */
   public function getJsErrors(): array {
     return $this->diagnosticsGetJsErrors();
   }
@@ -310,45 +330,66 @@ class DiagnosticsTraitJsRegistryImplementation extends DiagnosticsTraitTestImple
 /**
  * A minimal fake Mink session whose accessors return values or throw.
  *
- * Any property assigned a Throwable is thrown when its accessor is called,
- * exercising the trait's graceful-degradation paths.
+ * Assigning a Throwable to one of the *Error properties makes the matching
+ * accessor throw, exercising the trait's graceful-degradation paths.
  */
 class DiagnosticsFakeSession {
 
-  public mixed $url = 'http://example.com/page';
+  public string $url = 'http://example.com/page';
 
-  public mixed $status = 200;
+  public int $status = 200;
 
-  public mixed $driver;
+  public object $driver;
 
-  public mixed $script = [];
+  /**
+   * The live browser error buffer returned by evaluateScript().
+   *
+   * @var array<int, mixed>
+   */
+  public array $script = [];
+
+  public ?\Throwable $urlError = NULL;
+
+  public ?\Throwable $statusError = NULL;
+
+  public ?\Throwable $driverError = NULL;
+
+  public ?\Throwable $scriptError = NULL;
 
   public function __construct() {
     $this->driver = new DiagnosticsFakeDriver();
   }
 
   public function getCurrentUrl(): string {
-    return $this->resolve($this->url);
+    if ($this->urlError instanceof \Throwable) {
+      throw $this->urlError;
+    }
+
+    return $this->url;
   }
 
   public function getStatusCode(): int {
-    return $this->resolve($this->status);
+    if ($this->statusError instanceof \Throwable) {
+      throw $this->statusError;
+    }
+
+    return $this->status;
   }
 
   public function getDriver(): object {
-    return $this->resolve($this->driver);
+    if ($this->driverError instanceof \Throwable) {
+      throw $this->driverError;
+    }
+
+    return $this->driver;
   }
 
   public function evaluateScript(string $script): mixed {
-    return $this->resolve($this->script);
-  }
-
-  protected function resolve(mixed $value): mixed {
-    if ($value instanceof \Throwable) {
-      throw $value;
+    if ($this->scriptError instanceof \Throwable) {
+      throw $this->scriptError;
     }
 
-    return $value;
+    return $this->script;
   }
 
 }

--- a/tests/phpunit/src/DiagnosticsTraitTest.php
+++ b/tests/phpunit/src/DiagnosticsTraitTest.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests;
+
+use DrevOps\BehatSteps\DiagnosticsTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for DiagnosticsTrait.
+ */
+#[CoversClass(DiagnosticsTrait::class)]
+class DiagnosticsTraitTest extends UnitTestCase {
+
+  /**
+   * A test implementation of DiagnosticsTrait.
+   */
+  protected DiagnosticsTraitTestImplementation $testObject;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->testObject = new DiagnosticsTraitTestImplementation();
+    $this->testObject->session = new DiagnosticsFakeSession();
+    $this->testObject->setRerunCoordinates('/app/tests/behat/features/example.feature', 12);
+  }
+
+  public function testBuildBlockRendersEveryEnabledField(): void {
+    $this->testObject->session->script = [['message' => 'ReferenceError: x is not defined']];
+
+    $block = $this->testObject->buildBlock();
+
+    $this->assertStringContainsString('--- Failure diagnostics ---', $block);
+    $this->assertStringContainsString('URL: http://example.com/page', $block);
+    $this->assertStringContainsString('HTTP status: 200', $block);
+    $this->assertStringContainsString('Mink driver: ' . DiagnosticsFakeDriver::class, $block);
+    $this->assertStringContainsString('JS console errors: ReferenceError: x is not defined', $block);
+    $this->assertStringContainsString('Re-run: vendor/bin/behat', $block);
+    $this->assertStringContainsString('example.feature:12', $block);
+  }
+
+  #[DataProvider('dataProviderDisabledFieldIsOmitted')]
+  public function testDisabledFieldIsOmitted(string $toggle, string $absent_label): void {
+    $this->testObject->session->script = [['message' => 'ReferenceError: x is not defined']];
+    $this->testObject->show[$toggle] = FALSE;
+
+    $block = $this->testObject->buildBlock();
+
+    $this->assertStringNotContainsString($absent_label, $block);
+    // The block itself is still produced from the remaining fields.
+    $this->assertStringContainsString('--- Failure diagnostics ---', $block);
+  }
+
+  public static function dataProviderDisabledFieldIsOmitted(): array {
+    return [
+      'url off' => ['url', 'URL:'],
+      'status off' => ['status', 'HTTP status:'],
+      'driver off' => ['driver', 'Mink driver:'],
+      'js errors off' => ['js', 'JS console errors:'],
+      'rerun off' => ['rerun', 'Re-run:'],
+    ];
+  }
+
+  #[DataProvider('dataProviderUnavailableFieldIsOmitted')]
+  public function testUnavailableFieldIsOmitted(string $property, mixed $value, string $absent_label): void {
+    $this->testObject->session->{$property} = $value;
+
+    $block = $this->testObject->buildBlock();
+
+    $this->assertStringNotContainsString($absent_label, $block);
+  }
+
+  public static function dataProviderUnavailableFieldIsOmitted(): array {
+    return [
+      'blank url' => ['url', '', 'URL:'],
+      'url driver error' => ['url', new \RuntimeException('unsupported'), 'URL:'],
+      'status driver error' => ['status', new \RuntimeException('unsupported'), 'HTTP status:'],
+      'driver error' => ['driver', new \RuntimeException('unsupported'), 'Mink driver:'],
+      'no js errors' => ['script', [], 'JS console errors:'],
+    ];
+  }
+
+  public function testBuildBlockIsEmptyWhenNothingIsAvailable(): void {
+    $this->testObject->session = NULL;
+    $this->testObject->setRerunCoordinates(NULL, NULL);
+
+    $this->assertSame('', $this->testObject->buildBlock());
+  }
+
+  public function testAppendAddsBlockToExceptionMessage(): void {
+    $exception = new \Exception('Original failure.');
+
+    $this->testObject->appendTo($exception);
+
+    $this->assertStringContainsString('Original failure.', $exception->getMessage());
+    $this->assertStringContainsString('--- Failure diagnostics ---', $exception->getMessage());
+    $this->assertStringContainsString('URL: http://example.com/page', $exception->getMessage());
+  }
+
+  public function testAppendLeavesMessageUnchangedWhenBlockIsEmpty(): void {
+    $this->testObject->session = NULL;
+    $this->testObject->setRerunCoordinates(NULL, NULL);
+    $exception = new \Exception('Original failure.');
+
+    $this->testObject->appendTo($exception);
+
+    $this->assertSame('Original failure.', $exception->getMessage());
+  }
+
+  #[DataProvider('dataProviderGetUrl')]
+  public function testGetUrl(mixed $value, ?string $expected): void {
+    $this->testObject->session->url = $value;
+
+    $this->assertSame($expected, $this->testObject->getUrl());
+  }
+
+  public static function dataProviderGetUrl(): array {
+    return [
+      'value' => ['http://example.com/page', 'http://example.com/page'],
+      'blank returns null' => ['', NULL],
+      'driver error returns null' => [new \RuntimeException('unsupported'), NULL],
+    ];
+  }
+
+  #[DataProvider('dataProviderGetStatusCode')]
+  public function testGetStatusCode(mixed $value, ?int $expected): void {
+    $this->testObject->session->status = $value;
+
+    $this->assertSame($expected, $this->testObject->getStatusCode());
+  }
+
+  public static function dataProviderGetStatusCode(): array {
+    return [
+      'value' => [500, 500],
+      'driver error returns null' => [new \RuntimeException('unsupported'), NULL],
+    ];
+  }
+
+  public function testGetDriverNameReturnsClass(): void {
+    $this->assertSame(DiagnosticsFakeDriver::class, $this->testObject->getDriverName());
+  }
+
+  public function testGetDriverNameReturnsNullOnError(): void {
+    $this->testObject->session->driver = new \RuntimeException('unsupported');
+
+    $this->assertNull($this->testObject->getDriverName());
+  }
+
+  public function testGetJsErrorsReadsLiveBrowserBuffer(): void {
+    $this->testObject->session->script = [
+      ['message' => 'TypeError: a'],
+      ['message' => 'ReferenceError: b'],
+      ['not-a-message' => 'ignored'],
+    ];
+
+    $this->assertSame(['TypeError: a', 'ReferenceError: b'], $this->testObject->getJsErrors());
+  }
+
+  public function testGetJsErrorsReadsJavascriptTraitRegistryAndDeduplicates(): void {
+    $object = new DiagnosticsTraitJsRegistryImplementation();
+    $object->session = new DiagnosticsFakeSession();
+    $object->javascriptErrorRegistry = [
+      'http://example.com/a' => [['message' => 'TypeError: a'], ['no-message' => 'skip']],
+      'http://example.com/b' => 'not-an-array',
+    ];
+    // The same message arrives from the live buffer and is de-duplicated.
+    $object->session->script = [['message' => 'TypeError: a'], ['message' => 'ReferenceError: b']];
+
+    $this->assertSame(['TypeError: a', 'ReferenceError: b'], $object->getJsErrors());
+  }
+
+  public function testGetJsErrorsIsEmptyWhenUnavailable(): void {
+    $this->testObject->session->script = new \RuntimeException('unsupported');
+
+    $this->assertSame([], $this->testObject->getJsErrors());
+  }
+
+  #[DataProvider('dataProviderRerunCommand')]
+  public function testRerunCommand(?string $file, ?int $line, ?string $expected): void {
+    $this->testObject->setRerunCoordinates($file, $line);
+
+    $this->assertSame($expected, $this->testObject->rerunCommand());
+  }
+
+  public static function dataProviderRerunCommand(): array {
+    return [
+      'absolute path outside cwd kept as-is' => ['/elsewhere/features/x.feature', 7, 'vendor/bin/behat /elsewhere/features/x.feature:7'],
+      'missing file returns null' => [NULL, 7, NULL],
+      'missing line returns null' => ['/elsewhere/features/x.feature', NULL, NULL],
+    ];
+  }
+
+  public function testRerunCommandShortensPathUnderWorkingDirectory(): void {
+    $cwd = getcwd();
+    $this->assertNotFalse($cwd);
+    $this->testObject->setRerunCoordinates($cwd . '/features/x.feature', 7);
+
+    $this->assertSame('vendor/bin/behat features/x.feature:7', $this->testObject->rerunCommand());
+  }
+
+}
+
+/**
+ * Test implementation of DiagnosticsTrait.
+ */
+class DiagnosticsTraitTestImplementation {
+
+  use DiagnosticsTrait;
+
+  /**
+   * The fake session returned by getSession(), or NULL to simulate its absence.
+   */
+  public ?DiagnosticsFakeSession $session = NULL;
+
+  /**
+   * Per-field toggle state, keyed to match the diagnosticsShow*() overrides.
+   *
+   * @var array<string, bool>
+   */
+  public array $show = [
+    'url' => TRUE,
+    'status' => TRUE,
+    'driver' => TRUE,
+    'js' => TRUE,
+    'rerun' => TRUE,
+  ];
+
+  public function getSession(): DiagnosticsFakeSession {
+    if (!$this->session instanceof DiagnosticsFakeSession) {
+      throw new \RuntimeException('Session is not available.');
+    }
+
+    return $this->session;
+  }
+
+  public function setRerunCoordinates(?string $file, ?int $line): void {
+    $this->diagnosticsFeatureFile = $file;
+    $this->diagnosticsScenarioLine = $line;
+  }
+
+  public function buildBlock(): string {
+    return $this->diagnosticsBuildBlock();
+  }
+
+  public function appendTo(\Exception $exception): void {
+    $this->diagnosticsAppendToException($exception);
+  }
+
+  public function getUrl(): ?string {
+    return $this->diagnosticsGetUrl();
+  }
+
+  public function getStatusCode(): ?int {
+    return $this->diagnosticsGetStatusCode();
+  }
+
+  public function getDriverName(): ?string {
+    return $this->diagnosticsGetDriverName();
+  }
+
+  public function getJsErrors(): array {
+    return $this->diagnosticsGetJsErrors();
+  }
+
+  public function rerunCommand(): ?string {
+    return $this->diagnosticsGetRerunCommand();
+  }
+
+  protected function diagnosticsShowUrl(): bool {
+    return $this->show['url'];
+  }
+
+  protected function diagnosticsShowStatusCode(): bool {
+    return $this->show['status'];
+  }
+
+  protected function diagnosticsShowDriver(): bool {
+    return $this->show['driver'];
+  }
+
+  protected function diagnosticsShowJsErrors(): bool {
+    return $this->show['js'];
+  }
+
+  protected function diagnosticsShowRerun(): bool {
+    return $this->show['rerun'];
+  }
+
+}
+
+/**
+ * Test implementation that also exposes a JavascriptTrait-style registry.
+ */
+class DiagnosticsTraitJsRegistryImplementation extends DiagnosticsTraitTestImplementation {
+
+  /**
+   * Mimics the registry property maintained by JavascriptTrait.
+   *
+   * @var array<string, mixed>
+   */
+  public array $javascriptErrorRegistry = [];
+
+}
+
+/**
+ * A minimal fake Mink session whose accessors return values or throw.
+ *
+ * Any property assigned a Throwable is thrown when its accessor is called,
+ * exercising the trait's graceful-degradation paths.
+ */
+class DiagnosticsFakeSession {
+
+  public mixed $url = 'http://example.com/page';
+
+  public mixed $status = 200;
+
+  public mixed $driver;
+
+  public mixed $script = [];
+
+  public function __construct() {
+    $this->driver = new DiagnosticsFakeDriver();
+  }
+
+  public function getCurrentUrl(): string {
+    return $this->resolve($this->url);
+  }
+
+  public function getStatusCode(): int {
+    return $this->resolve($this->status);
+  }
+
+  public function getDriver(): object {
+    return $this->resolve($this->driver);
+  }
+
+  public function evaluateScript(string $script): mixed {
+    return $this->resolve($this->script);
+  }
+
+  protected function resolve(mixed $value): mixed {
+    if ($value instanceof \Throwable) {
+      throw $value;
+    }
+
+    return $value;
+  }
+
+}
+
+/**
+ * A stand-in driver used only for its class name.
+ */
+class DiagnosticsFakeDriver {
+
+}

--- a/tests/phpunit/src/DiagnosticsTraitTest.php
+++ b/tests/phpunit/src/DiagnosticsTraitTest.php
@@ -280,6 +280,8 @@ class DiagnosticsTraitTestImplementation {
   }
 
   /**
+   * Expose the collected JavaScript console error messages.
+   *
    * @return array<int, string>
    *   Collected JavaScript error messages.
    */
@@ -335,10 +337,19 @@ class DiagnosticsTraitJsRegistryImplementation extends DiagnosticsTraitTestImple
  */
 class DiagnosticsFakeSession {
 
+  /**
+   * The current page URL returned by getCurrentUrl().
+   */
   public string $url = 'http://example.com/page';
 
+  /**
+   * The response status code returned by getStatusCode().
+   */
   public int $status = 200;
 
+  /**
+   * The driver instance returned by getDriver().
+   */
   public object $driver;
 
   /**
@@ -348,12 +359,24 @@ class DiagnosticsFakeSession {
    */
   public array $script = [];
 
+  /**
+   * When set, getCurrentUrl() throws this instead of returning a value.
+   */
   public ?\Throwable $urlError = NULL;
 
+  /**
+   * When set, getStatusCode() throws this instead of returning a value.
+   */
   public ?\Throwable $statusError = NULL;
 
+  /**
+   * When set, getDriver() throws this instead of returning a value.
+   */
   public ?\Throwable $driverError = NULL;
 
+  /**
+   * When set, evaluateScript() throws this instead of returning a value.
+   */
   public ?\Throwable $scriptError = NULL;
 
   public function __construct() {


### PR DESCRIPTION
Closes #671

## Summary

Adds `DiagnosticsTrait`, an opt-in Behat trait that appends a compact diagnostics block to the failure message of any failed step via an `@AfterStep` hook, so a red CI run is self-explanatory without needing a re-run first. The block includes the current URL, HTTP status code, active Mink driver class, captured JavaScript console errors, and a ready-to-paste re-run command. Each field can be individually suppressed by overriding a `diagnosticsShow*()` method, and every value source degrades gracefully on failure so the trait itself never turns a failed step into a different failure. The trait is wired into the test `FeatureContext` and documented in `STEPS.md`/`README.md`.

## Changes

- Added `src/DiagnosticsTrait.php`: an `@AfterStep` hook detects a failed step via `ExceptionResult`, builds the diagnostics block (URL, HTTP status, Mink driver, JS console errors, re-run command), and appends it to the exception message in place via reflection.
- A `@BeforeScenario` hook resolves the `@behat-steps-skip:DiagnosticsTrait` opt-out (feature or scenario tag) and captures the feature file and scenario line used to build the re-run command.
- JS console errors are merged from two sources: the registry maintained by `JavascriptTrait` when the context also uses it (detected at runtime, no hard dependency), and the live browser buffer read via `evaluateScript()`.
- Added `tests/behat/features/diagnostics.feature`: BehatCli sub-context scenarios asserting the diagnostics block appears on a failed step and is suppressed when the skip tag is present.
- Added `tests/phpunit/src/DiagnosticsTraitTest.php`: unit tests covering block rendering, per-field toggles, graceful degradation when the Mink session throws, JS error merging/deduplication, and re-run command path shortening.
- Wired `DiagnosticsTrait` into `tests/behat/bootstrap/FeatureContext.php`.
- Regenerated `STEPS.md` and `README.md` with the new trait's entry.

## Before / After

```
Before                                   After
──────────────────────────────────       ──────────────────────────────────────────────────
Step failed:                             Step failed:
  Then I should see "..."                  Then I should see "..."
  Text "..." not found.                    Text "..." not found.

                                          --- Failure diagnostics ---
                                          URL: http://example.com/some-page
                                          HTTP status: 200
                                          Mink driver: Behat\Mink\Driver\BrowserKitDriver
                                          JS console errors: ReferenceError: x is not defined
                                          Re-run: vendor/bin/behat features/example.feature:3
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added an opt-in `DiagnosticsTrait` for Behat that appends a compact failure diagnostics block only when a step fails. The block can include the current URL, HTTP status, Mink driver class, JS console errors, and a rerun command, with each field individually toggleable and all collection handled defensively.

Also:
- Wired the trait into `FeatureContext`
- Added Behat coverage for failure output and scenario opt-out
- Added PHPUnit coverage for diagnostics formatting and helper behavior
- Updated `README.md` and `STEPS.md` to document the new trait and steps

No CONTRIBUTING.md step-format violations were evident from the provided changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->