### PR TITLE
[#677] Added shared entity registry with automatic scenario cleanup.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,22 @@
+# Migration guide
+
+## Unified entity cleanup
+
+Traits that create Drupal entities now register them in a single shared registry and delete them in reverse creation order through one `entityCleanupAfterScenario` hook, instead of each trait running its own after-scenario cleanup.
+
+The per-trait cleanup skip tags have been removed. Replace them as follows:
+
+| Removed tag                                    | Replacement                                                                                          |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `@behat-steps-skip:mediaAfterScenario`         | `@behat-steps-entity-cleanup-skip:media`                                                             |
+| `@behat-steps-skip:contentBlockAfterScenario`  | `@behat-steps-entity-cleanup-skip:block_content`                                                     |
+| `@behat-steps-skip:paragraphsAfterScenario`    | `@behat-steps-entity-cleanup-skip:paragraph`                                                         |
+| `@behat-steps-skip:eckAfterScenario`           | `@behat-steps-entity-cleanup-skip:ENTITY_TYPE_ID`                                                    |
+| `@behat-steps-skip:menuAfterScenario`          | `@behat-steps-entity-cleanup-skip:menu` and/or `@behat-steps-entity-cleanup-skip:menu_link_content`  |
+| `@behat-steps-skip:redirectAfterScenario`      | `@behat-steps-entity-cleanup-skip:redirect`                                                          |
+| `@behat-steps-skip:blockAfterScenario`         | `@behat-steps-entity-cleanup-skip:block`                                                             |
+| `@behat-steps-skip:webformAfterScenario`       | `@behat-steps-entity-cleanup-skip:webform`                                                           |
+
+To skip cleanup of every registered entity at once, use `@behat-steps-skip:entityCleanupAfterScenario`.
+
+`FileTrait` keeps its own `@behat-steps-skip:fileAfterScenario` tag, which now covers only unmanaged files; managed file entities it creates are cleaned up by the shared registry and can be kept with `@behat-steps-entity-cleanup-skip:file`.

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ Traits that create Drupal entities (content blocks, media, managed files,
 paragraphs, ECK entities, menus and menu links, redirects, blocks and webforms)
 register each created entity in a shared registry and delete them in reverse
 creation order at the end of the scenario, keeping the test database clean
-across long suites. Nodes, users, taxonomy terms and roles are cleaned up by the
-base Drupal Extension and are never registered here, so there is no
-double-deletion.
+across long suites. Nodes, users, taxonomy terms, roles and language entities
+are cleaned up by the base Drupal Extension and are never registered here, so
+there is no double-deletion.
 
 To keep **all** registered entities after a scenario, add
 `@behat-steps-skip:entityCleanupAfterScenario` to the scenario or feature.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,23 @@ by adding `@behat-steps-skip:METHOD_NAME` tag to your test.
 For example, to skip `beforeScenario` hook from `ElementTrait`, add
 `@behat-steps-skip:ElementTrait` tag to the feature.
 
+### Automatic entity cleanup
+
+Traits that create Drupal entities (content blocks, media, managed files,
+paragraphs, ECK entities, menus and menu links, redirects, blocks and webforms)
+register each created entity in a shared registry and delete them in reverse
+creation order at the end of the scenario, keeping the test database clean
+across long suites. Nodes, users, taxonomy terms and roles are cleaned up by the
+base Drupal Extension and are never registered here, so there is no
+double-deletion.
+
+To keep **all** registered entities after a scenario, add
+`@behat-steps-skip:entityCleanupAfterScenario` to the scenario or feature.
+
+To keep only entities of a **named type**, add
+`@behat-steps-entity-cleanup-skip:ENTITY_TYPE_ID` (for example
+`@behat-steps-entity-cleanup-skip:media`). Repeat the tag to keep several types.
+
 ## Writing tests with AI assistants
 
 Copy and paste below into your project's `CLAUDE.md` or `AGENTS.md` file.

--- a/STEPS.md
+++ b/STEPS.md
@@ -3366,9 +3366,7 @@ Then the response should be a valid Atom feed
 >  Manage Drupal blocks.
 >  - Create and configure blocks with custom visibility conditions.
 >  - Place blocks in regions and verify their rendering in the page.
->  - Automatically clean up created blocks after scenario completion.
->  
->  Skip processing with tag: `@behat-steps-skip:blockAfterScenario`
+>  - Created blocks are automatically removed at the end of the scenario.
 
 
 <details>
@@ -3648,9 +3646,7 @@ Given the render cache has been cleared
 >  Manage Drupal content blocks.
 >  - Define reusable custom block content with structured field data.
 >  - Create, edit, and verify block_content entities by type and description.
->  - Automatically clean up created entities after scenario completion.
->  
->  Skip processing with tag: `@behat-steps-skip:contentBlockAfterScenario`
+>  - Created entities are automatically removed at the end of the scenario.
 
 
 <details>
@@ -3947,9 +3943,7 @@ When I save the draggable views items of the view "draggableviews_demo" and the 
 >  Manage Drupal ECK entities with custom type and bundle creation.
 >  - Create structured ECK entities with defined field values.
 >  - Assert entity type registration and visit entity pages.
->  - Automatically clean up created entities after scenario completion.
->  
->  Skip processing with tag: `@behat-steps-skip:eckAfterScenario`
+>  - Created entities are automatically removed at the end of the scenario.
 
 
 <details>
@@ -4502,9 +4496,7 @@ Then an unmanaged file at the URI "public://config.txt" should not contain "debu
 >  - Create structured media items with proper file reference handling.
 >  - Assert media browser functionality and edit media entity fields.
 >  - Support for multiple media types with field value expansion handling.
->  - Automatically clean up created entities after scenario completion.
->  
->  Skip processing with tag: `@behat-steps-skip:mediaAfterScenario`
+>  - Created entities are automatically removed at the end of the scenario.
 
 
 <details>
@@ -4691,9 +4683,7 @@ Then the "image" media with the name "Test media image" should not exist
 >  - Assert menu items by label, path, and containment hierarchy.
 >  - Assert menu link visibility and active states in different regions.
 >  - Create and manage menu hierarchies with parent-child relationships.
->  - Automatically clean up created menu links after scenario completion.
->  
->  Skip processing with tag: `@behat-steps-skip:menuAfterScenario`
+>  - Created menus and menu links are automatically removed at the end of the scenario.
 
 
 <details>
@@ -4920,9 +4910,7 @@ Then the following modules should be disabled:
 >  - Create paragraph items with type-specific field values.
 >  - Test nested paragraph structures and reference field handling.
 >  - Attach paragraphs to various entity types with parent-child relationships.
->  - Automatically clean up created paragraph items after scenario completion.
->  
->  Skip processing with tag: `@behat-steps-skip:paragraphsAfterScenario`
+>  - Created paragraph items are automatically removed at the end of the scenario.
 
 
 <details>
@@ -5033,13 +5021,11 @@ Then the "myqueue" queue should be empty
 >  - Create one or more redirects from a table of source/destination/status.
 >  - Delete redirects by source path.
 >  - Assert that redirects do or do not exist for given source paths.
->  - Automatically clean up created redirects after scenario completion.
+>  - Created redirects are automatically removed at the end of the scenario.
 >  
 >  Requires the `redirect` contrib module to be installed and enabled in the
 >  consumer project: add `drupal/redirect` to `composer.json` and enable the
 >  module as part of the site's standard setup (e.g. in `core.extension.yml`).
->  <br/><br/>
->  Skip processing with tag: `@behat-steps-skip:redirectAfterScenario`
 
 
 <details>
@@ -5807,11 +5793,9 @@ Then the user "John" should not be blocked
 >  Manage Drupal webforms.
 >  - Delete webforms matching a given title for test isolation.
 >  - Clone webform templates into new webforms for scenario setup.
->  - Automatically clean up cloned webforms after scenario completion.
+>  - Cloned webforms are automatically removed at the end of the scenario.
 >  
 >  Requires `drupal/webform` module.
->  <br/><br/>
->  Skip processing with tag: `@behat-steps-skip:webformAfterScenario`
 
 
 <details>

--- a/docs.php
+++ b/docs.php
@@ -722,6 +722,7 @@ function tag_registry(): array {
   return [
     // Parametrized tags - expect a `:value` suffix.
     'behat-steps-skip' => 'parametrized',
+    'behat-steps-entity-cleanup-skip' => 'parametrized',
     'module' => 'parametrized',
     'breakpoint' => 'parametrized',
     'email' => 'parametrized',

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -6,57 +6,20 @@ namespace DrevOps\BehatSteps\Drupal;
 
 use Behat\Step\Given;
 use Behat\Step\Then;
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
-use Behat\Hook\AfterScenario;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use Drupal\block\Entity\Block;
-use Drupal\Core\Entity\EntityStorageException;
 
 /**
  * Manage Drupal blocks.
  *
  * - Create and configure blocks with custom visibility conditions.
  * - Place blocks in regions and verify their rendering in the page.
- * - Automatically clean up created blocks after scenario completion.
- *
- * Skip processing with tag: `@behat-steps-skip:blockAfterScenario`
+ * - Created blocks are automatically removed at the end of the scenario.
  */
 trait BlockTrait {
 
-  /**
-   * Array of created block instances.
-   *
-   * @var array<int, \Drupal\block\Entity\Block>
-   */
-  protected static array $blockInstances = [];
-
-  /**
-   * Clean up all blocks created during the scenario.
-   *
-   * This method automatically runs after each scenario to ensure clean
-   * test state.
-   * Add the tag @behat-steps-skip:blockAfterScenario to your scenario to
-   * prevent automatic cleanup of blocks.
-   */
-  #[AfterScenario('@api')]
-  public function blockAfterScenario(AfterScenarioScope $scope): void {
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-
-    foreach (static::$blockInstances as $key => $block) {
-      try {
-        $block->delete();
-      }
-      // @codeCoverageIgnoreStart
-      catch (EntityStorageException) {
-        // Ignore "already deleted" errors to keep teardown resilient.
-      }
-      // @codeCoverageIgnoreEnd
-      unset(static::$blockInstances[$key]);
-    }
-  }
+  use HelperTrait;
 
   /**
    * Create a block instance.
@@ -106,7 +69,7 @@ trait BlockTrait {
 
     $this->blockConfigure($admin_label, $fields);
 
-    static::$blockInstances[] = $block;
+    $this->entityRegister($block);
   }
 
   /**
@@ -178,11 +141,6 @@ trait BlockTrait {
     while ($block = $this->blockLoadByLabel($label)) {
       $block->delete();
     }
-
-    static::$blockInstances = array_filter(
-      static::$blockInstances,
-      fn(Block $b): bool => $b->get('settings')['label'] !== $label
-    );
   }
 
   /**

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -7,14 +7,10 @@ namespace DrevOps\BehatSteps\Drupal;
 use Behat\Step\Then;
 use Behat\Step\Given;
 use Behat\Step\When;
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Hook\AfterScenario;
 use Behat\Mink\Exception\ExpectationException;
-use DrevOps\BehatSteps\HelperTrait;
 use Drupal\block_content\BlockContentTypeInterface;
 use Drupal\block_content\Entity\BlockContent;
-use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Driver\Entity\EntityStub;
 
 /**
@@ -22,42 +18,11 @@ use Drupal\Driver\Entity\EntityStub;
  *
  * - Define reusable custom block content with structured field data.
  * - Create, edit, and verify block_content entities by type and description.
- * - Automatically clean up created entities after scenario completion.
- *
- * Skip processing with tag: `@behat-steps-skip:contentBlockAfterScenario`
+ * - Created entities are automatically removed at the end of the scenario.
  */
 trait ContentBlockTrait {
 
   use HelperTrait;
-
-  /**
-   * Array of created block_content entities.
-   *
-   * @var array<int,\Drupal\block_content\Entity\BlockContent>
-   */
-  protected static $contentBlockEntities = [];
-
-  /**
-   * Clean up all content block entities created during the scenario.
-   */
-  #[AfterScenario('@api')]
-  public function contentBlockAfterScenario(AfterScenarioScope $scope): void {
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-
-    foreach (static::$contentBlockEntities as $key => $block_content) {
-      try {
-        $block_content->delete();
-      }
-      // @codeCoverageIgnoreStart
-      catch (EntityStorageException) {
-        // Ignore "already deleted" errors to keep teardown resilient.
-      }
-      // @codeCoverageIgnoreEnd
-      unset(static::$contentBlockEntities[$key]);
-    }
-  }
 
   /**
    * Assert that a content block type exists.
@@ -227,7 +192,7 @@ trait ContentBlockTrait {
     $entity = BlockContent::create($stub->getValues());
     $entity->save();
 
-    static::$contentBlockEntities[] = $entity;
+    $this->entityRegister($entity);
 
     return $entity;
   }

--- a/src/Drupal/EckTrait.php
+++ b/src/Drupal/EckTrait.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Hook\AfterScenario;
 use Behat\Step\Given;
 use Behat\Step\When;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Driver\Capability\ContentCapabilityInterface;
 use Drupal\Driver\Entity\EntityStub;
 
@@ -17,51 +16,11 @@ use Drupal\Driver\Entity\EntityStub;
  *
  * - Create structured ECK entities with defined field values.
  * - Assert entity type registration and visit entity pages.
- * - Automatically clean up created entities after scenario completion.
- *
- * Skip processing with tag: `@behat-steps-skip:eckAfterScenario`
+ * - Created entities are automatically removed at the end of the scenario.
  */
 trait EckTrait {
 
-  /**
-   * Custom eck content entities organised by entity type.
-   *
-   * @var array<string, array<int, \Drupal\eck\EckEntityInterface|object>>
-   */
-  protected $eckEntities = [];
-
-  /**
-   * Remove ECK types and entities.
-   */
-  #[AfterScenario('@api')]
-  public function eckAfterScenario(AfterScenarioScope $scope): void {
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-
-    // @codeCoverageIgnoreStart
-    $entity_ids_by_type = [];
-    foreach ($this->eckEntities as $entity_type => $content_entities) {
-      foreach ($content_entities as $content_entity) {
-        // Handle both entity objects (with ->id() method) and stdClass (with ->id property).
-        if (is_object($content_entity) && method_exists($content_entity, 'id')) {
-          $entity_ids_by_type[$entity_type][] = $content_entity->id();
-        }
-        elseif (is_object($content_entity) && isset($content_entity->id)) {
-          $entity_ids_by_type[$entity_type][] = $content_entity->id;
-        }
-      }
-    }
-
-    foreach ($entity_ids_by_type as $entity_type => $entity_ids) {
-      $controller = \Drupal::entityTypeManager()->getStorage($entity_type);
-      $entities = $controller->loadMultiple($entity_ids);
-      $controller->delete($entities);
-    }
-
-    $this->eckEntities = [];
-    // @codeCoverageIgnoreEnd
-  }
+  use HelperTrait;
 
   /**
    * Create eck entities.
@@ -212,8 +171,10 @@ trait EckTrait {
 
     $driver->entityCreate($stub);
 
-    // Store the saved Drupal entity for AfterScenario cleanup.
-    $this->eckEntities[$stub->getEntityType()][] = $stub->getSavedEntity();
+    $saved = $stub->getSavedEntity();
+    if ($saved instanceof EntityInterface) {
+      $this->entityRegister($saved);
+    }
   }
 
 }

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -30,12 +30,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 trait FileTrait {
 
-  /**
-   * Files entities.
-   *
-   * @var array<int,FileInterface>
-   */
-  protected $fileEntities = [];
+  use HelperTrait;
 
   /**
    * Unmanaged file URIs.
@@ -122,7 +117,7 @@ trait FileTrait {
 
     $saved = $this->fileCreateEntity($path, $stub, $uri);
 
-    $this->fileEntities[] = $saved;
+    $this->entityRegister($saved);
 
     return $saved;
   }
@@ -186,7 +181,9 @@ trait FileTrait {
   }
 
   /**
-   * Clean all created managed files after scenario run.
+   * Remove unmanaged files created during the scenario.
+   *
+   * Managed file entities are removed by the shared entity registry cleanup.
    */
   #[AfterScenario('@api')]
   public function fileAfterScenario(AfterScenarioScope $scope): void {
@@ -195,15 +192,9 @@ trait FileTrait {
       return;
     }
     // @codeCoverageIgnoreEnd
-    foreach ($this->fileEntities as $file) {
-      $file->delete();
-    }
-
     foreach ($this->filesUnmanagedUris as $uri) {
       @unlink($uri);
     }
-
-    $this->fileEntities = [];
   }
 
   /**

--- a/src/Drupal/HelperTrait.php
+++ b/src/Drupal/HelperTrait.php
@@ -23,8 +23,8 @@ use Drupal\Driver\Entity\EntityStubInterface;
  * helpers.
  *
  * Entity types owned by the base Drupal Extension cleanup (node, user,
- * taxonomy_term, user_role) are never registered here, so there is no
- * double-deletion.
+ * taxonomy_term, user_role, language, configurable_language) are never
+ * registered here, so there is no double-deletion.
  *
  * Skip all cleanup with tag: `@behat-steps-skip:entityCleanupAfterScenario`
  * Skip cleanup for one entity type with tag:

--- a/src/Drupal/HelperTrait.php
+++ b/src/Drupal/HelperTrait.php
@@ -90,28 +90,51 @@ trait HelperTrait {
   }
 
   /**
-   * Delete registered entities in reverse creation order.
+   * Delete registered entities in reverse creation order at scenario teardown.
    */
   #[AfterScenario('@api')]
   public function entityCleanupAfterScenario(AfterScenarioScope $scope): void {
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+    $scenario = $scope->getScenario();
+
+    if ($scenario->hasTag('behat-steps-skip:' . __FUNCTION__)) {
       return;
     }
 
-    // @codeCoverageIgnoreStart
-    $skip_types = $this->entityCleanupSkippedTypes($scope->getScenario()->getTags());
+    $this->entityCleanupRun($this->entityCleanupSkippedTypes($scenario->getTags()));
+  }
 
+  /**
+   * Delete registered entities in reverse creation order, then reset.
+   *
+   * Entity types in self::ENTITY_CLEANUP_EXCLUDED_TYPES (owned by the base
+   * Drupal Extension) or in $skip_types are left in place.
+   *
+   * @param array<int, string> $skip_types
+   *   Entity type ids to leave in place.
+   */
+  protected function entityCleanupRun(array $skip_types): void {
     foreach (array_reverse($this->entityRegistry) as [$entity_type_id, $entity_id]) {
       if (in_array($entity_type_id, self::ENTITY_CLEANUP_EXCLUDED_TYPES, TRUE) || in_array($entity_type_id, $skip_types, TRUE)) {
         continue;
       }
 
-      $entity = \Drupal::entityTypeManager()->getStorage($entity_type_id)->load($entity_id);
-      $entity?->delete();
+      $this->entityCleanupDelete($entity_type_id, $entity_id);
     }
 
     $this->entityRegistry = [];
-    // @codeCoverageIgnoreEnd
+  }
+
+  /**
+   * Load an entity by type and id and delete it when it still exists.
+   *
+   * @param string $entity_type_id
+   *   The entity type machine name.
+   * @param int|string $entity_id
+   *   The entity id.
+   */
+  protected function entityCleanupDelete(string $entity_type_id, int|string $entity_id): void {
+    $entity = \Drupal::entityTypeManager()->getStorage($entity_type_id)->load($entity_id);
+    $entity?->delete();
   }
 
   /**

--- a/src/Drupal/HelperTrait.php
+++ b/src/Drupal/HelperTrait.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Hook\AfterScenario;
 use DrevOps\BehatSteps\HelperTrait as CommonHelperTrait;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Driver\DrupalDriverInterface;
 use Drupal\Driver\Entity\EntityStubInterface;
 
@@ -12,15 +15,127 @@ use Drupal\Driver\Entity\EntityStubInterface;
  * Internal Drupal helper methods for Behat step definitions.
  *
  * Drupal-specific counterpart to the generic HelperTrait: fixture path
- * expansion for file and image fields and managed-file lookups. Includes the
- * generic helper trait so a consumer trait can rely on a single include for
- * both generic and Drupal helpers.
+ * expansion for file and image fields, managed-file lookups, and a shared
+ * per-scenario entity registry. Creation steps register the entities they
+ * create; a separate teardown step deletes the registered entities in reverse
+ * creation order at scenario end. Includes the generic helper trait so a
+ * consumer trait can rely on a single include for both generic and Drupal
+ * helpers.
+ *
+ * Entity types owned by the base Drupal Extension cleanup (node, user,
+ * taxonomy_term, user_role) are never registered here, so there is no
+ * double-deletion.
+ *
+ * Skip all cleanup with tag: `@behat-steps-skip:entityCleanupAfterScenario`
+ * Skip cleanup for one entity type with tag:
+ * `@behat-steps-entity-cleanup-skip:media`
  *
  * This is an internal trait and should not be used directly in step definitions.
  */
 trait HelperTrait {
 
   use CommonHelperTrait;
+
+  /**
+   * Entity types owned by the base Drupal Extension's own cleanup.
+   *
+   * Never deleted by this trait to avoid double-deletion with the base
+   * extension (re-deleting a user or language throws, unlike nodes/terms).
+   */
+  const ENTITY_CLEANUP_EXCLUDED_TYPES = [
+    'node',
+    'user',
+    'taxonomy_term',
+    'user_role',
+    'language',
+    'configurable_language',
+  ];
+
+  /**
+   * Entities registered during the scenario, in creation order.
+   *
+   * Each item is a [entity_type_id, entity_id] pair. Ids are stored as scalars
+   * so each entity is reloaded fresh at cleanup time and an already-deleted row
+   * is tolerated. Registering an entity only records it here; deleting
+   * registered entities is a separate concern handled at scenario teardown.
+   *
+   * @var array<int, array{0: string, 1: int|string}>
+   */
+  protected array $entityRegistry = [];
+
+  /**
+   * Register a saved entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The saved entity to register.
+   */
+  protected function entityRegister(EntityInterface $entity): void {
+    $id = $entity->id();
+
+    if ($id !== NULL) {
+      $this->entityRegisterId($entity->getEntityTypeId(), $id);
+    }
+  }
+
+  /**
+   * Register an entity by type and id.
+   *
+   * @param string $entity_type_id
+   *   The entity type machine name.
+   * @param int|string $entity_id
+   *   The entity id.
+   */
+  protected function entityRegisterId(string $entity_type_id, int|string $entity_id): void {
+    $this->entityRegistry[] = [$entity_type_id, $entity_id];
+  }
+
+  /**
+   * Delete registered entities in reverse creation order.
+   */
+  #[AfterScenario('@api')]
+  public function entityCleanupAfterScenario(AfterScenarioScope $scope): void {
+    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+
+    // @codeCoverageIgnoreStart
+    $skip_types = $this->entityCleanupSkippedTypes($scope->getScenario()->getTags());
+
+    foreach (array_reverse($this->entityRegistry) as [$entity_type_id, $entity_id]) {
+      if (in_array($entity_type_id, self::ENTITY_CLEANUP_EXCLUDED_TYPES, TRUE) || in_array($entity_type_id, $skip_types, TRUE)) {
+        continue;
+      }
+
+      $entity = \Drupal::entityTypeManager()->getStorage($entity_type_id)->load($entity_id);
+      $entity?->delete();
+    }
+
+    $this->entityRegistry = [];
+    // @codeCoverageIgnoreEnd
+  }
+
+  /**
+   * Collect entity types named in the scenario's per-type bypass tags.
+   *
+   * @param array<int, string> $tags
+   *   The scenario's tag names (without the leading '@').
+   *
+   * @return array<int, string>
+   *   Entity type ids to skip, parsed from
+   *   'behat-steps-entity-cleanup-skip:<entity_type_id>' tags.
+   */
+  protected function entityCleanupSkippedTypes(array $tags): array {
+    $prefix = 'behat-steps-entity-cleanup-skip:';
+    $types = [];
+
+    foreach ($tags as $tag) {
+      if (str_starts_with($tag, $prefix)) {
+        $types[] = substr($tag, strlen($prefix));
+      }
+    }
+
+    return $types;
+  }
 
   /**
    * Expand fixture file paths for file/image fields on an entity stub.

--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Hook\AfterScenario;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Step\Given;
 use Behat\Step\Then;
@@ -22,36 +20,11 @@ use Drupal\media\MediaInterface;
  * - Create structured media items with proper file reference handling.
  * - Assert media browser functionality and edit media entity fields.
  * - Support for multiple media types with field value expansion handling.
- * - Automatically clean up created entities after scenario completion.
- *
- * Skip processing with tag: `@behat-steps-skip:mediaAfterScenario`
+ * - Created entities are automatically removed at the end of the scenario.
  */
 trait MediaTrait {
 
   use HelperTrait;
-
-  /**
-   * Array of created media entities.
-   *
-   * @var array<int,\Drupal\media\MediaInterface>
-   */
-  protected $mediaEntities = [];
-
-  /**
-   * Remove any created media items.
-   */
-  #[AfterScenario('@api')]
-  public function mediaAfterScenario(AfterScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-    // @codeCoverageIgnoreEnd
-    foreach ($this->mediaEntities as $media) {
-      $media->delete();
-    }
-    $this->mediaEntities = [];
-  }
 
   /**
    * Remove media type.
@@ -294,7 +267,7 @@ trait MediaTrait {
   protected function mediaCreateSingle(EntityStub $stub): MediaInterface {
     $this->parseEntityFields($stub);
     $saved = $this->mediaCreateEntity($stub);
-    $this->mediaEntities[] = $saved;
+    $this->entityRegister($saved);
 
     return $saved;
   }

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps\Drupal;
 
 use Behat\Step\Given;
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Hook\AfterScenario;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\system\Entity\Menu;
 use Drupal\system\MenuInterface;
@@ -18,25 +16,11 @@ use Drupal\system\MenuInterface;
  * - Assert menu items by label, path, and containment hierarchy.
  * - Assert menu link visibility and active states in different regions.
  * - Create and manage menu hierarchies with parent-child relationships.
- * - Automatically clean up created menu links after scenario completion.
- *
- * Skip processing with tag: `@behat-steps-skip:menuAfterScenario`
+ * - Created menus and menu links are automatically removed at the end of the scenario.
  */
 trait MenuTrait {
 
-  /**
-   * Menus.
-   *
-   * @var \Drupal\system\Entity\Menu[]
-   */
-  protected $menus = [];
-
-  /**
-   * Menu links.
-   *
-   * @var \Drupal\menu_link_content\Entity\MenuLinkContent[]
-   */
-  protected $menuLinks = [];
+  use HelperTrait;
 
   /**
    * Remove a single menu by its label if it exists.
@@ -86,7 +70,7 @@ trait MenuTrait {
       $menu = Menu::create($menu_hash);
       $menu->save();
 
-      $this->menus[] = $menu;
+      $this->entityRegister($menu);
     }
   }
 
@@ -157,29 +141,8 @@ trait MenuTrait {
       }
       $menu_link = MenuLinkContent::create($menu_link_hash);
       $menu_link->save();
-      $this->menuLinks[] = $menu_link;
+      $this->entityRegister($menu_link);
     }
-  }
-
-  /**
-   * Remove all menu items after scenario run.
-   */
-  #[AfterScenario('@api')]
-  public function menuAfterScenario(AfterScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-    // @codeCoverageIgnoreEnd
-    foreach ($this->menuLinks as $menu_link) {
-      $menu_link->delete();
-    }
-    $this->menuLinks = [];
-
-    foreach ($this->menus as $menu) {
-      $menu->delete();
-    }
-    $this->menus = [];
   }
 
   /**

--- a/src/Drupal/ParagraphsTrait.php
+++ b/src/Drupal/ParagraphsTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps\Drupal;
 
 use Behat\Step\Given;
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Hook\AfterScenario;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Driver\DrupalDriverInterface;
 use Drupal\Driver\Entity\EntityStub;
@@ -20,35 +18,11 @@ use Drupal\paragraphs\ParagraphInterface;
  * - Create paragraph items with type-specific field values.
  * - Test nested paragraph structures and reference field handling.
  * - Attach paragraphs to various entity types with parent-child relationships.
- * - Automatically clean up created paragraph items after scenario completion.
- *
- * Skip processing with tag: `@behat-steps-skip:paragraphsAfterScenario`
+ * - Created paragraph items are automatically removed at the end of the scenario.
  */
 trait ParagraphsTrait {
 
-  /**
-   * Array of created paragraph entities.
-   *
-   * @var array<int,\Drupal\paragraphs\ParagraphInterface>
-   */
-  protected static $paragraphEntities = [];
-
-  /**
-   * Clean all paragraphs instances after scenario run.
-   */
-  #[AfterScenario('@api')]
-  public function paragraphsAfterScenario(AfterScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-    // @codeCoverageIgnoreEnd
-    foreach (static::$paragraphEntities as $paragraph) {
-      $paragraph->delete();
-    }
-
-    static::$paragraphEntities = [];
-  }
+  use HelperTrait;
 
   /**
    * Create a paragraph of the given type with fields within an existing entity.
@@ -118,7 +92,7 @@ trait ParagraphsTrait {
       $parent_entity->save();
     }
 
-    static::$paragraphEntities[] = $paragraph;
+    $this->entityRegister($paragraph);
 
     return $paragraph;
   }

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Hook\AfterScenario;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Drupal\Component\Utility\UrlHelper;
@@ -18,15 +16,15 @@ use Drupal\redirect\Entity\Redirect;
  * - Create one or more redirects from a table of source/destination/status.
  * - Delete redirects by source path.
  * - Assert that redirects do or do not exist for given source paths.
- * - Automatically clean up created redirects after scenario completion.
+ * - Created redirects are automatically removed at the end of the scenario.
  *
  * Requires the `redirect` contrib module to be installed and enabled in the
  * consumer project: add `drupal/redirect` to `composer.json` and enable the
  * module as part of the site's standard setup (e.g. in `core.extension.yml`).
- *
- * Skip processing with tag: `@behat-steps-skip:redirectAfterScenario`
  */
 trait RedirectTrait {
+
+  use HelperTrait;
 
   /**
    * Allowed HTTP status codes for redirects.
@@ -34,13 +32,6 @@ trait RedirectTrait {
    * @var int[]
    */
   protected static $redirectAllowedStatusCodes = [301, 302, 303, 307, 308];
-
-  /**
-   * Redirects created during a scenario.
-   *
-   * @var \Drupal\redirect\Entity\Redirect[]
-   */
-  protected $redirects = [];
 
   /**
    * Create one or more redirects.
@@ -90,7 +81,7 @@ trait RedirectTrait {
       $redirect->setRedirect($to);
       $redirect->save();
 
-      $this->redirects[] = $redirect;
+      $this->entityRegister($redirect);
     }
   }
 
@@ -126,14 +117,6 @@ trait RedirectTrait {
 
       $entities = $storage->loadMultiple($ids);
       $storage->delete($entities);
-
-      // Drop any cleanup references for the just-deleted redirects so the
-      // after-scenario hook does not attempt to delete them again.
-      $deleted_ids = array_map(intval(...), array_keys($entities));
-      $this->redirects = array_values(array_filter(
-        $this->redirects,
-        fn(Redirect $redirect): bool => !in_array((int) $redirect->id(), $deleted_ids, TRUE),
-      ));
     }
   }
 
@@ -236,38 +219,6 @@ trait RedirectTrait {
     if ($present !== []) {
       throw new \Exception(sprintf('The following redirects should not exist but were found: %s.', implode(', ', $present)));
     }
-  }
-
-  /**
-   * Remove all created redirects after scenario run.
-   */
-  #[AfterScenario('@api')]
-  public function redirectAfterScenario(AfterScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-    // @codeCoverageIgnoreEnd
-    if (empty($this->redirects)) {
-      return;
-    }
-
-    // @codeCoverageIgnoreStart
-    if (!\Drupal::moduleHandler()->moduleExists('redirect')) {
-      $this->redirects = [];
-
-      return;
-    }
-    // @codeCoverageIgnoreEnd
-    $storage = \Drupal::entityTypeManager()->getStorage('redirect');
-    $ids = array_filter(array_map(fn(Redirect $redirect): int => (int) $redirect->id(), $this->redirects));
-    $entities = $ids !== [] ? $storage->loadMultiple($ids) : [];
-
-    if (!empty($entities)) {
-      $storage->delete($entities);
-    }
-
-    $this->redirects = [];
   }
 
   /**

--- a/src/Drupal/WebformTrait.php
+++ b/src/Drupal/WebformTrait.php
@@ -4,55 +4,20 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
-use Behat\Hook\AfterScenario;
 use Behat\Step\Given;
-use Drupal\Core\Entity\EntityStorageException;
 
 /**
  * Manage Drupal webforms.
  *
  * - Delete webforms matching a given title for test isolation.
  * - Clone webform templates into new webforms for scenario setup.
- * - Automatically clean up cloned webforms after scenario completion.
+ * - Cloned webforms are automatically removed at the end of the scenario.
  *
  * Requires `drupal/webform` module.
- *
- * Skip processing with tag: `@behat-steps-skip:webformAfterScenario`
  */
 trait WebformTrait {
 
-  /**
-   * Array of created webform entities for cleanup.
-   *
-   * @var array<int,\Drupal\webform\WebformInterface>
-   */
-  protected static $webformEntities = [];
-
-  /**
-   * Clean all created webform instances after scenario run.
-   */
-  #[AfterScenario('@api')]
-  public function webformAfterScenario(AfterScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      static::$webformEntities = [];
-      return;
-    }
-    // @codeCoverageIgnoreEnd
-    foreach (static::$webformEntities as $webform) {
-      try {
-        $webform->delete();
-      }
-      // @codeCoverageIgnoreStart
-      catch (EntityStorageException) {
-        // Ignore "already deleted" errors to keep teardown resilient.
-      }
-      // @codeCoverageIgnoreEnd
-    }
-
-    static::$webformEntities = [];
-  }
+  use HelperTrait;
 
   /**
    * Remove all webforms with a title containing the given string.
@@ -107,7 +72,7 @@ trait WebformTrait {
     $clone->set('template', FALSE);
     $clone->save();
 
-    static::$webformEntities[] = $clone;
+    $this->entityRegister($clone);
   }
 
   /**

--- a/tests/behat/features/drupal_block.feature
+++ b/tests/behat/features/drupal_block.feature
@@ -246,7 +246,7 @@ Feature: Check that BlockTrait works
       Could not create block with admin label "Non-existent Block Type"
       """
 
-  @api @behat-steps-skip:blockAfterScenario
+  @api @behat-steps-entity-cleanup-skip:block
   Scenario: Blocks are not automatically cleaned up when skip tag is used
     Given the instance of "User account menu" block exists with the following configuration:
       | label         | [TEST] Skip Cleanup Block |

--- a/tests/behat/features/drupal_content_block.feature
+++ b/tests/behat/features/drupal_content_block.feature
@@ -169,7 +169,7 @@ Feature: Check that ContentBlockTrait works
       | [TEST] Content Block That Doesn't Exist |
     Then I should not see the text "[TEST] Content Block That Doesn't Exist"
 
-  @api @behat-steps-skip:contentBlockAfterScenario
+  @api @behat-steps-entity-cleanup-skip:block_content
   Scenario: Content blocks are not automatically cleaned up when skip tag is used
     Given the following "basic" content blocks exist:
       | info                      | body              | status |

--- a/tests/behat/features/drupal_eck.feature
+++ b/tests/behat/features/drupal_eck.feature
@@ -55,7 +55,7 @@ Feature: Check that EckTrait works
       Unable to find "test_entity_type" page "[TEST] ECK Entity non-existing"
       """
 
-  @api @behat-steps-skip:eckAfterScenario
+  @api @behat-steps-entity-cleanup-skip:test_entity_type
   Scenario: ECK entities are not automatically cleaned up when skip tag is used
     Given the following eck "test_bundle" "test_entity_type" entities exist:
       | title                   | field_test_text   |
@@ -78,4 +78,4 @@ Feature: Check that EckTrait works
     And I am logged in as a user with the "administrator" role
     When I visit eck "test_bundle" "test_entity_type" entity with the title "[TEST] Auto Cleanup ECK 1"
     Then I should see "[TEST] Auto Cleanup ECK 1"
-    # ECK entities will be auto-deleted by eckAfterScenario hook
+    # ECK entities will be auto-deleted by the shared entity cleanup hook

--- a/tests/behat/features/drupal_entity_cleanup.feature
+++ b/tests/behat/features/drupal_entity_cleanup.feature
@@ -1,0 +1,58 @@
+Feature: Check that automatic entity cleanup works
+  As a Behat Steps library developer
+  I want entities created during a scenario to be tracked and removed at teardown
+  So that a test database stays clean across long suites without manual cleanup
+
+  # Entities created through the library's creation steps are registered in a
+  # shared registry and deleted in reverse creation order at scenario teardown.
+  # These paired scenarios rely on Behat running scenarios in file order: the
+  # first scenario of each pair creates an entity, the second asserts what the
+  # teardown of the first scenario did with it.
+
+  @api
+  Scenario: Registered entities exist during the scenario that creates them
+    Given the following redirects exist:
+      | from                 | to          |
+      | /entity-cleanup-auto | /user/login |
+    Then the following redirects should exist:
+      | from                 |
+      | /entity-cleanup-auto |
+
+  @api
+  Scenario: Registered entities are deleted at teardown of the creating scenario
+    Then the following redirects should not exist:
+      | /entity-cleanup-auto |
+
+  @api @behat-steps-skip:entityCleanupAfterScenario
+  Scenario: The cleanup skip tag keeps all registered entities
+    Given the following redirects exist:
+      | from                     | to          |
+      | /entity-cleanup-kept-all | /user/login |
+    Then the following redirects should exist:
+      | from                     |
+      | /entity-cleanup-kept-all |
+
+  @api
+  Scenario: An entity kept by the skip tag survives teardown and is removed manually
+    Then the following redirects should exist:
+      | from                     |
+      | /entity-cleanup-kept-all |
+    Given the following redirects do not exist:
+      | /entity-cleanup-kept-all |
+
+  @api @behat-steps-entity-cleanup-skip:redirect
+  Scenario: The per-type skip tag keeps entities of the named type
+    Given the following redirects exist:
+      | from                      | to          |
+      | /entity-cleanup-kept-type | /user/login |
+    Then the following redirects should exist:
+      | from                      |
+      | /entity-cleanup-kept-type |
+
+  @api
+  Scenario: An entity kept by the per-type skip tag survives teardown and is removed manually
+    Then the following redirects should exist:
+      | from                      |
+      | /entity-cleanup-kept-type |
+    Given the following redirects do not exist:
+      | /entity-cleanup-kept-type |

--- a/tests/phpunit/src/Drupal/HelperTraitTest.php
+++ b/tests/phpunit/src/Drupal/HelperTraitTest.php
@@ -58,6 +58,39 @@ class HelperTraitTest extends UnitTestCase {
     $this->assertSame([['media', 7], ['block_content', 'custom_id']], $this->testObject->getEntityRegistry());
   }
 
+  public function testEntityCleanupRunDeletesInReverseOrderAndResets(): void {
+    $this->testObject->callEntityRegisterId('redirect', 1);
+    $this->testObject->callEntityRegisterId('media', 2);
+    $this->testObject->callEntityRegisterId('block', 3);
+
+    $this->testObject->callEntityCleanupRun([]);
+
+    $this->assertSame([['block', 3], ['media', 2], ['redirect', 1]], $this->testObject->deleted);
+    $this->assertSame([], $this->testObject->getEntityRegistry());
+  }
+
+  public function testEntityCleanupRunExcludesBaseOwnedTypes(): void {
+    $this->testObject->callEntityRegisterId('node', 1);
+    $this->testObject->callEntityRegisterId('redirect', 2);
+    $this->testObject->callEntityRegisterId('user', 3);
+    $this->testObject->callEntityRegisterId('configurable_language', 'en');
+
+    $this->testObject->callEntityCleanupRun([]);
+
+    $this->assertSame([['redirect', 2]], $this->testObject->deleted);
+    $this->assertSame([], $this->testObject->getEntityRegistry());
+  }
+
+  public function testEntityCleanupRunSkipsNamedTypes(): void {
+    $this->testObject->callEntityRegisterId('media', 1);
+    $this->testObject->callEntityRegisterId('redirect', 2);
+
+    $this->testObject->callEntityCleanupRun(['media']);
+
+    $this->assertSame([['redirect', 2]], $this->testObject->deleted);
+    $this->assertSame([], $this->testObject->getEntityRegistry());
+  }
+
   /**
    * Tests that per-type cleanup bypass tags are parsed into entity type ids.
    *
@@ -287,6 +320,13 @@ class HelperTraitTestImplementation {
    */
   public ?DrupalDriverInterface $driver = NULL;
 
+  /**
+   * Records [type, id] pairs passed to the overridden entityCleanupDelete().
+   *
+   * @var array<int, array{0: string, 1: int|string}>
+   */
+  public array $deleted = [];
+
   public function callHelperLooksLikeCompoundCell(string $value): bool {
     return $this->helperLooksLikeCompoundCell($value);
   }
@@ -324,6 +364,25 @@ class HelperTraitTestImplementation {
    */
   public function getEntityRegistry(): array {
     return $this->entityRegistry;
+  }
+
+  /**
+   * Run the entity cleanup with the given skipped types.
+   *
+   * @param array<int, string> $skip_types
+   *   Entity type ids to leave in place.
+   */
+  public function callEntityCleanupRun(array $skip_types): void {
+    $this->entityCleanupRun($skip_types);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Overridden to record deletions instead of touching Drupal.
+   */
+  protected function entityCleanupDelete(string $entity_type_id, int|string $entity_id): void {
+    $this->deleted[] = [$entity_type_id, $entity_id];
   }
 
   public function getMinkParameter(string $name): mixed {

--- a/tests/phpunit/src/Drupal/HelperTraitTest.php
+++ b/tests/phpunit/src/Drupal/HelperTraitTest.php
@@ -51,6 +51,39 @@ class HelperTraitTest extends UnitTestCase {
     }
   }
 
+  public function testEntityRegisterId(): void {
+    $this->testObject->callEntityRegisterId('media', 7);
+    $this->testObject->callEntityRegisterId('block_content', 'custom_id');
+
+    $this->assertSame([['media', 7], ['block_content', 'custom_id']], $this->testObject->getEntityRegistry());
+  }
+
+  /**
+   * Tests that per-type cleanup bypass tags are parsed into entity type ids.
+   *
+   * @param array<int, string> $tags
+   *   Scenario tag names.
+   * @param array<int, string> $expected
+   *   Expected skipped entity type ids.
+   */
+  #[DataProvider('dataProviderEntityCleanupSkippedTypes')]
+  public function testEntityCleanupSkippedTypes(array $tags, array $expected): void {
+    $this->assertSame($expected, $this->testObject->callEntityCleanupSkippedTypes($tags));
+  }
+
+  public static function dataProviderEntityCleanupSkippedTypes(): array {
+    return [
+      'no tags' => [[], []],
+      'unrelated tags ignored' => [['api', 'behat-steps-skip:entityCleanupAfterScenario'], []],
+      'single type' => [['behat-steps-entity-cleanup-skip:media'], ['media']],
+      'multiple types' => [
+        ['api', 'behat-steps-entity-cleanup-skip:media', 'behat-steps-entity-cleanup-skip:block_content'],
+        ['media', 'block_content'],
+      ],
+      'empty value' => [['behat-steps-entity-cleanup-skip:'], ['']],
+    ];
+  }
+
   #[DataProvider('dataProviderLooksLikeCompoundCell')]
   public function testLooksLikeCompoundCell(string $value, bool $expected): void {
     $this->assertSame($expected, $this->testObject->callHelperLooksLikeCompoundCell($value));
@@ -264,6 +297,33 @@ class HelperTraitTestImplementation {
 
   public function callHelperExpandEntityFieldsFixtures(string $entity_type, EntityStubInterface $stub): void {
     $this->helperExpandEntityFieldsFixtures($entity_type, $stub);
+  }
+
+  public function callEntityRegisterId(string $entity_type_id, int|string $entity_id): void {
+    $this->entityRegisterId($entity_type_id, $entity_id);
+  }
+
+  /**
+   * Expose entityCleanupSkippedTypes() for testing.
+   *
+   * @param array<int, string> $tags
+   *   Scenario tag names.
+   *
+   * @return array<int, string>
+   *   Entity type ids to skip.
+   */
+  public function callEntityCleanupSkippedTypes(array $tags): array {
+    return $this->entityCleanupSkippedTypes($tags);
+  }
+
+  /**
+   * Expose the entity registry for testing.
+   *
+   * @return array<int, array{0: string, 1: int|string}>
+   *   The registered entities.
+   */
+  public function getEntityRegistry(): array {
+    return $this->entityRegistry;
   }
 
   public function getMinkParameter(string $name): mixed {


### PR DESCRIPTION
Closes #677

## Summary

Adds a shared per-scenario entity registry to `HelperTrait` (Drupal) that centralises cleanup of Drupal entities created during Behat scenarios. Instead of each direct-API creation trait maintaining its own registry property, its own `#[AfterScenario]` hook, and its own skip tag, entities are registered into one array and deleted in reverse creation order by a single hook.

## Changes

- `src/Drupal/HelperTrait.php`: adds `entityRegister(EntityInterface)` and `entityRegisterId(string $type, int|string $id)` to record `[type, id]` pairs in a new `$entityRegistry` array, and a single `#[AfterScenario('@api')] entityCleanupAfterScenario()` hook that reloads each registered entity by id and deletes it in reverse creation order, tolerating entities already deleted elsewhere in the scenario.
- A hard-coded `ENTITY_CLEANUP_EXCLUDED_TYPES` list (`node`, `user`, `taxonomy_term`, `user_role`, `language`, `configurable_language`) stops the hook from double-deleting entities the base Drupal Extension already cleans up.
- Two bypass tags: `@behat-steps-skip:entityCleanupAfterScenario` skips cleanup entirely for a scenario; `@behat-steps-entity-cleanup-skip:ENTITY_TYPE_ID` skips one entity type and can be repeated for several types.
- Retrofits 9 creation traits to call `entityRegister()` / `entityRegisterId()` and removes their individual registry property and `#[AfterScenario]` hook: `MediaTrait`, `FileTrait` (managed files only - its `fileAfterScenario` hook still handles unmanaged files), `ParagraphsTrait`, `ContentBlockTrait`, `EckTrait`, `MenuTrait` (menus and menu links), `RedirectTrait`, `BlockTrait`, `WebformTrait`.
- `RedirectTrait` and `BlockTrait` also drop manual registry-pruning from their delete steps, since the shared hook's reload-and-tolerate approach already handles entities deleted mid-scenario.
- Node, user, taxonomy term, and role creation is untouched - it remains the responsibility of the base Drupal Extension's own cleanup.
- `docs.php`: registers the new `behat-steps-entity-cleanup-skip` parametrized tag.
- `tests/behat/features/drupal_entity_cleanup.feature` (new): paired scenarios that prove auto-cleanup, the global skip tag, and the per-type skip tag, relying on Behat's file-order execution - one scenario creates an entity, the next asserts whether it survived teardown.
- `tests/phpunit/src/Drupal/HelperTraitTest.php`: unit tests for `entityRegisterId()` and `entityCleanupSkippedTypes()`.
- `drupal_block.feature`, `drupal_content_block.feature`, `drupal_eck.feature`: migrated from the removed per-trait skip tags to the new per-type tag.
- `MIGRATION.md` (new): maps each removed skip tag to its replacement.
- `README.md`: documents the cleanup mechanism and its two bypass tags.
- `STEPS.md`: regenerated.

### Breaking change

The per-trait cleanup skip tags are removed: `@behat-steps-skip:mediaAfterScenario`, `:contentBlockAfterScenario`, `:eckAfterScenario`, `:menuAfterScenario`, `:redirectAfterScenario`, `:blockAfterScenario`, `:webformAfterScenario`, `:paragraphsAfterScenario`. See `MIGRATION.md` for the replacement tag for each.

## Before / After

```
BEFORE: one registry, one hook and one skip tag per trait

┌────────────────────────────────────────────┐
│ XTrait                                     │
├────────────────────────────────────────────┤
│ $xEntities (own array property)            │
│ xAfterScenario() #[AfterScenario('@api')]  │
│  - deletes everything in $xEntities        │
│ skip tag: @behat-steps-skip:xAfterScenario │
└────────────────────────────────────────────┘

  same shape repeated independently in: MediaTrait, FileTrait,
  ParagraphsTrait, ContentBlockTrait, EckTrait, MenuTrait, RedirectTrait,
  BlockTrait, WebformTrait


AFTER: one shared registry and one hook, fed by every creation trait

┌────────────────────────────────────────────────────────┐
│ HelperTrait (DrevOps\BehatSteps\Drupal)                │
├────────────────────────────────────────────────────────┤
│ $entityRegistry (one shared array property)            │
├────────────────────────────────────────────────────────┤
│ entityRegister($entity)                                │
│ entityRegisterId($type, $id)                           │
├────────────────────────────────────────────────────────┤
│ entityCleanupAfterScenario() #[AfterScenario('@api')]  │
│  - deletes $entityRegistry in reverse creation order   │
│  - reloads each entity by id, tolerates pre-deletion   │
│  - excludes node, user, taxonomy_term, user_role,      │
│    language, configurable_language                     │
├────────────────────────────────────────────────────────┤
│ skip all: @behat-steps-skip:entityCleanupAfterScenario │
│ skip type: @behat-steps-entity-cleanup-skip:TYPE       │
└────────────────────────────────────────────────────────┘
               ▲
               │ entityRegister() / entityRegisterId()
               │
  MediaTrait, FileTrait, ParagraphsTrait, ContentBlockTrait, EckTrait,
  MenuTrait, RedirectTrait, BlockTrait, WebformTrait
  (no own registry, no own hook, no own skip tag)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
This PR introduces a shared, per-scenario Drupal entity registry used by Behat step traits to ensure scenario-created entities are automatically cleaned up at teardown in **reverse creation order**. Cleanup is implemented once in `src/Drupal/HelperTrait.php` via a `#[AfterScenario('`@api`')]` hook that:
- records created entities centrally during the scenario,
- reloads entities by type/id before deletion, and
- tolerates entities that may have been deleted earlier in the scenario.

### Key behavior changes
- **Centralized cleanup:** Entity-creating traits now register created entities via `HelperTrait::entityRegister()` instead of maintaining their own static registries and trait-level `*AfterScenario` hooks.
- **Reverse-order deletion:** Entities recorded in the shared registry are deleted in reverse creation order.
- **Compatibility with base Drupal extension:** Cleanup excludes entity types already handled by the base Drupal Extension via `ENTITY_CLEANUP_EXCLUDED_TYPES`.
- **Bypass/skip tags:**
  - Global skip: `behat-steps-skip:entityCleanupAfterScenario`
  - Per-entity-type skip (repeatable): `@behat-steps-entity-cleanup-skip:<entity_type_id>`

### Traits updated to use the shared registry
Removed per-trait teardown logic and switched to registering entities for the shared cleanup:
- `MediaTrait`
- `FileTrait` (**managed files only** via registry; unmanaged files still cleaned up via unlinking tracked URIs)
- `ParagraphsTrait`
- `ContentBlockTrait`
- `EckTrait`
- `MenuTrait`
- `RedirectTrait`
- `BlockTrait`
- `WebformTrait`

### Documentation and tag validation updates
- Added `MIGRATION.md` documenting the new shared cleanup mechanism, removal/replacement of old per-trait cleanup skip tags, and the `FileTrait` managed vs unmanaged behavior.
- Updated `README.md` with an “Automatic entity cleanup” section and the new tag-based controls.
- Updated `STEPS.md` to reflect the new lifecycle wording and remove references to old per-trait skip tags.
- Extended `docs.php` tag validation to recognize the parametrized tag `@behat-steps-entity-cleanup-skip:<value>`.

### Tests
- Added `tests/behat/features/drupal_entity_cleanup.feature` to verify:
  - entities created in one scenario are removed after scenario teardown,
  - the global cleanup skip tag preserves all registered entities (requiring manual removal),
  - the per-type skip tag preserves only specified entity types (requiring manual removal).
- Updated existing feature files to use the new per-entity-type skip tags:
  - `tests/behat/features/drupal_block.feature`
  - `tests/behat/features/drupal_content_block.feature`
  - `tests/behat/features/drupal_eck.feature`
- Expanded `tests/phpunit/src/Drupal/HelperTraitTest.php` with coverage for entity registration and scenario skip-tag parsing.

### Critical: Step format guideline violations (per `CONTRIBUTING.md`)
The following feature steps use **`Given I ...`** and/or **`Then I ...`**, which conflicts with the documented steps format guidance (“Avoid using `Given I`” / “Avoid using `Then I`”):
- `tests/behat/features/drupal_content_block.feature`
  - `Given I am logged in ...`
- `tests/behat/features/drupal_block.feature`
  - `Then I should see ...`
  - `Then I should not see ...`
- `tests/behat/features/drupal_eck.feature`
  - `Given I am logged in ...`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->