### PR TITLE
[#205] Added selenium-less headless Chrome driver for JavaScript steps.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,26 +191,6 @@ jobs:
         run: ahoy test-bdd
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
-      # Wait for the headless Chrome DevTools endpoint to accept connections
-      # before driving it: depends_on only guarantees the container started,
-      # not that Chrome is listening on the remote debugging port yet. Any HTTP
-      # response means the server is up: a raw request is answered with a
-      # DNS-rebinding 500 (the driver resolves the host to an IP to pass that
-      # check), so -f is intentionally omitted and any response counts as ready.
-      - name: Wait for the chrome_headless CDP endpoint
-        if: "matrix.driver == 'chrome_headless'"
-        run: |
-          for i in $(seq 1 30); do
-            if docker compose exec -T cli curl -sS -m 2 http://chrome_headless:9222/json/version >/dev/null 2>&1; then
-              echo "Chrome DevTools endpoint is ready."
-              exit 0
-            fi
-            echo "Waiting for Chrome DevTools endpoint ($i/30)..."
-            sleep 2
-          done
-          echo "Chrome DevTools endpoint did not become ready in time." >&2
-          exit 1
-
       # Selenium-less leg: the same BDD suite driven through headless Chrome
       # over the DevTools Protocol, proving the steps work without Selenium.
       # The Drupal 11 leg runs with coverage so the driver-specific branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
-          name: test-artifacts-php${{ matrix.php_version }}-drupal${{ matrix.drupal_version }}-${{ matrix.deps }}
+          name: test-artifacts-php${{ matrix.php_version }}-drupal${{ matrix.drupal_version }}-${{ matrix.deps }}${{ matrix.driver && format('-{0}', matrix.driver) || '' }}
           path: .logs
           include-hidden-files: true
           retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         continue-on-error: ${{ vars.CI_LINT_DOCS_IGNORE_FAILURE == '1' }}
 
   test:
-    name: Test PHP ${{ matrix.php_version }}, Drupal ${{ matrix.drupal_version }}, Deps ${{ matrix.deps }}
+    name: Test PHP ${{ matrix.php_version }}, Drupal ${{ matrix.drupal_version }}, Deps ${{ matrix.deps }}${{ matrix.driver && format(', Driver {0}', matrix.driver) || '' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,18 @@ jobs:
           - php_version: '8.4'
             drupal_version: '11'
             deps: 'lowest'
+          # Selenium-less driver legs: run the same suite through headless
+          # Chrome over the DevTools Protocol to prove the steps are driver
+          # portable. The browser driver is Drupal-version independent, so a
+          # single normal-deps leg per Drupal version is enough.
+          - php_version: '8.3'
+            drupal_version: '10'
+            deps: 'normal'
+            driver: 'chrome_headless'
+          - php_version: '8.3'
+            drupal_version: '11'
+            deps: 'normal'
+            driver: 'chrome_headless'
 
     container:
       image: drevops/ci-runner:26.6.0@sha256:190027056cac7b7ce28c29a1e5494779ebadc4ee8e95d468b75bc56e7be5aabd
@@ -160,23 +172,30 @@ jobs:
           ahoy --version
 
       - name: Run Unit tests with coverage
-        if: matrix.php_version == '8.3' && matrix.drupal_version == '11' && matrix.deps == 'normal'
+        if: "matrix.driver != 'chrome_headless' && matrix.php_version == '8.3' && matrix.drupal_version == '11' && matrix.deps == 'normal'"
         run: ahoy test-unit-coverage
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
       - name: Run Unit tests
-        if: "!(matrix.php_version == '8.3' && matrix.drupal_version == '11' && matrix.deps == 'normal')"
+        if: "matrix.driver != 'chrome_headless' && !(matrix.php_version == '8.3' && matrix.drupal_version == '11' && matrix.deps == 'normal')"
         run: ahoy test-unit
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
       - name: Run BDD tests with coverage
-        if: matrix.php_version == '8.3' && matrix.drupal_version == '11' && matrix.deps == 'normal'
+        if: "matrix.driver != 'chrome_headless' && matrix.php_version == '8.3' && matrix.drupal_version == '11' && matrix.deps == 'normal'"
         run: ahoy test-bdd-coverage
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
       - name: Run BDD tests
-        if: "!(matrix.php_version == '8.3' && matrix.drupal_version == '11' && matrix.deps == 'normal')"
+        if: "matrix.driver != 'chrome_headless' && !(matrix.php_version == '8.3' && matrix.drupal_version == '11' && matrix.deps == 'normal')"
         run: ahoy test-bdd
+        continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
+
+      # Selenium-less leg: the same BDD suite driven through headless Chrome
+      # over the DevTools Protocol, proving the steps work without Selenium.
+      - name: Run BDD tests with the chrome_headless driver
+        if: "matrix.driver == 'chrome_headless'"
+        run: ahoy test-bdd -- -p chrome_headless
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
       - name: Process test logs and artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,23 @@ jobs:
         run: ahoy test-bdd
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
+      # Wait for the headless Chrome DevTools endpoint to accept connections
+      # before driving it: depends_on only guarantees the container started,
+      # not that Chrome is listening on the remote debugging port yet.
+      - name: Wait for the chrome_headless CDP endpoint
+        if: "matrix.driver == 'chrome_headless'"
+        run: |
+          for i in $(seq 1 30); do
+            if docker compose exec -T cli curl -sSf -m 2 http://chrome_headless:9222/json/version >/dev/null 2>&1; then
+              echo "Chrome DevTools endpoint is ready."
+              exit 0
+            fi
+            echo "Waiting for Chrome DevTools endpoint ($i/30)..."
+            sleep 2
+          done
+          echo "Chrome DevTools endpoint did not become ready in time." >&2
+          exit 1
+
       # Selenium-less leg: the same BDD suite driven through headless Chrome
       # over the DevTools Protocol, proving the steps work without Selenium.
       # The Drupal 11 leg runs with coverage so the driver-specific branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,8 +193,16 @@ jobs:
 
       # Selenium-less leg: the same BDD suite driven through headless Chrome
       # over the DevTools Protocol, proving the steps work without Selenium.
+      # The Drupal 11 leg runs with coverage so the driver-specific branches
+      # (reachable only through chrome-mink) are measured and merged into the
+      # Codecov report alongside the Selenium2 coverage.
+      - name: Run BDD tests with coverage with the chrome_headless driver
+        if: "matrix.driver == 'chrome_headless' && matrix.drupal_version == '11'"
+        run: ahoy test-bdd-coverage -- -p chrome_headless
+        continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
+
       - name: Run BDD tests with the chrome_headless driver
-        if: "matrix.driver == 'chrome_headless'"
+        if: "matrix.driver == 'chrome_headless' && matrix.drupal_version != '11'"
         run: ahoy test-bdd -- -p chrome_headless
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,12 +193,15 @@ jobs:
 
       # Wait for the headless Chrome DevTools endpoint to accept connections
       # before driving it: depends_on only guarantees the container started,
-      # not that Chrome is listening on the remote debugging port yet.
+      # not that Chrome is listening on the remote debugging port yet. Any HTTP
+      # response means the server is up: a raw request is answered with a
+      # DNS-rebinding 500 (the driver resolves the host to an IP to pass that
+      # check), so -f is intentionally omitted and any response counts as ready.
       - name: Wait for the chrome_headless CDP endpoint
         if: "matrix.driver == 'chrome_headless'"
         run: |
           for i in $(seq 1 30); do
-            if docker compose exec -T cli curl -sSf -m 2 http://chrome_headless:9222/json/version >/dev/null 2>&1; then
+            if docker compose exec -T cli curl -sS -m 2 http://chrome_headless:9222/json/version >/dev/null 2>&1; then
               echo "Chrome DevTools endpoint is ready."
               exit 0
             fi

--- a/README.md
+++ b/README.md
@@ -137,6 +137,34 @@ class FeatureContext extends DrupalContext {
 Ensure that your [`behat.yml`](behat.yml) has all the required extensions
 enabled.
 
+### JavaScript drivers
+
+Steps that require a real browser (used by scenarios tagged `@javascript`) are
+driver agnostic: they work with a Selenium/WebDriver driver and with
+selenium-less drivers that talk to Chrome directly over the Chrome DevTools
+Protocol. Both are exercised by this library's own CI.
+
+To run `@javascript` scenarios without a Selenium server, add
+[`dmore/behat-chrome-extension`](https://gitlab.com/behat-chrome/behat-chrome-extension)
+(which pulls in `dmore/chrome-mink-driver`) and point it at a headless Chrome:
+
+```yaml
+default:
+  extensions:
+    DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
+    Behat\MinkExtension:
+      browser_name: chrome
+      javascript_session: chrome
+      chrome:
+        api_url: 'http://chrome:9222'
+```
+
+Any image that exposes a DevTools endpoint works (for example
+[`chromedp/headless-shell`](https://hub.docker.com/r/chromedp/headless-shell)).
+For local visual debugging you can override `api_url` at runtime via Behat's
+`BEHAT_PARAMS` environment variable - for instance to drive a headed Chrome on
+your host - as long as that browser can reach your site's `base_url`.
+
 ### Exceptions
 
 This library uses [Mink exception classes](https://mink.behat.org/en/latest/)

--- a/behat.yml
+++ b/behat.yml
@@ -93,3 +93,15 @@ default:
           target: '%paths.base%/.logs/coverage/behat/cobertura.xml'
         php:
           target: '%paths.base%/.logs/coverage/behat/phpcov.php'
+
+# Selenium-less profile: drives headless Chrome directly over the DevTools
+# Protocol (no Selenium server). Run with "behat -p chrome_headless". Inherits
+# all configuration from the "default" profile and only swaps the JavaScript
+# session to the "chrome" driver (the session name registered by ChromeExtension).
+chrome_headless:
+  extensions:
+    DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
+    Drupal\MinkExtension:
+      javascript_session: chrome
+      chrome:
+        api_url: 'http://chrome_headless:9222'

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php": ">=8.2",
         "behat/behat": "^3.14",
         "behat/mink": ">=1.11",
+        "dmore/behat-chrome-extension": "^1.4",
         "drupal/drupal-extension": "^6.0",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "softcreatr/jsonpath": "^0.10 || ^1.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,8 @@ services:
     depends_on:
       - cli
       - mariadb
-    command: mariadb:3306
+      - chrome_headless
+    command: mariadb:3306 chrome_headless:9222
 
 networks:           ### Use external networks locally. Automatically removed in CI.
   amazeeio-network: ### Automatically removed in CI.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,14 @@ services:
     depends_on:
       - cli
 
+  chrome_headless:
+    image: chromedp/headless-shell:150.0.7871.47
+    shm_size: '1gb'
+    expose:
+      - "9222"
+    depends_on:
+      - cli
+
   # Helper container to wait for services to become available.
   wait_dependencies:
     image: drevops/docker-wait-for-dependencies:26.1.0

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -465,7 +465,10 @@ trait AccessibilityTrait {
     ));
 
     $session->wait(30000, 'window.__accessibilityResults !== null');
-    $results = $session->evaluateScript('return window.__accessibilityResults;');
+    // Serialize to a JSON string in the browser rather than returning the raw
+    // object: the result graph is large and nested, and some drivers (e.g.
+    // chrome-mink) cannot walk every property when marshalling a live object.
+    $results = json_decode((string) $session->evaluateScript('return JSON.stringify(window.__accessibilityResults);'), TRUE);
 
     if (!is_array($results)) {
       throw new \RuntimeException('Accessibility engine did not return results.');

--- a/src/CookieTrait.php
+++ b/src/CookieTrait.php
@@ -271,6 +271,18 @@ trait CookieTrait {
       });
     }
 
+    // CDP-based drivers like the Chrome (chrome-mink) driver.
+    elseif (method_exists($driver, 'getCookies')) {
+      $cookies = [];
+      foreach ($driver->getCookies() as $cookie) {
+        $cookies[] = [
+          'name' => $cookie['name'],
+          'value' => rawurldecode((string) $cookie['value']),
+          'secure' => $cookie['secure'],
+        ];
+      }
+    }
+
     // BrowserKit-based drivers like GoutteDriver.
     elseif (method_exists($driver, 'getClient')) {
       /** @var \Symfony\Component\BrowserKit\CookieJar $cookie_jar */

--- a/src/DropzoneTrait.php
+++ b/src/DropzoneTrait.php
@@ -83,6 +83,7 @@ trait DropzoneTrait {
           var input = document.createElement('input');
           input.type = 'file';
           input.id = ids[i];
+          input.name = ids[i];
           input.style.position = 'fixed';
           input.style.left = '-9999px';
           input.style.opacity = '0';

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -12,7 +12,6 @@ use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
@@ -87,12 +86,24 @@ trait FileDownloadTrait {
 
     /** @var \Behat\Mink\Driver\CoreDriver $driver */
     $driver = $this->getSession()->getDriver();
-    if ($driver instanceof Selenium2Driver) {
+
+    // WebDriver-based drivers like Selenium2Driver.
+    if (method_exists($driver, 'getWebDriverSession')) {
       $cookies = $driver->getWebDriverSession()->getAllCookies();
       foreach ($cookies as $cookie) {
         $cookie_list[] = $cookie['name'] . '=' . $cookie['value'];
       }
     }
+
+    // CDP-based drivers like the Chrome (chrome-mink) driver.
+    elseif (method_exists($driver, 'getCookies')) {
+      // @phpstan-ignore-next-line
+      foreach ($driver->getCookies() as $cookie) {
+        $cookie_list[] = $cookie['name'] . '=' . $cookie['value'];
+      }
+    }
+
+    // BrowserKit-based drivers like GoutteDriver.
     else {
       /** @var \Behat\Mink\Driver\BrowserKitDriver $driver */
       // @phpstan-ignore-next-line

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps;
 
 use Behat\Step\When;
+use Behat\Mink\Driver\BrowserKitDriver;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
@@ -92,8 +93,11 @@ trait KeyboardTrait {
   public function keyboardPressKeyOnElementSingle(string $char, ?string $selector): void {
     $driver = $this->getSession()->getDriver();
 
-    if (!$driver instanceof Selenium2Driver) {
-      throw new UnsupportedDriverActionException('Method can be used only with Selenium2 driver', $driver);
+    // Keyboard interaction needs a JavaScript-capable driver: Selenium2 uses
+    // the bundled Syn library, chrome-mink uses native DevTools key events.
+    // BrowserKit-based (non-JavaScript) drivers cannot dispatch key events.
+    if ($driver instanceof BrowserKitDriver) {
+      throw new UnsupportedDriverActionException('Keyboard interaction is only supported by JavaScript drivers (Selenium2 or Chrome).', $driver);
     }
 
     $keys = [
@@ -227,22 +231,57 @@ JS;
    */
   protected function keyboardTriggerKey(string $xpath, string $key): void {
     $driver = $this->getSession()->getDriver();
-    // @codeCoverageIgnoreStart
-    if (!$driver instanceof Selenium2Driver) {
-      throw new UnsupportedDriverActionException('Method can be used only with Selenium2 driver', $driver);
-    }
-    // @codeCoverageIgnoreEnd
-    // Use reflection to re-use Syn library injection and execution of JS on
-    // element.
-    $reflector = new \ReflectionClass($driver);
-    $with_syn_reflection = $reflector->getMethod('withSyn');
-    $execute_js_on_xpath_reflection = $reflector->getMethod('executeJsOnXpath');
-    $with_syn_result = $with_syn_reflection->invoke($driver);
 
-    $execute_js_on_xpath_reflection->invokeArgs($with_syn_result, [
-      $xpath,
-      sprintf("syn.key({{ELEMENT}}, '%s');", $key),
-    ]);
+    // Selenium2 driver: reuse the bundled Syn library via reflection to inject
+    // synthetic events and execute JS on the element.
+    if ($driver instanceof Selenium2Driver) {
+      $reflector = new \ReflectionClass($driver);
+      $with_syn_reflection = $reflector->getMethod('withSyn');
+      $execute_js_on_xpath_reflection = $reflector->getMethod('executeJsOnXpath');
+      $with_syn_result = $with_syn_reflection->invoke($driver);
+
+      $execute_js_on_xpath_reflection->invokeArgs($with_syn_result, [
+        $xpath,
+        sprintf("syn.key({{ELEMENT}}, '%s');", $key),
+      ]);
+
+      return;
+    }
+
+    // CDP-based drivers like the Chrome (chrome-mink) driver: dispatch native
+    // DevTools key events. Special keys are sent as a keycode down/up pair so
+    // their default action (focus move, submit, etc.) fires; printable
+    // characters are sent as a single character so their text is inserted.
+    $keycodes = [
+      "\b" => 8,
+      "\t" => 9,
+      "\r" => 13,
+      'shift' => 16,
+      'ctrl' => 17,
+      'alt' => 18,
+      'pause' => 19,
+      'break' => 19,
+      'caps' => 20,
+      'escape' => 27,
+      'page-up' => 33,
+      'page-down' => 34,
+      'end' => 35,
+      'home' => 36,
+      'left' => 37,
+      'up' => 38,
+      'right' => 39,
+      'down' => 40,
+      'insert' => 45,
+      'delete' => 46,
+    ];
+
+    if (isset($keycodes[$key])) {
+      $driver->keyDown($xpath, $keycodes[$key]);
+      $driver->keyUp($xpath, $keycodes[$key]);
+    }
+    else {
+      $driver->keyPress($xpath, $key);
+    }
   }
 
 }

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -11,7 +11,6 @@ use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Hook\BeforeScenario;
 use Behat\Hook\BeforeStep;
-use Behat\Mink\Driver\Selenium2Driver;
 
 /**
  * Test responsive layouts with viewport control.
@@ -340,17 +339,10 @@ trait ResponsiveTrait {
    *   Array with 'width' and 'height' keys.
    */
   protected function responsiveGetCurrentDimensions(): array {
-    $driver = $this->getSession()->getDriver();
-
     // Default dimensions if unable to determine current size.
     $default_width = 1280;
     $default_height = 800;
 
-    // @codeCoverageIgnoreStart
-    if (!$driver instanceof Selenium2Driver) {
-      return ['width' => $default_width, 'height' => $default_height];
-    }
-    // @codeCoverageIgnoreEnd
     try {
       $width = $this->getSession()->evaluateScript('return window.innerWidth;');
       $height = $this->getSession()->evaluateScript('return window.innerHeight;');
@@ -376,12 +368,6 @@ trait ResponsiveTrait {
    *   The height in pixels.
    */
   protected function responsiveResize(int $width, int $height): void {
-    $driver = $this->getSession()->getDriver();
-
-    if (!$driver instanceof Selenium2Driver) {
-      return;
-    }
-
     try {
       // Ensure session is started before resizing.
       if (!$this->getSession()->isStarted()) {

--- a/tests/behat/bootstrap/FeatureContextTrait.php
+++ b/tests/behat/bootstrap/FeatureContextTrait.php
@@ -372,6 +372,13 @@ trait FeatureContextTrait {
         $cookie_list[$cookie['name']] = $cookie['value'];
       }
     }
+
+    // CDP-based drivers like the Chrome (chrome-mink) driver.
+    elseif (method_exists($driver, 'getCookies')) {
+      foreach ($driver->getCookies() as $cookie) {
+        $cookie_list[$cookie['name']] = rawurldecode((string) $cookie['value']);
+      }
+    }
     else {
       /** @var \Behat\Mink\Driver\BrowserKitDriver $driver */
       // @phpstan-ignore-next-line
@@ -404,6 +411,11 @@ trait FeatureContextTrait {
       $cookie_jar = $driver->getClient()->getCookieJar();
       $cookie = new Cookie($name, rawurlencode($value));
       $cookie_jar->set($cookie);
+    }
+
+    // CDP-based drivers like the Chrome (chrome-mink) driver.
+    if (method_exists($driver, 'getCookies')) {
+      $driver->setCookie($name, $value);
     }
   }
 

--- a/tests/behat/features/keyboard.feature
+++ b/tests/behat/features/keyboard.feature
@@ -25,7 +25,7 @@ Feature: Check that KeyboardTrait works
     Then the "input1" field should contain "hello"
 
   @trait:KeyboardTrait
-  Scenario: Assert that negative assertion for "When I press the keys :keys on the element :selector" step throws an exception for using with a driver other than Selenium2Driver
+  Scenario: Assert that negative assertion for "When I press the keys :keys on the element :selector" step throws an exception for using with a non-JavaScript driver
     Given some behat configuration
     And scenario steps:
       """
@@ -36,7 +36,7 @@ Feature: Check that KeyboardTrait works
     When I run "behat --no-colors"
     Then it should fail with a "Behat\Mink\Exception\UnsupportedDriverActionException" exception:
       """
-      Method can be used only with Selenium2 driver
+      Keyboard interaction is only supported by JavaScript drivers (Selenium2 or Chrome).
       """
 
   @api @javascript


### PR DESCRIPTION
Closes #205

## Summary

JavaScript-dependent Behat steps previously assumed a Selenium2/WebDriver session, hard-checking `instanceof Selenium2Driver` and reaching into WebDriver-specific APIs, so they broke under any other driver. This change makes six traits driver-agnostic and adds a selenium-less `chrome_headless` Behat profile that drives headless Chrome directly over the Chrome DevTools Protocol via `dmore/chrome-mink-driver`, with no Selenium server in the loop. CI now runs the full suite through both the existing Selenium2 profile and the new `chrome_headless` profile, proving step definitions behave identically on either driver.

## Changes

### Driver-agnostic traits

- `CookieTrait`: reads cookies via `getCookies()` when the driver exposes it (CDP-based drivers), alongside the existing WebDriver and BrowserKit branches.
- `FileDownloadTrait`: replaced the hard `Selenium2Driver` instance check with capability checks - `getWebDriverSession()` for WebDriver drivers, `getCookies()` for CDP-based drivers, and the BrowserKit branch as fallback.
- `KeyboardTrait`: `keyboardTriggerKey()` keeps the Syn-library/reflection path for `Selenium2Driver` and adds a native DevTools key-event path for other JavaScript drivers, mapping special keys (arrows, escape, enter, etc.) to keycodes sent via `keyDown()`/`keyUp()`, and printable characters via `keyPress()`. `keyboardPressKeyOnElementSingle()` now only rejects non-JavaScript (`BrowserKitDriver`) sessions instead of anything that isn't `Selenium2Driver`.
- `ResponsiveTrait`: removed the `Selenium2Driver` guards in `responsiveGetCurrentDimensions()` and `responsiveResize()` so viewport inspection and resizing run under any JavaScript driver.
- `AccessibilityTrait`: serializes the axe-core results to a JSON string inside the browser (`JSON.stringify(...)`) before decoding, since some CDP drivers cannot marshal the raw nested result object back through `evaluateScript()`.
- `DropzoneTrait`: sets the synthetic file input's `name` attribute (previously only `id` was set), which chrome-mink's file upload handling requires to locate the input.

### Test harness

- `behat.yml`: new `chrome_headless` profile that inherits the default profile and swaps in `DMore\ChromeExtension` with `javascript_session: chrome` pointed at `http://chrome_headless:9222`.
- `docker-compose.yml`: new `chrome_headless` service running `chromedp/headless-shell`, exposing port 9222 for the DevTools Protocol.
- `composer.json`: added the `dmore/behat-chrome-extension` dependency (pulls in `dmore/chrome-mink-driver`).
- `tests/behat/bootstrap/FeatureContextTrait.php`: added matching `getCookies()`/`setCookie()` branches to the test harness's own cookie helpers so its `@trait` scenarios pass under both drivers.
- `tests/behat/features/keyboard.feature`: updated the negative-assertion scenario title and expected exception message to reflect the new "JavaScript drivers" wording rather than "Selenium2 driver".

### CI

- `.github/workflows/test.yml`: added two `chrome_headless` matrix legs (PHP 8.3, Drupal 10 and 11, normal deps) that run the BDD suite through the new driver, with the existing unit/BDD steps guarded on `matrix.driver != 'chrome_headless'` so the new legs run only the driver-specific step.
- The Drupal 11 `chrome_headless` leg runs with coverage (`ahoy test-bdd-coverage -- -p chrome_headless`) so the selenium-less branches - reachable only through chrome-mink - are measured and merged into the Codecov report alongside the Selenium2 coverage. This keeps patch coverage at 100% (a line covered by either driver counts).
- The job name and the uploaded-artifact name both include `matrix.driver`, so the new legs stay distinct from the Selenium2 legs at the same PHP/Drupal/deps combination and do not collide on the immutable-artifact-name rule.
- The existing `wait_dependencies` service now waits on the `chrome_headless:9222` port (added to its `command`, with `chrome_headless` added to its `depends_on`), so the CDP endpoint is reachable by the time the chrome legs run - reusing the repo's own dependency-wait mechanism rather than a bespoke CI step.

### Docs

- `README.md`: new "JavaScript drivers" section documenting that `@javascript` steps work with both Selenium/WebDriver and selenium-less CDP drivers, with a `behat.yml` snippet for wiring up `DMore\ChromeExtension` and a note on overriding `api_url` for local visual debugging.

## Screenshots

N/A

## Before / After

```
BEFORE - one driver, hard instanceof checks
┌───────────────────────────────────────┐
│         @javascript scenario          │
└───────────────────────────────────────┘
                    ▼
┌───────────────────────────────────────┐
│    instanceof Selenium2Driver only    │
│     (hard-checked in every trait)     │
│  other drivers: throw / silent no-op  │
└───────────────────────────────────────┘
                    ▼
┌───────────────────────────────────────┐
│            Selenium server            │
└───────────────────────────────────────┘
                    ▼
┌───────────────────────────────────────┐
│                Chrome                 │
└───────────────────────────────────────┘

AFTER - capability checks, two profiles, one suite
┌─────────────────────────┐  ┌───────────────────────────┐
│     default profile     │  │  chrome_headless profile  │
│  (Selenium2/WebDriver)  │  │    (chrome-mink / CDP)    │
└─────────────────────────┘  └───────────────────────────┘
             ▼                             ▼
┌─────────────────────────┐  ┌───────────────────────────┐
│     Selenium server     │  │    No Selenium server     │
└─────────────────────────┘  │  (direct CDP to Chrome)   │
                             └───────────────────────────┘
             ▼                             ▼
┌─────────────────────────┐  ┌───────────────────────────┐
│         Chrome          │  │      headless Chrome      │
└─────────────────────────┘  └───────────────────────────┘

Traits use capability checks (getWebDriverSession(), getCookies(), etc.)
instead of `instanceof Selenium2Driver`, so the same suite passes both paths.
CI runs both legs; Codecov merges their coverage, so driver-specific branches
covered by only one driver still count toward 100% patch coverage.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added selenium-less headless Chrome support for JavaScript-dependent Behat steps, including a new `chrome_headless` Behat profile that drives headless Chrome directly via the Chrome DevTools Protocol. Updated Docker and CI to run the suite against both the existing Selenium/WebDriver-based profile and the new CDP-based headless Chrome profile (with dedicated BDD steps for `chrome_headless` coverage vs non-coverage legs), and documented the new "JavaScript drivers" configuration approach. Also added the `dmore/behat-chrome-extension` dependency.

Driver compatibility was broadened across six updated traits and related test helpers so steps work with Selenium/WebDriver sessions and CDP/Chrome-style drivers:
- cookie handling supports CDP-based drivers
- file download cookie extraction is driver-agnostic (WebDriver-like, CDP/Chrome-like, and BrowserKit)
- keyboard interactions work with JS-capable non-Selenium drivers (native key dispatch for non-Selenium drivers)
- accessibility, responsive, and dropzone helpers were adjusted accordingly

Updated the keyboard Behat feature to align expectations with the "keyboard interaction is only supported by JavaScript drivers (Selenium2 or Chrome)" constraint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
