### PR TITLE
[#672] Added index-based element interaction and count steps to 'ElementTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -626,6 +626,48 @@ When I click on the element ".button"
 </details>
 
 <details>
+  <summary><code>@When I click on the element :selector with the index :index</code></summary>
+
+<br/>
+Click on the element at the 1-based index among all selector matches
+<br/><br/>
+
+```gherkin
+When I click on the element ".card" with the index 2
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I follow the link :text with the index :index</code></summary>
+
+<br/>
+Follow the link at the 1-based index among all links with the text
+<br/><br/>
+
+```gherkin
+When I follow the link "Read more" with the index 2
+
+```
+
+</details>
+
+<details>
+  <summary><code>@When I press the button :label with the index :index</code></summary>
+
+<br/>
+Press the button at the 1-based index among all buttons with the label
+<br/><br/>
+
+```gherkin
+When I press the button "Delete" with the index 2
+
+```
+
+</details>
+
+<details>
   <summary><code>@When I trigger the JS event :event on the element :selector</code></summary>
 
 <br/>
@@ -930,6 +972,20 @@ Assert that element with specified CSS is visually hidden on page
 
 ```gherkin
 Then the element ".visually-hidden" should not be displayed within a viewport
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :parent should contain :count element(s) matching :selector</code></summary>
+
+<br/>
+Assert the number of elements matching a selector within a parent element
+<br/><br/>
+
+```gherkin
+Then the element "#main-nav" should contain 3 element(s) matching ".menu-item"
 
 ```
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -985,7 +985,7 @@ Assert the number of elements matching a selector within a parent element
 <br/><br/>
 
 ```gherkin
-Then the element "#main-nav" should contain 3 element(s) matching ".menu-item"
+Then the element "#main-nav" should contain 3 elements matching ".menu-item"
 
 ```
 

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -7,6 +7,7 @@ namespace DrevOps\BehatSteps;
 use Behat\Step\Then;
 use Behat\Step\Given;
 use Behat\Step\When;
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 
@@ -303,6 +304,51 @@ trait ElementTrait {
     }
 
     $element->click();
+  }
+
+  /**
+   * Click on the element at the 1-based index among all selector matches.
+   *
+   * Useful when a selector matches several repeated components (cards, rows,
+   * menu items) and only the Nth one should be clicked.
+   *
+   * @code
+   * When I click on the element ".card" with the index 2
+   * @endcode
+   *
+   *
+   * @javascript
+   */
+  #[When('I click on the element :selector with the index :index')]
+  public function elementClickByIndex(string $selector, int $index): void {
+    $elements = $this->getSession()->getPage()->findAll('css', $selector);
+    $this->elementFindNthOrFail($elements, $index, sprintf('element matching "%s"', $selector))->click();
+  }
+
+  /**
+   * Follow the link at the 1-based index among all links with the text.
+   *
+   * @code
+   * When I follow the link "Read more" with the index 2
+   * @endcode
+   */
+  #[When('I follow the link :text with the index :index')]
+  public function elementFollowLinkByIndex(string $text, int $index): void {
+    $elements = $this->getSession()->getPage()->findAll('named', ['link', $text]);
+    $this->elementFindNthOrFail($elements, $index, sprintf('link "%s"', $text))->click();
+  }
+
+  /**
+   * Press the button at the 1-based index among all buttons with the label.
+   *
+   * @code
+   * When I press the button "Delete" with the index 2
+   * @endcode
+   */
+  #[When('I press the button :label with the index :index')]
+  public function elementPressButtonByIndex(string $label, int $index): void {
+    $elements = $this->getSession()->getPage()->findAll('named', ['button', $label]);
+    $this->elementFindNthOrFail($elements, $index, sprintf('button "%s"', $label))->press();
   }
 
   /**
@@ -641,6 +687,28 @@ JS;
   }
 
   /**
+   * Assert the number of elements matching a selector within a parent element.
+   *
+   * @code
+   * Then the element "#main-nav" should contain 3 elements matching ".menu-item"
+   * @endcode
+   */
+  #[Then('the element :parent should contain :count element(s) matching :selector')]
+  public function elementAssertChildElementCount(string $parent, int $count, string $selector): void {
+    $parent_element = $this->getSession()->getPage()->find('css', $parent);
+
+    if (!$parent_element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $parent);
+    }
+
+    $actual = count($parent_element->findAll('css', $selector));
+
+    if ($actual !== $count) {
+      throw new ExpectationException(sprintf('Expected the element "%s" to contain %d element(s) matching "%s", but found %d.', $parent, $count, $selector, $actual), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
    * Assert that an element is displayed within a viewport using different FE techniques.
    *
    * @param string $selector
@@ -702,6 +770,41 @@ JS;
     JS;
 
     return $this->getSession()->evaluateScript($script);
+  }
+
+  /**
+   * Return the element at a 1-based index or throw a clear error.
+   *
+   * @param \Behat\Mink\Element\NodeElement[] $elements
+   *   The matched elements, in document order.
+   * @param int $index
+   *   The 1-based index of the element to return.
+   * @param string $subject
+   *   Human-readable description of what was searched for (for example,
+   *   'link "Read more"'), used to build the error messages.
+   *
+   * @return \Behat\Mink\Element\NodeElement
+   *   The element at the requested index.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   *   When no elements matched.
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   When the index is below 1 or beyond the number of matches.
+   */
+  protected function elementFindNthOrFail(array $elements, int $index, string $subject): NodeElement {
+    if ($index < 1) {
+      throw new ExpectationException(sprintf('The index must be 1 or greater, but "%d" was given.', $index), $this->getSession()->getDriver());
+    }
+
+    if ($elements === []) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), $subject);
+    }
+
+    if ($index > count($elements)) {
+      throw new ExpectationException(sprintf('Cannot use the %s at index %d: only %d found.', $subject, $index, count($elements)), $this->getSession()->getDriver());
+    }
+
+    return $elements[$index - 1];
   }
 
   /**

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -769,13 +769,11 @@ Feature: Check that ElementTrait works
     When I press the button "Repeated action" with the index 3
     Then I should see "Clicked 3"
 
-  @api
   Scenario: Assert "When I follow the link :text with the index :index" follows the Nth match
     When I visit "/sites/default/files/elements.html"
     And I follow the link "Repeated link" with the index 2
     Then I should see "Link Testing Fixture"
 
-  @api
   Scenario: Assert "Then the element :parent should contain :count element(s) matching :selector" counts matches within a parent
     When I visit "/sites/default/files/elements.html"
     Then the element "#nth-parent" should contain 3 elements matching ".nth-child"

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -756,3 +756,96 @@ Feature: Check that ElementTrait works
       """
       Element(s) defined by "#top" selector is displayed within a viewport, but should not be.
       """
+
+  @javascript @phpserver
+  Scenario: Assert "When I click on the element :selector with the index :index" clicks the Nth match
+    Given I am on the phpserver test page
+    When I click on the element ".nth-btn" with the index 2
+    Then I should see "Clicked 2"
+
+  @javascript @phpserver
+  Scenario: Assert "When I press the button :label with the index :index" presses the Nth match
+    Given I am on the phpserver test page
+    When I press the button "Repeated action" with the index 3
+    Then I should see "Clicked 3"
+
+  @api
+  Scenario: Assert "When I follow the link :text with the index :index" follows the Nth match
+    When I visit "/sites/default/files/elements.html"
+    And I follow the link "Repeated link" with the index 2
+    Then I should see "Link Testing Fixture"
+
+  @api
+  Scenario: Assert "Then the element :parent should contain :count element(s) matching :selector" counts matches within a parent
+    When I visit "/sites/default/files/elements.html"
+    Then the element "#nth-parent" should contain 3 elements matching ".nth-child"
+
+  @trait:ElementTrait
+  Scenario: Assert index-based interaction fails when the index is below 1
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I visit "/sites/default/files/elements.html"
+      When I click on the element ".nth-child" with the index 0
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The index must be 1 or greater, but "0" was given.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert index-based interaction fails when the index is out of range
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I visit "/sites/default/files/elements.html"
+      When I click on the element ".nth-child" with the index 99
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Cannot use the element matching ".nth-child" at index 99: only 3 found.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert index-based interaction fails when no element matches
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I visit "/sites/default/files/elements.html"
+      When I click on the element ".does-not-exist" with the index 1
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching ".does-not-exist" not found.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :parent should contain :count element(s) matching :selector" fails on a count mismatch
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I visit "/sites/default/files/elements.html"
+      Then the element "#nth-parent" should contain 5 elements matching ".nth-child"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected the element "#nth-parent" to contain 5 element(s) matching ".nth-child", but found 3.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :parent should contain :count element(s) matching :selector" fails when the parent is missing
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I visit "/sites/default/files/elements.html"
+      Then the element "#does-not-exist" should contain 1 element matching ".nth-child"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css "#does-not-exist" not found.
+      """

--- a/tests/behat/fixtures/elements.html
+++ b/tests/behat/fixtures/elements.html
@@ -66,6 +66,19 @@
     <a href="/path3">Link 3</a>
   </div>
 
+  <!-- Section: Repeated Elements (index-based interaction) -->
+  <div class="section">
+    <h2>Repeated Elements</h2>
+    <div id="nth-parent">
+      <span class="nth-child">Child one</span>
+      <span class="nth-child">Child two</span>
+      <span class="nth-child">Child three</span>
+    </div>
+    <p><a href="/sites/default/files/table.html" class="nth-link">Repeated link</a></p>
+    <p><a href="/sites/default/files/links.html" class="nth-link">Repeated link</a></p>
+    <p><a href="/sites/default/files/metatags.html" class="nth-link">Repeated link</a></p>
+  </div>
+
   <!-- Section: Focus Testing -->
   <div class="section">
     <h2>Focus Testing</h2>

--- a/tests/behat/fixtures/elements_relative.html
+++ b/tests/behat/fixtures/elements_relative.html
@@ -442,6 +442,13 @@ cp /app/tests/behat/fixtures/elements_relative.html /app/build/web/sites/default
 </button>
 <div id="overlay-off-canvas"></div>
 
+<div id="nth-container">
+  <button class="nth-btn" onclick="document.getElementById('nth-result').textContent = 'Clicked 1'">Repeated action</button>
+  <button class="nth-btn" onclick="document.getElementById('nth-result').textContent = 'Clicked 2'">Repeated action</button>
+  <button class="nth-btn" onclick="document.getElementById('nth-result').textContent = 'Clicked 3'">Repeated action</button>
+  <div id="nth-result"></div>
+</div>
+
 <div id="over-container">
   <div id="over-cover">
     Text COVER over


### PR DESCRIPTION
Closes #672

## Summary

Adds index-based (nth) element interaction steps to `ElementTrait` for cases where a selector, link text, or button label matches several repeated elements (cards, rows, menu items) and only one specific match needs to be acted on. Also adds a parent-scoped element count assertion, filling a gap since MinkContext only offers a page-wide element count rather than one scoped to a parent element.

## Changes

- Added `#[When('I click on the element :selector with the index :index')]` (`elementClickByIndex()`) to click the 1-based Nth element matching a CSS selector.
- Added `#[When('I follow the link :text with the index :index')]` (`elementFollowLinkByIndex()`) to follow the 1-based Nth link matching the given text.
- Added `#[When('I press the button :label with the index :index')]` (`elementPressButtonByIndex()`) to press the 1-based Nth button matching the given label.
- Added `#[Then('the element :parent should contain :count element(s) matching :selector')]` (`elementAssertChildElementCount()`) to assert how many descendants of a parent element match a selector.
- Added a shared protected helper `elementFindNthOrFail()` that resolves the Nth element from a match array and throws clear, distinct errors for an index below 1, no matches at all, and an index beyond the number of matches.
- Extended `tests/behat/fixtures/elements.html` and `tests/behat/fixtures/elements_relative.html` with repeated elements (a parent with three child spans, three duplicate links, and three duplicate buttons) to exercise the new steps.
- Extended `tests/behat/features/element.feature` with 4 positive scenarios and 5 negative scenarios (index below 1, index out of range, no match found, count mismatch, missing parent) covering the new steps.
- Regenerated `STEPS.md` to document the four new steps.

## Before / After

```
Before:
+------------------------------------------------------------+
| Selector matches multiple elements (e.g. ".card")          |
|                                                              |
|   I click on the element ".card"                            |
|        |                                                    |
|        v                                                    |
|   Ambiguous - always resolves to the first match only       |
|   No built-in way to target the 2nd, 3rd, ... match          |
|   No parent-scoped "should contain N elements" assertion     |
+------------------------------------------------------------+

After:
+------------------------------------------------------------+
| I click on the element ".card" with the index 2             |
| I follow the link "Read more" with the index 2              |
| I press the button "Delete" with the index 2                |
|        |                                                    |
|        v                                                    |
|   elementFindNthOrFail() resolves match #2 (1-based)         |
|        |                                                    |
|        +-- index < 1        -> ExpectationException         |
|        +-- no matches       -> ElementNotFoundException      |
|        +-- index > count    -> ExpectationException          |
|        +-- otherwise        -> element returned and acted on |
|                                                              |
| Then the element "#main-nav" should contain 3 element(s)     |
|   matching ".menu-item"                                      |
|        |                                                    |
|        v                                                    |
|   Parent-scoped count assertion (vs. page-wide MinkContext)  |
+------------------------------------------------------------+
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added index-based `ElementTrait` interactions for repeated elements: click the Nth CSS match, follow the Nth link by text, and press the Nth button by label, all using 1-based indexes with clear errors for index < 1, out-of-range, or no matching elements. Also added a parent-scoped assertion to verify an exact count of descendant elements matching a selector. Expanded Behat coverage with repeated-element fixtures (including positive and negative scenarios) and regenerated `STEPS.md` documentation for the new steps.

No step-definition format rule violations from `CONTRIBUTING.md` were identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->