### PR TITLE
[#699] Added path alias and publish state steps to 'ContentTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -4110,6 +4110,14 @@ Then the content block type "Search" should exist
 >  - Create, find, and manipulate nodes with structured field data.
 >  - Navigate to node pages by title and manage editorial workflows.
 >  - Support content moderation transitions and scheduled publishing.
+>  - Set path aliases and assert the published state of content.
+>  
+>  Steps that match content by title resolve to the most recently created node
+>  when several nodes of the same type share that title.
+>  <br/><br/>
+>  The path alias step requires the core `path` module to be enabled. When the
+>  contrib `pathauto` module is enabled, automatic alias generation is switched
+>  off for the content so that the provided alias is preserved.
 
 
 <details>
@@ -4273,6 +4281,20 @@ When I rebuild the access grants for all content
 </details>
 
 <details>
+  <summary><code>@When I set the path alias of the :content_type content with the title :title to :alias</code></summary>
+
+<br/>
+Set the path alias of a content with the specified title
+<br/><br/>
+
+```gherkin
+When I set the path alias of the "article" content with the title "Test article" to "/my-test-article"
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then :content_type content with the title :title should not exist</code></summary>
 
 <br/>
@@ -4282,6 +4304,34 @@ Assert content with specified type and title does not exist
 ```gherkin
 Then "page" content with the title "Test page" should not exist
 Then "article" content with the title "Test article" should not exist
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then :content_type content with the title :title should be published</code></summary>
+
+<br/>
+Assert content with specified type and title is published
+<br/><br/>
+
+```gherkin
+Then "page" content with the title "Test page" should be published
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then :content_type content with the title :title should not be published</code></summary>
+
+<br/>
+Assert content with specified type and title is not published
+<br/><br/>
+
+```gherkin
+Then "page" content with the title "Test page" should not be published
 
 ```
 

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -22,6 +22,14 @@ use Drupal\workflows\Entity\Workflow;
  * - Create, find, and manipulate nodes with structured field data.
  * - Navigate to node pages by title and manage editorial workflows.
  * - Support content moderation transitions and scheduled publishing.
+ * - Set path aliases and assert the published state of content.
+ *
+ * Steps that match content by title resolve to the most recently created node
+ * when several nodes of the same type share that title.
+ *
+ * The path alias step requires the core `path` module to be enabled. When the
+ * contrib `pathauto` module is enabled, automatic alias generation is switched
+ * off for the content so that the provided alias is preserved.
  */
 trait ContentTrait {
 
@@ -160,23 +168,7 @@ trait ContentTrait {
    *   The operation to perform.
    */
   protected function contentVisitActionPageWithTitle(string $content_type, string $title, string $action_subpath = ''): void {
-    $content_type_entity = \Drupal::entityTypeManager()->getStorage('node_type')->load($content_type);
-
-    if (!$content_type_entity) {
-      throw new \RuntimeException(sprintf('Content type "%s" does not exist.', $content_type));
-    }
-
-    $nids = $this->contentLoadMultiple($content_type, [
-      'title' => $title,
-    ]);
-
-    if (empty($nids)) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
-    }
-
-    ksort($nids);
-
-    $nid = end($nids);
+    $nid = $this->contentResolveNidByTitle($content_type, $title);
     $path = $this->locatePath('/node/' . $nid . $action_subpath);
 
     $this->getSession()->visit($path);
@@ -191,30 +183,8 @@ trait ContentTrait {
    */
   #[When('I change the moderation state of the :content_type content with the title :title to the :new_state state')]
   public function contentChangeModerationStateWithTitle(string $content_type, string $title, string $new_state): void {
-    $content_type_entity = \Drupal::entityTypeManager()->getStorage('node_type')->load($content_type);
+    $node = $this->contentLoadNodeByTitle($content_type, $title);
 
-    if (!$content_type_entity) {
-      throw new \RuntimeException(sprintf('Content type "%s" does not exist.', $content_type));
-    }
-
-    $nids = $this->contentLoadMultiple($content_type, [
-      'title' => $title,
-    ]);
-
-    if (empty($nids)) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
-    }
-
-    ksort($nids);
-
-    $nid = end($nids);
-    $node = Node::load($nid);
-
-    // @codeCoverageIgnoreStart
-    if (!$node instanceof NodeInterface) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
-    }
-    // @codeCoverageIgnoreEnd
     $state_is_valid = FALSE;
     $workflows = Workflow::loadMultiple();
     foreach ($workflows as $workflow) {
@@ -247,24 +217,8 @@ trait ContentTrait {
    */
   #[When('I rebuild the access grants for the :content_type content with the title :title')]
   public function contentRebuildAccessGrantsByTitle(string $content_type, string $title): void {
-    $nids = $this->contentLoadMultiple($content_type, [
-      'title' => $title,
-    ]);
+    $node = $this->contentLoadNodeByTitle($content_type, $title);
 
-    if (empty($nids)) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
-    }
-
-    ksort($nids);
-
-    $nid = end($nids);
-    $node = Node::load($nid);
-
-    // @codeCoverageIgnoreStart
-    if (!$node instanceof NodeInterface) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
-    }
-    // @codeCoverageIgnoreEnd
     $handler = \Drupal::entityTypeManager()->getAccessControlHandler('node');
     assert($handler instanceof NodeAccessControlHandlerInterface);
     $grants = $handler->acquireGrants($node);
@@ -288,6 +242,45 @@ trait ContentTrait {
   }
 
   /**
+   * Set the path alias of a content with the specified title.
+   *
+   * The alias replaces any existing alias for the content. A missing leading
+   * slash is added automatically, so both "about-us" and "/about-us" are
+   * accepted.
+   *
+   * @code
+   * When I set the path alias of the "article" content with the title "Test article" to "/my-test-article"
+   * @endcode
+   */
+  #[When('I set the path alias of the :content_type content with the title :title to :alias')]
+  public function contentSetPathAliasWithTitle(string $content_type, string $title, string $alias): void {
+    $this->contentAssertPathModuleEnabled();
+
+    $alias = trim($alias);
+
+    if ($alias === '') {
+      throw new \RuntimeException(sprintf('Path alias for "%s" content with the title "%s" cannot be empty.', $content_type, $title));
+    }
+
+    $node = $this->contentLoadNodeByTitle($content_type, $title);
+
+    // The current value carries the 'pid' of the existing alias, which makes
+    // the save update that alias rather than add a second one.
+    $path_value = (array) ($node->get('path')->getValue()[0] ?? []);
+    $path_value['alias'] = '/' . ltrim($alias, '/');
+
+    // 0 is 'PathautoState::SKIP', which stops pathauto from regenerating the
+    // alias on save. The property exists only on 'PathautoItem', so setting
+    // it without the module throws.
+    if (\Drupal::moduleHandler()->moduleExists('pathauto')) {
+      $path_value['pathauto'] = 0;
+    }
+
+    $node->set('path', $path_value);
+    $node->save();
+  }
+
+  /**
    * Assert content with specified type and title does not exist.
    *
    * @code
@@ -305,6 +298,38 @@ trait ContentTrait {
   }
 
   /**
+   * Assert content with specified type and title is published.
+   *
+   * @code
+   * Then "page" content with the title "Test page" should be published
+   * @endcode
+   */
+  #[Then(':content_type content with the title :title should be published')]
+  public function contentAssertPublishedWithTitle(string $content_type, string $title): void {
+    $node = $this->contentLoadNodeByTitle($content_type, $title);
+
+    if (!$node->isPublished()) {
+      throw new ExpectationException(sprintf('"%s" content with the title "%s" should be published, but it is not (nid: %s).', $content_type, $title, $node->id()), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert content with specified type and title is not published.
+   *
+   * @code
+   * Then "page" content with the title "Test page" should not be published
+   * @endcode
+   */
+  #[Then(':content_type content with the title :title should not be published')]
+  public function contentAssertNotPublishedWithTitle(string $content_type, string $title): void {
+    $node = $this->contentLoadNodeByTitle($content_type, $title);
+
+    if ($node->isPublished()) {
+      throw new ExpectationException(sprintf('"%s" content with the title "%s" should not be published, but it is (nid: %s).', $content_type, $title, $node->id()), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
    * Expand fixture file paths for file/image fields on nodes.
    *
    * Rewrites bare fixture filenames (e.g. 'document.pdf') on 'file' and
@@ -318,6 +343,74 @@ trait ContentTrait {
   #[BeforeNodeCreate]
   public function contentBeforeNodeCreate(BeforeNodeCreateScope $scope): void {
     $this->helperExpandEntityFieldsFixtures('node', $scope->getStub());
+  }
+
+  /**
+   * Resolve the ID of the node with the specified type and title.
+   *
+   * When several nodes of the same type share the title, the most recently
+   * created one is resolved.
+   *
+   * @param string $content_type
+   *   The content type.
+   * @param string $title
+   *   The title of the content.
+   *
+   * @return int
+   *   The node ID.
+   */
+  protected function contentResolveNidByTitle(string $content_type, string $title): int {
+    $content_type_entity = \Drupal::entityTypeManager()->getStorage('node_type')->load($content_type);
+
+    if (!$content_type_entity) {
+      throw new \RuntimeException(sprintf('Content type "%s" does not exist.', $content_type));
+    }
+
+    $nids = $this->contentLoadMultiple($content_type, [
+      'title' => $title,
+    ]);
+
+    if (empty($nids)) {
+      throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
+    }
+
+    ksort($nids);
+
+    return (int) end($nids);
+  }
+
+  /**
+   * Load the node with the specified type and title.
+   *
+   * @param string $content_type
+   *   The content type.
+   * @param string $title
+   *   The title of the content.
+   *
+   * @return \Drupal\node\NodeInterface
+   *   The node.
+   */
+  protected function contentLoadNodeByTitle(string $content_type, string $title): NodeInterface {
+    $node = Node::load($this->contentResolveNidByTitle($content_type, $title));
+
+    // @codeCoverageIgnoreStart
+    if (!$node instanceof NodeInterface) {
+      throw new \RuntimeException(sprintf('Unable to find "%s" content with title "%s".', $content_type, $title));
+    }
+
+    // @codeCoverageIgnoreEnd
+    return $node;
+  }
+
+  /**
+   * Throw when the `path` module is not enabled.
+   */
+  protected function contentAssertPathModuleEnabled(): void {
+    // @codeCoverageIgnoreStart
+    if (!\Drupal::moduleHandler()->moduleExists('path')) {
+      throw new \RuntimeException('The "path" module is not enabled. Enable it to manage content path aliases.');
+    }
+    // @codeCoverageIgnoreEnd
   }
 
   /**

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -390,3 +390,152 @@ Feature: Check that ContentTrait works
     And I am logged in as a user with the "administrator" role
     When I visit the "article" content edit page with the title "[TEST] Compound fixture image"
     Then I should see "[TEST] Compound fixture image"
+
+  @api
+  Scenario: Assert "When I set the path alias of the :content_type content with the title :title to :alias" works as expected
+    Given the following page content:
+      | title                   |
+      | [TEST] Alias page title |
+    And I am logged in as a user with the "administrator" role
+    When I set the path alias of the "page" content with the title "[TEST] Alias page title" to "/test-custom-alias"
+    And I go to "test-custom-alias"
+    Then I should get a 200 HTTP response
+    And I should see "[TEST] Alias page title"
+
+  @api
+  Scenario: Assert "When I set the path alias of the :content_type content with the title :title to :alias" works as expected for an alias without a leading slash
+    Given the following page content:
+      | title                            |
+      | [TEST] Alias no slash page title |
+    And I am logged in as a user with the "administrator" role
+    When I set the path alias of the "page" content with the title "[TEST] Alias no slash page title" to "test-no-slash-alias"
+    And I go to "test-no-slash-alias"
+    Then I should get a 200 HTTP response
+    And I should see "[TEST] Alias no slash page title"
+
+  @api
+  Scenario: Assert "When I set the path alias of the :content_type content with the title :title to :alias" replaces an existing alias instead of adding a second one
+    Given the following page content:
+      | title                            |
+      | [TEST] Alias replaced page title |
+    And I am logged in as a user with the "administrator" role
+    When I set the path alias of the "page" content with the title "[TEST] Alias replaced page title" to "/test-alias-first"
+    And I go to "test-alias-first"
+    Then I should get a 200 HTTP response
+    When I set the path alias of the "page" content with the title "[TEST] Alias replaced page title" to "/test-alias-second"
+    And I go to "test-alias-second"
+    Then I should get a 200 HTTP response
+    And the path should be "/test-alias-second"
+    When I go to "test-alias-first"
+    Then the path should be "/test-alias-second"
+
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "When I set the path alias of the :content_type content with the title :title to :alias" works as expected for non-existing content type
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      When I set the path alias of the "non_existing" content with the title "[TEST] Page title" to "/test-alias"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Content type "non_existing" does not exist.
+      """
+
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "When I set the path alias of the :content_type content with the title :title to :alias" works as expected for non-existing content
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am logged in as a user with the "administrator" role
+      When I set the path alias of the "page" content with the title "[TEST] Non-existing" to "/test-alias"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Unable to find "page" content with title "[TEST] Non-existing".
+      """
+
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "When I set the path alias of the :content_type content with the title :title to :alias" works as expected for an empty alias
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following page content:
+        | title                         |
+        | [TEST] Empty alias page title |
+      When I set the path alias of the "page" content with the title "[TEST] Empty alias page title" to ""
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Path alias for "page" content with the title "[TEST] Empty alias page title" cannot be empty.
+      """
+
+  @api
+  Scenario: Assert "Then :content_type content with the title :title should be published" works as expected
+    Given the following page content:
+      | title                       | moderation_state |
+      | [TEST] Published page title | published        |
+    Then "page" content with the title "[TEST] Published page title" should be published
+
+  @api
+  Scenario: Assert "Then :content_type content with the title :title should not be published" works as expected
+    Given the following page content:
+      | title                         | moderation_state |
+      | [TEST] Unpublished page title | draft            |
+    Then "page" content with the title "[TEST] Unpublished page title" should not be published
+
+  @api
+  Scenario: Assert publish state assertions resolve the most recently created content when titles are duplicated
+    Given the following page content:
+      | title                       | moderation_state |
+      | [TEST] Duplicate page title | published        |
+      | [TEST] Duplicate page title | draft            |
+    Then "page" content with the title "[TEST] Duplicate page title" should not be published
+
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "Then :content_type content with the title :title should be published" works as expected when content is not published
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following page content:
+        | title                         | moderation_state |
+        | [TEST] Unpublished page title | draft            |
+      Then "page" content with the title "[TEST] Unpublished page title" should be published
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      "page" content with the title "[TEST] Unpublished page title" should be published, but it is not (nid:
+      """
+
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "Then :content_type content with the title :title should not be published" works as expected when content is published
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given the following page content:
+        | title                       | moderation_state |
+        | [TEST] Published page title | published        |
+      Then "page" content with the title "[TEST] Published page title" should not be published
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      "page" content with the title "[TEST] Published page title" should not be published, but it is (nid:
+      """
+
+  @trait:Drupal\ContentTrait
+  Scenario: Assert negative "Then :content_type content with the title :title should be published" works as expected for non-existing content
+    Given some behat configuration
+    And scenario steps:
+      """
+      Then "page" content with the title "[TEST] Non-existing" should be published
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Unable to find "page" content with title "[TEST] Non-existing".
+      """


### PR DESCRIPTION
Closes #699

## Summary

Adds three new Behat steps to `ContentTrait` for managing path aliases and asserting the published state of Drupal content matched by title, and refactors the trait's existing title-lookup logic so all title-matched steps share the same node resolution code.

## Changes

### New steps in `src/Drupal/ContentTrait.php`

- `When I set the path alias of the :content_type content with the title :title to :alias` - writes the alias through the node's `path` field, preserving the existing alias `pid` so the save updates the current alias in place instead of creating a second one. A missing leading slash is added automatically. When the `pathauto` module is enabled, `pathauto` is set to `0` (`PathautoState::SKIP`) so the provided alias is not immediately regenerated; the property is set only when the module is enabled, since it exists only on `PathautoItem`. A guard (`contentAssertPathModuleEnabled()`) throws a named error when the `path` module is not enabled, instead of failing with an unrelated entity-API error.
- `Then :content_type content with the title :title should be published`
- `Then :content_type content with the title :title should not be published`

### Refactor

- Extracted `contentResolveNidByTitle()` (content-type existence check, title lookup, and duplicate-title resolution via `ksort()`/`end()`) and `contentLoadNodeByTitle()` (node loading on top of the resolved nid) out of the existing per-step logic.
- `contentVisitActionPageWithTitle()`, `contentChangeModerationStateWithTitle()`, and `contentRebuildAccessGrantsByTitle()` now route through these two helpers, removing the previously repeated lookup block from each. All existing exception messages are unchanged.
- `contentRebuildAccessGrantsByTitle()` gains the content-type existence check it previously lacked, since that check now lives in the shared `contentResolveNidByTitle()`.
- Duplicate titles resolve to the most recently created node, matching the trait's prior behaviour; the rule is now documented once on the trait and pinned by a scenario.

### Tests

12 new BDD scenarios in `tests/behat/features/drupal_content.feature` (6 `@api`, 6 `@trait` negatives) covering:

- Setting a path alias and visiting it.
- Alias normalisation when no leading slash is given.
- Replacing an existing alias rather than adding a second one.
- An empty alias, missing content, and a missing content type.
- Asserting published and not-published states, including the duplicate-title resolution case.
- Negative cases for both publish assertions and the missing-content case.

### Documentation

`STEPS.md` regenerated from the updated source docblocks.

## Before / After

Node lookup by title, which every title-matched step needs:

```
Before
──────
  contentVisitActionPageWithTitle()        ─┐
  contentChangeModerationStateWithTitle()  ─┼─  same lookup block, inlined three times:
  contentRebuildAccessGrantsByTitle()      ─┘
                                                 load node type, throw if missing
                                                 entity query by title
                                                 ksort() then end()
                                                 Node::load() + instanceof guard

  contentRebuildAccessGrantsByTitle() omitted the content-type check.


After
─────
  contentVisitActionPageWithTitle()        ──→  contentResolveNidByTitle()
  contentChangeModerationStateWithTitle()  ──→  contentLoadNodeByTitle()
  contentRebuildAccessGrantsByTitle()      ──→  contentLoadNodeByTitle()
  contentSetPathAliasWithTitle()           ──→  contentLoadNodeByTitle()      (new)
  contentAssertPublishedWithTitle()        ──→  contentLoadNodeByTitle()      (new)
  contentAssertNotPublishedWithTitle()     ──→  contentLoadNodeByTitle()      (new)
                                                            │
                                                            ▼
                                                 content-type check
                                                 entity query by title
                                                 most recent match wins
```

Writing the alias, where the existing `pid` decides whether the old alias survives:

```
Before (pid dropped)                       After (pid preserved)
────────────────────                       ─────────────────────
  node/7  ──→  /content/my-page              node/7  ──→  /my-alias
  node/7  ──→  /my-alias                                  (single alias, updated in place)
          (two aliases, both resolving)
```
