### PR TITLE
[#676] Added 'ConfigTrait' for stored and effective Drupal config value steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ from the community.
 | [Drupal\BlockTrait](STEPS.md#drupalblocktrait) | Manage Drupal blocks. |
 | [Drupal\CacheTrait](STEPS.md#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
 | [Drupal\ConfigOverrideTrait](STEPS.md#drupalconfigoverridetrait) | Disable Drupal config overrides from settings.php during a scenario. |
+| [Drupal\ConfigTrait](STEPS.md#drupalconfigtrait) | Assert and set stored Drupal configuration values with automatic revert. |
 | [Drupal\ContentBlockTrait](STEPS.md#drupalcontentblocktrait) | Manage Drupal content blocks. |
 | [Drupal\ContentTrait](STEPS.md#drupalcontenttrait) | Manage Drupal content with workflow and moderation support. |
 | [Drupal\DraggableviewsTrait](STEPS.md#drupaldraggableviewstrait) | Order items in the Drupal Draggable Views. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -36,6 +36,7 @@
 | [Drupal\BlockTrait](#drupalblocktrait) | Manage Drupal blocks. |
 | [Drupal\CacheTrait](#drupalcachetrait) | Invalidate specific Drupal caches from within a scenario. |
 | [Drupal\ConfigOverrideTrait](#drupalconfigoverridetrait) | Disable Drupal config overrides from settings.php during a scenario. |
+| [Drupal\ConfigTrait](#drupalconfigtrait) | Assert and set stored Drupal configuration values with automatic revert. |
 | [Drupal\ContentBlockTrait](#drupalcontentblocktrait) | Manage Drupal content blocks. |
 | [Drupal\ContentTrait](#drupalcontenttrait) | Manage Drupal content with workflow and moderation support. |
 | [Drupal\DraggableviewsTrait](#drupaldraggableviewstrait) | Order items in the Drupal Draggable Views. |
@@ -3638,6 +3639,187 @@ Given the render cache has been cleared
 >  Skip processing with tags: `@behat-steps-skip:configOverrideBeforeScenario`
 >  and `@behat-steps-skip:configOverrideBeforeStep`.
 
+
+## Drupal\ConfigTrait
+
+[Source](src/Drupal/ConfigTrait.php), [Example](tests/behat/features/drupal_config.feature)
+
+>  Assert and set stored Drupal configuration values with automatic revert.
+>  <br/><br/>
+>  Set a configuration value for test setup and assert that a configuration
+>  object's key holds, or contains, an expected value. Nested keys are
+>  addressable with dotted notation (for example `page.front`).
+>  <br/><br/>
+>  Two families of assertions read the value differently:
+>  - The default steps read the STORED value via editable configuration,
+>  ignoring `settings.php` overrides. This is symmetric with the set steps
+>  and is what most setup-and-assert scenarios need.
+>  - The `effective` steps read the value through the config factory with
+>  module and `settings.php` overrides applied - the value the running site
+>  actually uses.
+>  <br/><br/>
+>  Values are compared by their stringified form, so `true`, `42` and JSON
+>  arrays written in a step match their typed configuration counterparts. The
+>  `contain` steps match a substring for string values and membership for
+>  array values, searched recursively.
+>  <br/><br/>
+>  Configuration objects touched by the set steps are snapshotted on first
+>  write and restored after the scenario: an existing object is reset to its
+>  original data and an object that did not exist is deleted. Skip the revert
+>  with `@behat-steps-skip:configAfterScenario` or `@behat-steps-skip:ConfigTrait`.
+>  <br/><br/>
+>  ```
+>  @api
+>  Scenario: Assert configured values
+>    Given the config "mymodule.settings" key "api.endpoint" has the value "https://api.example.com"
+>    Then the config "mymodule.settings" key "api.endpoint" should have the value "https://api.example.com"
+>    And the config "system.site" key "name" should have the effective value "My overridden site"
+>  ```
+
+
+<details>
+  <summary><code>@Given the config :name key :key has the value :value</code></summary>
+
+<br/>
+Set a stored Drupal configuration value
+<br/><br/>
+
+```gherkin
+Given the config "system.site" key "page.front" has the value "/node"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the following config values:</code></summary>
+
+<br/>
+Set multiple stored Drupal configuration values from a table
+<br/><br/>
+
+```gherkin
+Given the following config values:
+  | name              | key          | value                   |
+  | system.site       | name         | My site                 |
+  | mymodule.settings | api.endpoint | https://api.example.com |
+  | mymodule.settings | roles        | ["editor","reviewer"]   |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the config :name key :key should have the value :value</code></summary>
+
+<br/>
+Assert that a stored configuration value equals an expected value
+<br/><br/>
+
+```gherkin
+Then the config "system.site" key "name" should have the value "My site"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the config :name key :key should not have the value :value</code></summary>
+
+<br/>
+Assert that a stored configuration value does not equal a value
+<br/><br/>
+
+```gherkin
+Then the config "system.site" key "name" should not have the value "Wrong"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the config :name key :key should contain the value :value</code></summary>
+
+<br/>
+Assert that a stored configuration value contains an expected value
+<br/><br/>
+
+```gherkin
+Then the config "system.site" key "name" should contain the value "site"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the config :name key :key should not contain the value :value</code></summary>
+
+<br/>
+Assert that a stored configuration value does not contain a value
+<br/><br/>
+
+```gherkin
+Then the config "system.site" key "name" should not contain the value "xyz"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the config :name key :key should have the effective value :value</code></summary>
+
+<br/>
+Assert that an effective configuration value equals an expected value
+<br/><br/>
+
+```gherkin
+Then the config "system.site" key "name" should have the effective value "Overridden"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the config :name key :key should not have the effective value :value</code></summary>
+
+<br/>
+Assert that an effective configuration value does not equal a value
+<br/><br/>
+
+```gherkin
+Then the config "system.site" key "name" should not have the effective value "Wrong"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the config :name key :key should contain the effective value :value</code></summary>
+
+<br/>
+Assert that an effective configuration value contains an expected value
+<br/><br/>
+
+```gherkin
+Then the config "system.site" key "name" should contain the effective value "Over"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the config :name key :key should not contain the effective value :value</code></summary>
+
+<br/>
+Assert that an effective configuration value does not contain a value
+<br/><br/>
+
+```gherkin
+Then the config "system.site" key "name" should not contain the effective value "xyz"
+
+```
+
+</details>
 
 ## Drupal\ContentBlockTrait
 

--- a/src/Drupal/ConfigTrait.php
+++ b/src/Drupal/ConfigTrait.php
@@ -1,0 +1,478 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Drupal;
+
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Hook\AfterScenario;
+use Behat\Hook\BeforeScenario;
+use Behat\Step\Given;
+use Behat\Step\Then;
+
+/**
+ * Assert and set stored Drupal configuration values with automatic revert.
+ *
+ * Set a configuration value for test setup and assert that a configuration
+ * object's key holds, or contains, an expected value. Nested keys are
+ * addressable with dotted notation (for example `page.front`).
+ *
+ * Two families of assertions read the value differently:
+ * - The default steps read the STORED value via editable configuration,
+ *   ignoring `settings.php` overrides. This is symmetric with the set steps
+ *   and is what most setup-and-assert scenarios need.
+ * - The `effective` steps read the value through the config factory with
+ *   module and `settings.php` overrides applied - the value the running site
+ *   actually uses.
+ *
+ * Values are compared by their stringified form, so `true`, `42` and JSON
+ * arrays written in a step match their typed configuration counterparts. The
+ * `contain` steps match a substring for string values and membership for
+ * array values, searched recursively.
+ *
+ * Configuration objects touched by the set steps are snapshotted on first
+ * write and restored after the scenario: an existing object is reset to its
+ * original data and an object that did not exist is deleted. Skip the revert
+ * with `@behat-steps-skip:configAfterScenario` or `@behat-steps-skip:ConfigTrait`.
+ *
+ * @code
+ * @api
+ * Scenario: Assert configured values
+ *   Given the config "mymodule.settings" key "api.endpoint" has the value "https://api.example.com"
+ *   Then the config "mymodule.settings" key "api.endpoint" should have the value "https://api.example.com"
+ *   And the config "system.site" key "name" should have the effective value "My overridden site"
+ * @endcode
+ */
+trait ConfigTrait {
+
+  /**
+   * Original raw data of configuration objects touched during the scenario.
+   *
+   * Keyed by configuration name. Each entry records whether the object existed
+   * before the first write so that revert can delete objects created by the
+   * scenario rather than leaving empty shells behind.
+   *
+   * @var array<string, array{existed: bool, data: array<int|string, mixed>}>
+   */
+  protected array $configOriginalData = [];
+
+  /**
+   * Reset the snapshot registry before each scenario.
+   */
+  #[BeforeScenario('@api')]
+  public function configBeforeScenario(BeforeScenarioScope $scope): void {
+    $this->configOriginalData = [];
+  }
+
+  /**
+   * Revert every touched configuration object after the scenario finishes.
+   */
+  #[AfterScenario('@api')]
+  public function configAfterScenario(AfterScenarioScope $scope): void {
+    if (
+      $scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)
+      || $scope->getScenario()->hasTag('behat-steps-skip:ConfigTrait')
+    ) {
+      $this->configOriginalData = [];
+      return;
+    }
+
+    foreach ($this->configOriginalData as $name => $snapshot) {
+      $config = \Drupal::configFactory()->getEditable($name);
+      if ($snapshot['existed']) {
+        $config->setData($snapshot['data'])->save();
+      }
+      else {
+        $config->delete();
+      }
+    }
+
+    $this->configOriginalData = [];
+  }
+
+  /**
+   * Set a stored Drupal configuration value.
+   *
+   * @code
+   * Given the config "system.site" key "page.front" has the value "/node"
+   * @endcode
+   */
+  #[Given('the config :name key :key has the value :value')]
+  public function configSet(string $name, string $key, string $value): void {
+    $this->configSnapshot($name);
+    \Drupal::configFactory()->getEditable($name)->set($key, $this->configCastValue($value))->save();
+  }
+
+  /**
+   * Set multiple stored Drupal configuration values from a table.
+   *
+   * @code
+   * Given the following config values:
+   *   | name              | key          | value                   |
+   *   | system.site       | name         | My site                 |
+   *   | mymodule.settings | api.endpoint | https://api.example.com |
+   *   | mymodule.settings | roles        | ["editor","reviewer"]   |
+   * @endcode
+   */
+  #[Given('the following config values:')]
+  public function configSetMultiple(TableNode $table): void {
+    foreach ($table->getHash() as $row) {
+      if (!isset($row['name'], $row['key']) || !array_key_exists('value', $row)) {
+        throw new \RuntimeException('The config values table must contain "name", "key" and "value" columns.');
+      }
+
+      $this->configSnapshot($row['name']);
+      \Drupal::configFactory()->getEditable($row['name'])->set($row['key'], $this->configCastValue($row['value']))->save();
+    }
+  }
+
+  /**
+   * Assert that a stored configuration value equals an expected value.
+   *
+   * @code
+   * Then the config "system.site" key "name" should have the value "My site"
+   * @endcode
+   */
+  #[Then('the config :name key :key should have the value :value')]
+  public function configAssertValueEquals(string $name, string $key, string $value): void {
+    $this->configCompareEquals($this->configReadStored($name, $key), $value, TRUE, $name, $key, 'value');
+  }
+
+  /**
+   * Assert that a stored configuration value does not equal a value.
+   *
+   * @code
+   * Then the config "system.site" key "name" should not have the value "Wrong"
+   * @endcode
+   */
+  #[Then('the config :name key :key should not have the value :value')]
+  public function configAssertValueNotEquals(string $name, string $key, string $value): void {
+    $this->configCompareEquals($this->configReadStored($name, $key), $value, FALSE, $name, $key, 'value');
+  }
+
+  /**
+   * Assert that a stored configuration value contains an expected value.
+   *
+   * @code
+   * Then the config "system.site" key "name" should contain the value "site"
+   * @endcode
+   */
+  #[Then('the config :name key :key should contain the value :value')]
+  public function configAssertValueContains(string $name, string $key, string $value): void {
+    $this->configCompareContains($this->configReadStored($name, $key), $value, TRUE, $name, $key, 'value');
+  }
+
+  /**
+   * Assert that a stored configuration value does not contain a value.
+   *
+   * @code
+   * Then the config "system.site" key "name" should not contain the value "xyz"
+   * @endcode
+   */
+  #[Then('the config :name key :key should not contain the value :value')]
+  public function configAssertValueNotContains(string $name, string $key, string $value): void {
+    $this->configCompareContains($this->configReadStored($name, $key), $value, FALSE, $name, $key, 'value');
+  }
+
+  /**
+   * Assert that an effective configuration value equals an expected value.
+   *
+   * The effective value has module and `settings.php` overrides applied.
+   *
+   * @code
+   * Then the config "system.site" key "name" should have the effective value "Overridden"
+   * @endcode
+   */
+  #[Then('the config :name key :key should have the effective value :value')]
+  public function configAssertEffectiveValueEquals(string $name, string $key, string $value): void {
+    $this->configCompareEquals($this->configReadEffective($name, $key), $value, TRUE, $name, $key, 'effective value');
+  }
+
+  /**
+   * Assert that an effective configuration value does not equal a value.
+   *
+   * The effective value has module and `settings.php` overrides applied.
+   *
+   * @code
+   * Then the config "system.site" key "name" should not have the effective value "Wrong"
+   * @endcode
+   */
+  #[Then('the config :name key :key should not have the effective value :value')]
+  public function configAssertEffectiveValueNotEquals(string $name, string $key, string $value): void {
+    $this->configCompareEquals($this->configReadEffective($name, $key), $value, FALSE, $name, $key, 'effective value');
+  }
+
+  /**
+   * Assert that an effective configuration value contains an expected value.
+   *
+   * The effective value has module and `settings.php` overrides applied.
+   *
+   * @code
+   * Then the config "system.site" key "name" should contain the effective value "Over"
+   * @endcode
+   */
+  #[Then('the config :name key :key should contain the effective value :value')]
+  public function configAssertEffectiveValueContains(string $name, string $key, string $value): void {
+    $this->configCompareContains($this->configReadEffective($name, $key), $value, TRUE, $name, $key, 'effective value');
+  }
+
+  /**
+   * Assert that an effective configuration value does not contain a value.
+   *
+   * The effective value has module and `settings.php` overrides applied.
+   *
+   * @code
+   * Then the config "system.site" key "name" should not contain the effective value "xyz"
+   * @endcode
+   */
+  #[Then('the config :name key :key should not contain the effective value :value')]
+  public function configAssertEffectiveValueNotContains(string $name, string $key, string $value): void {
+    $this->configCompareContains($this->configReadEffective($name, $key), $value, FALSE, $name, $key, 'effective value');
+  }
+
+  /**
+   * Read a stored configuration value, ignoring runtime overrides.
+   *
+   * Editable configuration objects never carry module or `settings.php`
+   * overrides, so reading through one yields the value as saved.
+   *
+   * @param string $name
+   *   The configuration object name.
+   * @param string $key
+   *   The configuration key, using dotted notation for nested keys.
+   *
+   * @return mixed
+   *   The stored value, or NULL when the object or key does not exist.
+   */
+  protected function configReadStored(string $name, string $key): mixed {
+    return \Drupal::configFactory()->getEditable($name)->get($key);
+  }
+
+  /**
+   * Read an effective configuration value, with overrides applied.
+   *
+   * @param string $name
+   *   The configuration object name.
+   * @param string $key
+   *   The configuration key, using dotted notation for nested keys.
+   *
+   * @return mixed
+   *   The effective value, or NULL when the object or key does not exist.
+   */
+  protected function configReadEffective(string $name, string $key): mixed {
+    return \Drupal::config($name)->get($key);
+  }
+
+  /**
+   * Snapshot a configuration object's original data on first write.
+   *
+   * @param string $name
+   *   The configuration object name.
+   */
+  protected function configSnapshot(string $name): void {
+    if (array_key_exists($name, $this->configOriginalData)) {
+      return;
+    }
+
+    $config = \Drupal::configFactory()->getEditable($name);
+    $this->configOriginalData[$name] = [
+      'existed' => !$config->isNew(),
+      'data' => $config->getRawData(),
+    ];
+  }
+
+  /**
+   * Assert equality between an actual configuration value and an expected one.
+   *
+   * @param mixed $actual
+   *   The value read from configuration.
+   * @param string $expected
+   *   The expected value as written in the step.
+   * @param bool $should_match
+   *   TRUE to require equality, FALSE to require inequality.
+   * @param string $name
+   *   The configuration object name, for error messages.
+   * @param string $key
+   *   The configuration key, for error messages.
+   * @param string $descriptor
+   *   How the value is described in error messages ("value" or
+   *   "effective value").
+   */
+  protected function configCompareEquals(mixed $actual, string $expected, bool $should_match, string $name, string $key, string $descriptor): void {
+    $is_set = $actual !== NULL;
+    $actual_string = $this->configStringifyValue($actual);
+    $matches = $is_set && $actual_string === $expected;
+
+    if ($should_match) {
+      if (!$is_set) {
+        throw new \Exception(sprintf('The config "%s" key "%s" is not set, but it should have the %s "%s".', $name, $key, $descriptor, $expected));
+      }
+
+      if (!$matches) {
+        throw new \Exception(sprintf('The config "%s" key "%s" has the %s "%s", but it should have the %s "%s".', $name, $key, $descriptor, $actual_string, $descriptor, $expected));
+      }
+
+      return;
+    }
+
+    if ($matches) {
+      throw new \Exception(sprintf('The config "%s" key "%s" has the %s "%s", but it should not have the %s "%s".', $name, $key, $descriptor, $actual_string, $descriptor, $expected));
+    }
+  }
+
+  /**
+   * Assert containment between an actual configuration value and an expected one.
+   *
+   * @param mixed $actual
+   *   The value read from configuration.
+   * @param string $expected
+   *   The expected value as written in the step.
+   * @param bool $should_contain
+   *   TRUE to require containment, FALSE to require the absence of it.
+   * @param string $name
+   *   The configuration object name, for error messages.
+   * @param string $key
+   *   The configuration key, for error messages.
+   * @param string $descriptor
+   *   How the value is described in error messages ("value" or
+   *   "effective value").
+   */
+  protected function configCompareContains(mixed $actual, string $expected, bool $should_contain, string $name, string $key, string $descriptor): void {
+    $is_set = $actual !== NULL;
+    $contains = $is_set && $this->configValueContains($actual, $expected);
+    $actual_string = $this->configStringifyValue($actual);
+
+    if ($should_contain) {
+      if (!$is_set) {
+        throw new \Exception(sprintf('The config "%s" key "%s" is not set, but its %s should contain "%s".', $name, $key, $descriptor, $expected));
+      }
+
+      if (!$contains) {
+        throw new \Exception(sprintf('The config "%s" key "%s" has the %s "%s", which does not contain "%s".', $name, $key, $descriptor, $actual_string, $expected));
+      }
+
+      return;
+    }
+
+    if ($contains) {
+      throw new \Exception(sprintf('The config "%s" key "%s" has the %s "%s", which contains "%s" but should not.', $name, $key, $descriptor, $actual_string, $expected));
+    }
+  }
+
+  /**
+   * Determine whether a configuration value contains an expected value.
+   *
+   * A string or scalar value is matched by substring; an array value is
+   * matched by membership, comparing the stringified form of each scalar leaf
+   * and recursing into nested arrays.
+   *
+   * @param mixed $actual
+   *   The value read from configuration.
+   * @param string $expected
+   *   The expected value as written in the step.
+   *
+   * @return bool
+   *   TRUE when the value contains the expected value.
+   */
+  protected function configValueContains(mixed $actual, string $expected): bool {
+    if (is_array($actual)) {
+      return $this->configArrayContainsValue($actual, $expected);
+    }
+
+    return str_contains($this->configStringifyValue($actual), $expected);
+  }
+
+  /**
+   * Recursively determine whether an array holds an expected scalar value.
+   *
+   * @param array<int|string, mixed> $data
+   *   The array to search.
+   * @param string $expected
+   *   The expected value as written in the step.
+   *
+   * @return bool
+   *   TRUE when a scalar leaf stringifies to the expected value.
+   */
+  protected function configArrayContainsValue(array $data, string $expected): bool {
+    foreach ($data as $item) {
+      if (is_array($item)) {
+        if ($this->configArrayContainsValue($item, $expected)) {
+          return TRUE;
+        }
+      }
+      elseif ($this->configStringifyValue($item) === $expected) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Cast a string value from a step into the shape stored in configuration.
+   *
+   * @param string $value
+   *   The raw value captured from the step or table cell.
+   *
+   * @return mixed
+   *   The cast value: decoded JSON for array/object input, integer or float
+   *   for numeric input, boolean for "true"/"false", NULL for "null", or the
+   *   original string otherwise.
+   */
+  protected function configCastValue(string $value): mixed {
+    $trimmed = trim($value);
+
+    if ($trimmed === '') {
+      return $value;
+    }
+
+    $lower = strtolower($trimmed);
+    if ($lower === 'true') {
+      return TRUE;
+    }
+    if ($lower === 'false') {
+      return FALSE;
+    }
+    if ($lower === 'null') {
+      return NULL;
+    }
+
+    if ($trimmed[0] === '{' || $trimmed[0] === '[') {
+      $decoded = json_decode($trimmed, TRUE);
+      if (json_last_error() === JSON_ERROR_NONE) {
+        return $decoded;
+      }
+    }
+
+    if (is_numeric($trimmed)) {
+      return str_contains($trimmed, '.') ? (float) $trimmed : (int) $trimmed;
+    }
+
+    return $value;
+  }
+
+  /**
+   * Stringify a configuration value for comparison and error messages.
+   *
+   * @param mixed $value
+   *   The value to stringify.
+   *
+   * @return string
+   *   The stringified value.
+   */
+  protected function configStringifyValue(mixed $value): string {
+    if ($value === NULL) {
+      return 'NULL';
+    }
+    if (is_bool($value)) {
+      return $value ? 'true' : 'false';
+    }
+    if (is_scalar($value)) {
+      return (string) $value;
+    }
+    return (string) json_encode($value);
+  }
+
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -18,6 +18,7 @@ use DrevOps\BehatSteps\Drupal\BigPipeTrait;
 use DrevOps\BehatSteps\Drupal\BlockTrait;
 use DrevOps\BehatSteps\Drupal\CacheTrait;
 use DrevOps\BehatSteps\Drupal\ConfigOverrideTrait;
+use DrevOps\BehatSteps\Drupal\ConfigTrait;
 use DrevOps\BehatSteps\Drupal\ContentBlockTrait;
 use DrevOps\BehatSteps\Drupal\ContentTrait;
 use DrevOps\BehatSteps\Drupal\DraggableviewsTrait;
@@ -72,6 +73,7 @@ class FeatureContext extends DrupalContext {
   use CacheTrait;
   use CommandTrait;
   use ConfigOverrideTrait;
+  use ConfigTrait;
   use ContentBlockTrait;
   use ContentTrait;
   use CookieTrait;

--- a/tests/behat/features/drupal_config.feature
+++ b/tests/behat/features/drupal_config.feature
@@ -1,0 +1,214 @@
+@config
+Feature: Check that ConfigTrait works
+  As Behat Steps library developer
+  I want to provide tools to set and assert Drupal configuration values
+  So that users can assert stored and effective config during tests with automatic revert
+
+  @api
+  Scenario: Set and assert a stored string config value
+    Given the config "behat_steps_test.settings" key "endpoint" has the value "https://api.example.com"
+    Then the config "behat_steps_test.settings" key "endpoint" should have the value "https://api.example.com"
+
+  @api
+  Scenario: Set and assert a stored nested (dotted) config value
+    Given the config "behat_steps_test.settings" key "api.endpoint" has the value "https://nested.example.com"
+    Then the config "behat_steps_test.settings" key "api.endpoint" should have the value "https://nested.example.com"
+
+  @api
+  Scenario: Set multiple config values of different types from a table
+    Given the following config values:
+      | name                   | key      | value           |
+      | behat_steps_test.types | enabled  | true            |
+      | behat_steps_test.types | disabled | false           |
+      | behat_steps_test.types | count    | 30              |
+      | behat_steps_test.types | ratio    | 1.5             |
+      | behat_steps_test.types | label    | hello world     |
+      | behat_steps_test.types | tags     | ["a","b","c"]   |
+      | behat_steps_test.types | map      | {"k":"v"}       |
+      | behat_steps_test.types | nested   | {"a":["x","y"]} |
+      | behat_steps_test.types | empty    |                 |
+      | behat_steps_test.types | broken   | [a,b]           |
+    Then the config "behat_steps_test.types" key "enabled" should have the value "true"
+    And the config "behat_steps_test.types" key "disabled" should have the value "false"
+    And the config "behat_steps_test.types" key "count" should have the value "30"
+    And the config "behat_steps_test.types" key "ratio" should have the value "1.5"
+    And the config "behat_steps_test.types" key "label" should have the value "hello world"
+    And the config "behat_steps_test.types" key "tags" should contain the value "b"
+    And the config "behat_steps_test.types" key "map" should contain the value "v"
+    And the config "behat_steps_test.types" key "nested" should contain the value "y"
+    And the config "behat_steps_test.types" key "nested" should not contain the value "z"
+    And the config "behat_steps_test.types" key "empty" should have the value ""
+    And the config "behat_steps_test.types" key "broken" should have the value "[a,b]"
+
+  @api
+  Scenario: Assert stored string containment and its negations
+    Given the config "behat_steps_test.settings" key "endpoint" has the value "https://api.example.com/v2"
+    Then the config "behat_steps_test.settings" key "endpoint" should contain the value "example.com"
+    And the config "behat_steps_test.settings" key "endpoint" should not contain the value "other.org"
+    And the config "behat_steps_test.settings" key "endpoint" should not have the value "https://api.example.com"
+
+  @api
+  Scenario: Assert stored array membership and its negation
+    Given the following config values:
+      | name                 | key   | value                 |
+      | behat_steps_test.arr | roles | ["editor","reviewer"] |
+    Then the config "behat_steps_test.arr" key "roles" should contain the value "editor"
+    And the config "behat_steps_test.arr" key "roles" should not contain the value "admin"
+
+  @api
+  Scenario: Assert an unset stored config key neither has nor contains a value
+    Then the config "behat_steps_test.settings" key "missing" should not have the value "anything"
+    And the config "behat_steps_test.settings" key "missing" should not contain the value "anything"
+
+  @api
+  Scenario: Setting a config value to null leaves the key unset
+    Given the config "behat_steps_test.settings" key "cleared" has the value "null"
+    Then the config "behat_steps_test.settings" key "cleared" should not have the value "null"
+
+  @api
+  Scenario: Stored assertion reads the saved value ignoring settings.php overrides
+    Then the config "system.site" key "name" should have the value "Drush Site-Install"
+    And the config "system.site" key "name" should contain the value "Drush"
+
+  @api
+  Scenario: Effective assertion reads the settings.php-overridden value
+    Then the config "system.site" key "name" should have the effective value "Overridden Site Name"
+    And the config "system.site" key "name" should contain the effective value "Overridden"
+
+  @api
+  Scenario: Stored and effective values differ for an overridden key
+    Then the config "system.site" key "name" should have the value "Drush Site-Install"
+    And the config "system.site" key "name" should not have the value "Overridden Site Name"
+    And the config "system.site" key "name" should have the effective value "Overridden Site Name"
+    And the config "system.site" key "name" should not have the effective value "Drush Site-Install"
+    And the config "system.site" key "name" should not contain the effective value "Drush"
+
+  # Setup scenario: store a known value so the next scenario can prove it got
+  # reverted automatically. The AfterScenario hook is skipped here so the value
+  # persists into the following scenario.
+  @api @behat-steps-skip:configAfterScenario
+  Scenario: Seed a config value without auto-revert
+    Given the config "behat_steps_test.persistent" key "flag" has the value "seeded"
+    Then the config "behat_steps_test.persistent" key "flag" should have the value "seeded"
+
+  @api
+  Scenario: Config values are reverted after scenario
+    Given the config "behat_steps_test.persistent" key "flag" has the value "overridden"
+    Then the config "behat_steps_test.persistent" key "flag" should have the value "overridden"
+
+  @api
+  Scenario: Verify previous scenario config change was reverted to the seeded value
+    Then the config "behat_steps_test.persistent" key "flag" should have the value "seeded"
+
+  @api
+  Scenario: A newly created config object is set during the scenario
+    Given the config "behat_steps_test.ephemeral" key "foo" has the value "bar"
+    Then the config "behat_steps_test.ephemeral" key "foo" should have the value "bar"
+
+  @api
+  Scenario: Verify the new config object was deleted by the previous revert
+    Then the config "behat_steps_test.ephemeral" key "foo" should not have the value "bar"
+
+  @api @trait:Drupal\ConfigTrait
+  Scenario: Negative assertion for "should have the value" fails on value mismatch
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the config "behat_steps_test.settings" key "endpoint" has the value "https://a.example.com"
+      Then the config "behat_steps_test.settings" key "endpoint" should have the value "https://b.example.com"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The config "behat_steps_test.settings" key "endpoint" has the value "https://a.example.com", but it should have the value "https://b.example.com".
+      """
+
+  @api @trait:Drupal\ConfigTrait
+  Scenario: Negative assertion for "should have the value" fails when the key is not set
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      Then the config "behat_steps_test.absent" key "endpoint" should have the value "https://a.example.com"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The config "behat_steps_test.absent" key "endpoint" is not set, but it should have the value "https://a.example.com".
+      """
+
+  @api @trait:Drupal\ConfigTrait
+  Scenario: Negative assertion for "should not have the value" fails when it matches
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the config "behat_steps_test.settings" key "endpoint" has the value "https://a.example.com"
+      Then the config "behat_steps_test.settings" key "endpoint" should not have the value "https://a.example.com"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The config "behat_steps_test.settings" key "endpoint" has the value "https://a.example.com", but it should not have the value "https://a.example.com".
+      """
+
+  @api @trait:Drupal\ConfigTrait
+  Scenario: Negative assertion for "should contain the value" fails when the value is absent
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the config "behat_steps_test.settings" key "endpoint" has the value "https://a.example.com"
+      Then the config "behat_steps_test.settings" key "endpoint" should contain the value "zzz"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The config "behat_steps_test.settings" key "endpoint" has the value "https://a.example.com", which does not contain "zzz".
+      """
+
+  @api @trait:Drupal\ConfigTrait
+  Scenario: Negative assertion for "should contain the value" fails when the key is not set
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      Then the config "behat_steps_test.absent" key "endpoint" should contain the value "example"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The config "behat_steps_test.absent" key "endpoint" is not set, but its value should contain "example".
+      """
+
+  @api @trait:Drupal\ConfigTrait
+  Scenario: Negative assertion for "should not contain the value" fails when the value is present
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the config "behat_steps_test.settings" key "endpoint" has the value "https://a.example.com"
+      Then the config "behat_steps_test.settings" key "endpoint" should not contain the value "example"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The config "behat_steps_test.settings" key "endpoint" has the value "https://a.example.com", which contains "example" but should not.
+      """
+
+  @api @trait:Drupal\ConfigTrait
+  Scenario: A config values table missing the value column fails with an exception
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I go to "/"
+      And the following config values:
+        | name                      | key    |
+        | behat_steps_test.settings | broken |
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      The config values table must contain "name", "key" and "value" columns.
+      """


### PR DESCRIPTION
Closes #676

## Summary

Adds `ConfigTrait`, a Drupal Behat trait exposing Gherkin steps to set and assert Drupal configuration values, with automatic per-scenario revert. Two assertion families read the value differently: the default STORED steps read via editable configuration, ignoring `settings.php` overrides, symmetric with the set steps; the EFFECTIVE steps read through the config factory with module and `settings.php` overrides applied, i.e. the value the running site actually uses. Each family covers equals and contains assertions plus their negatives, and values can be set individually or from a table. Configuration objects touched by a set step are snapshotted on first write and reverted after the scenario, so config changes never leak between scenarios.

## Changes

- New `src/Drupal/ConfigTrait.php`:
  - Set steps write to stored (editable) config: `the config :name key :key has the value :value` (single) and `the following config values:` (table). `configCastValue()` casts the raw string from the step into bool/int/float/null/decoded-JSON-array/string depending on its content.
  - Eight assertion steps: `should have` / `should not have` / `should contain` / `should not contain the value` (STORED, via `getEditable()->get()`) and the same four suffixed `effective value` (via `\Drupal::config()->get()`, overrides applied). Nested keys use dotted notation (e.g. `page.front`); values are compared via their stringified form (`configStringifyValue()`); `contain` does substring matching for scalars and recursive membership matching for arrays (`configValueContains()` / `configArrayContainsValue()`).
  - `#[BeforeScenario('@api')]` resets a `$configOriginalData` snapshot registry; `#[AfterScenario('@api')]` reverts every touched config object - resetting ones that existed, deleting ones the scenario created - unless the scenario carries `@behat-steps-skip:configAfterScenario` or `@behat-steps-skip:ConfigTrait`.
- `tests/behat/bootstrap/FeatureContext.php`: imports and registers `ConfigTrait` alongside the other Drupal traits.
- `tests/behat/features/drupal_config.feature`: 22 scenarios covering value-type casting (bool/int/float/string/JSON array/object/nested array/malformed JSON/empty/null-clears-key), stored-vs-effective divergence against a `settings.php`-overridden `system.site.name`, unset-key behaviour, three chained scenarios proving auto-revert (seed without revert, override, verify reverted) plus cleanup of a scenario-created object, and `@trait:Drupal\ConfigTrait` behat-in-behat scenarios asserting the exact failure message for each of the four stored assertions and for the table-validation exception.
- `STEPS.md` / `README.md`: regenerated via `docs.php` to catalogue the new trait and its 10 steps.

## Before / After

```
BEFORE: no Gherkin vocabulary for config values - drop into custom PHP

┌─────────────────────────────────────────────────────┐
│ Feature file                                        │
│   Given ...  (no built-in step exists)              │
│                                                     │
│ Custom PHP (hand-rolled per project)                │
│   Drupal::configFactory()->getEditable($name)       │
│     ->set($key, $value)->save();                    │
│                                                     │
│   no revert - leaks into later scenarios unless the │
│   project remembers to write its own teardown       │
└─────────────────────────────────────────────────────┘


AFTER: ConfigTrait - stored + effective assertions, auto-revert built in

┌───────────────────────────────────────────────────────────────┐
│ ConfigTrait (DrevOps\BehatSteps\Drupal)                       │
├───────────────────────────────────────────────────────────────┤
│ Set (always writes stored/editable config):                   │
│   the config :name key :key has the value :value              │
│   the following config values: | name | key | value |         │
├───────────────────────────────────────────────────────────────┤
│ Assert STORED - getEditable(), ignores settings.php:          │
│   should have / should not have the value                     │
│   should contain / should not contain the value               │
├───────────────────────────────────────────────────────────────┤
│ Assert EFFECTIVE - config factory, overrides applied:         │
│   should have / should not have the effective value           │
│   should contain / should not contain the effective value     │
├───────────────────────────────────────────────────────────────┤
│ BeforeScenario: snapshot object on first write                │
│ AfterScenario:  revert (reset existing / delete new)          │
│   skip: @behat-steps-skip:configAfterScenario or :ConfigTrait │
└───────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds `ConfigTrait` for Drupal config setup and assertions with automatic per-scenario revert.

- New `Given` steps set stored config values individually or from a table, with dotted nested keys and basic type casting.
- New `Then` steps assert stored config values and effective values, with equality and contains checks plus negated forms.
- Touched config objects are snapshotted on first write and restored or deleted after the scenario, with skip support via trait-specific tags.
- Added BDD coverage for setting, asserting, revert behavior, overrides, and failure cases.
- Registered the trait in `FeatureContext.php` and regenerated docs in `STEPS.md` and `README.md`.

No CONTRIBUTING.md step-format violations found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->