### PR TITLE
[#698] Added computed-style, stacking and viewport pinning assertions to 'ElementTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -811,6 +811,90 @@ Then the element "#main-content" with the attribute "class" and the value contai
 </details>
 
 <details>
+  <summary><code>@Then the element :selector should have the CSS property :property with the value :value</code></summary>
+
+<br/>
+Assert an element has a computed CSS property with a value
+<br/><br/>
+
+```gherkin
+Then the element ".button" should have the CSS property "background-color" with the value "rgb(0, 0, 255)"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector should have the CSS property :property with the value containing :value</code></summary>
+
+<br/>
+Assert an element has a computed CSS property containing a value
+<br/><br/>
+
+```gherkin
+Then the element ".card" should have the CSS property "box-shadow" with the value containing "rgb(0, 0, 0)"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector should not have the CSS property :property with the value :value</code></summary>
+
+<br/>
+Assert an element does not have a computed CSS property with a value
+<br/><br/>
+
+```gherkin
+Then the element ".button" should not have the CSS property "display" with the value "none"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector should not have the CSS property :property with the value containing :value</code></summary>
+
+<br/>
+Assert an element does not have a computed CSS property containing a value
+<br/><br/>
+
+```gherkin
+Then the element ".card" should not have the CSS property "box-shadow" with the value containing "inset"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector1 should stack above the element :selector2</code></summary>
+
+<br/>
+Assert that one element stacks above another
+<br/><br/>
+
+```gherkin
+Then the element "#modal" should stack above the element "#page-header"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector1 should stack below the element :selector2</code></summary>
+
+<br/>
+Assert that one element stacks below another
+<br/><br/>
+
+```gherkin
+Then the element "#page-header" should stack below the element "#modal"
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the element :selector should be at the top of the viewport</code></summary>
 
 <br/>
@@ -833,6 +917,50 @@ Assert the element :selector should be centered in the viewport
 
 ```gherkin
 Then the element "#content" should be centered in the viewport
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector should be pinned to the top of the viewport</code></summary>
+
+<br/>
+Assert that an element is pinned to the top of the viewport
+<br/><br/>
+
+```gherkin
+When I scroll to the element "#footer"
+Then the element "#header" should be pinned to the top of the viewport
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector should be pinned to the top of the viewport within :tolerance pixels</code></summary>
+
+<br/>
+Assert that an element is pinned to the top of the viewport within a tolerance
+<br/><br/>
+
+```gherkin
+Then the element "#header" should be pinned to the top of the viewport within 10 pixels
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then the element :selector should not be pinned to the top of the viewport</code></summary>
+
+<br/>
+Assert that an element is not pinned to the top of the viewport
+<br/><br/>
+
+```gherkin
+When I scroll to the element "#footer"
+Then the element "#header" should not be pinned to the top of the viewport
 
 ```
 

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -433,9 +433,12 @@ trait ElementTrait {
       return;
     }
 
-    $reason = $basis === 'document-order'
-      ? sprintf('both have an effective z-index of %s and "%s" comes %s in the document', $z1, $selector2, $is_above ? 'later' : 'earlier')
-      : sprintf('their effective z-indexes are %s and %s', $z1, $z2);
+    $reason = match ($basis) {
+      'document-order' => sprintf('both have an effective z-index of %s and "%s" comes %s in the document', $z1, $selector2, $is_above ? 'later' : 'earlier'),
+      'nesting-first' => sprintf('"%s" sits inside the stacking context of "%s" with an effective z-index of %s', $selector1, $selector2, $z1),
+      'nesting-second' => sprintf('"%s" sits inside the stacking context of "%s" with an effective z-index of %s', $selector2, $selector1, $z2),
+      default => sprintf('their effective z-indexes are %s and %s', $z1, $z2),
+    };
 
     throw new ExpectationException(sprintf('Expected element "%s" to stack %s the element "%s", but it stacks %s it: %s.', $selector1, $is_above ? 'above' : 'below', $selector2, $is_above ? 'below' : 'above', $reason), $this->getSession()->getDriver());
   }
@@ -547,12 +550,12 @@ trait ElementTrait {
         // above it unless it opted out with a negative z-index.
         if (index >= chain1.length) {
           var nested2 = zIndexOf(chain2[index]);
-          return (nested2 < 0 ? '1' : '-1') + '|0|' + nested2 + '|nesting';
+          return (nested2 < 0 ? '1' : '-1') + '|0|' + nested2 + '|nesting-second';
         }
 
         if (index >= chain2.length) {
           var nested1 = zIndexOf(chain1[index]);
-          return (nested1 < 0 ? '-1' : '1') + '|' + nested1 + '|0|nesting';
+          return (nested1 < 0 ? '-1' : '1') + '|' + nested1 + '|0|nesting-first';
         }
 
         var z1 = zIndexOf(chain1[index]);

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -224,6 +224,356 @@ trait ElementTrait {
   }
 
   /**
+   * Assert an element has a computed CSS property with a value.
+   *
+   * The value is compared against the value computed by the browser, not
+   * against the value written in the stylesheet: `color: red` computes to
+   * `rgb(255, 0, 0)` and `margin: 1em` computes to a pixel length. The
+   * property name is accepted in either `background-color` or
+   * `backgroundColor` form; CSS custom properties are used verbatim. The
+   * assertion applies to the first element matching the selector.
+   *
+   * @code
+   * Then the element ".button" should have the CSS property "background-color" with the value "rgb(0, 0, 255)"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should have the CSS property :property with the value :value')]
+  public function elementAssertHasCssPropertyWithValue(string $selector, string $property, string $value): void {
+    $this->elementAssertCssProperty($selector, $property, $value, TRUE, FALSE);
+  }
+
+  /**
+   * Assert an element has a computed CSS property containing a value.
+   *
+   * Use for multi-part computed values, such as `box-shadow`, `font-family`
+   * or `transition`, where an exact match is brittle.
+   *
+   * @code
+   * Then the element ".card" should have the CSS property "box-shadow" with the value containing "rgb(0, 0, 0)"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should have the CSS property :property with the value containing :value')]
+  public function elementAssertHasCssPropertyContainingValue(string $selector, string $property, string $value): void {
+    $this->elementAssertCssProperty($selector, $property, $value, FALSE, FALSE);
+  }
+
+  /**
+   * Assert an element does not have a computed CSS property with a value.
+   *
+   * @code
+   * Then the element ".button" should not have the CSS property "display" with the value "none"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should not have the CSS property :property with the value :value')]
+  public function elementAssertNotHasCssPropertyWithValue(string $selector, string $property, string $value): void {
+    $this->elementAssertCssProperty($selector, $property, $value, TRUE, TRUE);
+  }
+
+  /**
+   * Assert an element does not have a computed CSS property containing a value.
+   *
+   * @code
+   * Then the element ".card" should not have the CSS property "box-shadow" with the value containing "inset"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should not have the CSS property :property with the value containing :value')]
+  public function elementAssertNotHasCssPropertyContainingValue(string $selector, string $property, string $value): void {
+    $this->elementAssertCssProperty($selector, $property, $value, FALSE, TRUE);
+  }
+
+  /**
+   * Assert the computed value of a CSS property on an element.
+   *
+   * A property with an empty computed value is reported as an error in both
+   * the positive and the inverted form: the realistic cause is a misspelled
+   * property name, which must not silently satisfy a negative assertion.
+   *
+   * @param string $selector
+   *   The CSS selector.
+   * @param string $property
+   *   The CSS property name, in either kebab-case or camelCase.
+   * @param string $value
+   *   The value to assert.
+   * @param bool $is_exact
+   *   Whether to assert the value exactly.
+   * @param bool $is_inverted
+   *   Whether to assert the value is not present.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  protected function elementAssertCssProperty(string $selector, string $property, string $value, bool $is_exact, bool $is_inverted): void {
+    $element = $this->getSession()->getPage()->find('css', $selector);
+
+    if (!$element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    $property_js = json_encode($this->elementNormaliseCssProperty($property), JSON_UNESCAPED_SLASHES);
+    $script = sprintf('return window.getComputedStyle({{ELEMENT}}).getPropertyValue(%s).trim();', $property_js);
+    $actual = (string) $this->elementExecuteJs($selector, $script);
+
+    if ($actual === '') {
+      throw new ExpectationException(sprintf('The CSS property "%s" has no computed value on the element "%s".', $property, $selector), $this->getSession()->getDriver());
+    }
+
+    $is_found = $is_exact ? $actual === $value : str_contains($actual, $value);
+
+    if ($is_inverted && $is_found) {
+      $message = $is_exact
+        ? sprintf('The CSS property "%s" on the element "%s" has a computed value "%s", but it should not.', $property, $selector, $actual)
+        : sprintf('The CSS property "%s" on the element "%s" has a computed value "%s" containing "%s", but it should not.', $property, $selector, $actual, $value);
+      throw new ExpectationException($message, $this->getSession()->getDriver());
+    }
+
+    if (!$is_inverted && !$is_found) {
+      $message = $is_exact
+        ? sprintf('The CSS property "%s" on the element "%s" has a computed value "%s", but it should have a value "%s".', $property, $selector, $actual, $value)
+        : sprintf('The CSS property "%s" on the element "%s" has a computed value "%s", but it should contain a value "%s".', $property, $selector, $actual, $value);
+      throw new ExpectationException($message, $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Convert a CSS property name to the form getPropertyValue() expects.
+   *
+   * @param string $property
+   *   The CSS property name, in either kebab-case or camelCase.
+   *
+   * @return string
+   *   The property name in kebab-case. Custom properties are returned as-is,
+   *   because they are case-sensitive.
+   */
+  protected function elementNormaliseCssProperty(string $property): string {
+    if (str_starts_with($property, '--')) {
+      return $property;
+    }
+
+    return strtolower((string) preg_replace('/([a-z0-9])([A-Z])/', '$1-$2', $property));
+  }
+
+  /**
+   * Assert that one element stacks above another.
+   *
+   * Compares the effective paint order rather than the `z-index` property:
+   * a `z-index` read from an element is only meaningful within its own
+   * stacking context, so a child of a stacking-context-forming ancestor can
+   * carry a high `z-index` and still paint below an element with a lower one.
+   *
+   * The comparison walks the stacking context chain of both elements, finds
+   * the context they share, and compares the two participants that branch off
+   * it, using document order to break a tie. Painting order within a single
+   * stacking context (floats, inline content and positioned descendants) is
+   * not modelled.
+   *
+   * @code
+   * Then the element "#modal" should stack above the element "#page-header"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector1 should stack above the element :selector2')]
+  public function elementAssertStacksAbove(string $selector1, string $selector2): void {
+    $this->elementAssertStackingOrder($selector1, $selector2, TRUE);
+  }
+
+  /**
+   * Assert that one element stacks below another.
+   *
+   * @code
+   * Then the element "#page-header" should stack below the element "#modal"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector1 should stack below the element :selector2')]
+  public function elementAssertStacksBelow(string $selector1, string $selector2): void {
+    $this->elementAssertStackingOrder($selector1, $selector2, FALSE);
+  }
+
+  /**
+   * Assert the stacking order of two elements.
+   *
+   * @param string $selector1
+   *   The CSS selector of the first element.
+   * @param string $selector2
+   *   The CSS selector of the second element.
+   * @param bool $is_above
+   *   Whether the first element is expected to stack above the second one.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  protected function elementAssertStackingOrder(string $selector1, string $selector2, bool $is_above): void {
+    $page = $this->getSession()->getPage();
+
+    if (!$page->find('css', $selector1)) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector1);
+    }
+
+    if (!$page->find('css', $selector2)) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector2);
+    }
+
+    [$order, $z1, $z2, $basis] = explode('|', $this->elementResolveStackingOrder($selector1, $selector2), 4);
+
+    if ($basis === 'same-element') {
+      throw new ExpectationException(sprintf('The selectors "%s" and "%s" match the same element.', $selector1, $selector2), $this->getSession()->getDriver());
+    }
+
+    $is_stacked_above = $order === '1';
+
+    if ($is_stacked_above === $is_above) {
+      return;
+    }
+
+    $reason = $basis === 'document-order'
+      ? sprintf('both have an effective z-index of %s and "%s" comes %s in the document', $z1, $selector2, $is_above ? 'later' : 'earlier')
+      : sprintf('their effective z-indexes are %s and %s', $z1, $z2);
+
+    throw new ExpectationException(sprintf('Expected element "%s" to stack %s the element "%s", but it stacks %s it: %s.', $selector1, $is_above ? 'above' : 'below', $selector2, $is_above ? 'below' : 'above', $reason), $this->getSession()->getDriver());
+  }
+
+  /**
+   * Resolve the stacking order of two elements in the browser.
+   *
+   * @param string $selector1
+   *   The CSS selector of the first element.
+   * @param string $selector2
+   *   The CSS selector of the second element.
+   *
+   * @return string
+   *   A pipe-delimited string of the order (`1` when the first element stacks
+   *   above the second one, `-1` when it stacks below it, `0` when both
+   *   selectors match the same element), the effective z-index of each
+   *   compared participant, and the basis of the comparison.
+   */
+  protected function elementResolveStackingOrder(string $selector1, string $selector2): string {
+    $selector1_js = json_encode($selector1, JSON_UNESCAPED_SLASHES);
+    $selector2_js = json_encode($selector2, JSON_UNESCAPED_SLASHES);
+
+    $script = <<<JS
+      return (function() {
+        function zIndexOf(el) {
+          var parsed = parseInt(window.getComputedStyle(el).zIndex, 10);
+          return isNaN(parsed) ? 0 : parsed;
+        }
+
+        function createsStackingContext(el) {
+          if (el === document.documentElement) {
+            return true;
+          }
+
+          var style = window.getComputedStyle(el);
+
+          if (style.position === 'fixed' || style.position === 'sticky') {
+            return true;
+          }
+
+          if (style.position !== 'static' && style.zIndex !== 'auto') {
+            return true;
+          }
+
+          if (parseFloat(style.opacity) < 1 || style.mixBlendMode !== 'normal' || style.isolation === 'isolate') {
+            return true;
+          }
+
+          var properties = ['transform', 'filter', 'perspective', 'clipPath', 'mask', 'backdropFilter'];
+          for (var i = 0; i < properties.length; i++) {
+            if (style[properties[i]] && style[properties[i]] !== 'none') {
+              return true;
+            }
+          }
+
+          if (/(^|\s)(layout|paint|strict|content)(\s|$)/.test(style.contain || '')) {
+            return true;
+          }
+
+          if (/(transform|opacity|filter|perspective|clip-path|mask|backdrop-filter)/.test(style.willChange || '')) {
+            return true;
+          }
+
+          // A flex or grid item takes part in its parent's stacking context
+          // when it carries a z-index, without needing to be positioned.
+          var parent = el.parentElement;
+          if (parent && style.zIndex !== 'auto') {
+            var parent_display = window.getComputedStyle(parent).display;
+            if (['flex', 'inline-flex', 'grid', 'inline-grid'].indexOf(parent_display) !== -1) {
+              return true;
+            }
+          }
+
+          return false;
+        }
+
+        // The chain of stacking contexts the element sits in, from the root
+        // element down, with the element itself as the last participant.
+        function chainOf(el) {
+          var chain = [el];
+          var node = el.parentElement;
+
+          while (node) {
+            if (createsStackingContext(node)) {
+              chain.unshift(node);
+            }
+            node = node.parentElement;
+          }
+
+          return chain;
+        }
+
+        var element1 = document.querySelector({$selector1_js});
+        var element2 = document.querySelector({$selector2_js});
+
+        if (element1 === element2) {
+          return '0|0|0|same-element';
+        }
+
+        var chain1 = chainOf(element1);
+        var chain2 = chainOf(element2);
+
+        var index = 0;
+        while (index < chain1.length && index < chain2.length && chain1[index] === chain2[index]) {
+          index++;
+        }
+
+        // One element sits inside the other's stacking context, so it paints
+        // above it unless it opted out with a negative z-index.
+        if (index >= chain1.length) {
+          var nested2 = zIndexOf(chain2[index]);
+          return (nested2 < 0 ? '1' : '-1') + '|0|' + nested2 + '|nesting';
+        }
+
+        if (index >= chain2.length) {
+          var nested1 = zIndexOf(chain1[index]);
+          return (nested1 < 0 ? '-1' : '1') + '|' + nested1 + '|0|nesting';
+        }
+
+        var z1 = zIndexOf(chain1[index]);
+        var z2 = zIndexOf(chain2[index]);
+
+        if (z1 !== z2) {
+          return (z1 > z2 ? '1' : '-1') + '|' + z1 + '|' + z2 + '|z-index';
+        }
+
+        // Equal z-indexes are resolved by document order: the participant that
+        // comes later paints above the earlier one.
+        var follows = chain1[index].compareDocumentPosition(chain2[index]) & Node.DOCUMENT_POSITION_FOLLOWING;
+
+        return (follows ? '-1' : '1') + '|' + z1 + '|' + z2 + '|document-order';
+      }());
+JS;
+
+    return (string) $this->getSession()->getDriver()->evaluateScript($script);
+  }
+
+  /**
    * Assert the element :selector should be at the top of the viewport.
    *
    * @code
@@ -253,6 +603,107 @@ trait ElementTrait {
     $result = $this->elementExecuteJs($selector, 'var rect = {{ELEMENT}}.getBoundingClientRect(); var element_center = rect.top + rect.height / 2; var viewport_third = window.innerHeight / 3; return (element_center >= viewport_third && element_center <= viewport_third * 2);');
     if (!$result) {
       throw new ExpectationException(sprintf('Element with selector "%s" is not centered in the viewport.', $selector), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that an element is pinned to the top of the viewport.
+   *
+   * The element's top edge has to sit within 2 pixels of the viewport top,
+   * which absorbs the sub-pixel offsets that normal rendering produces. Use
+   * the step with an explicit tolerance for layouts that need more slack.
+   *
+   * This asserts where the element currently renders, so scroll the page
+   * first to tell a pinned element apart from one that merely starts at the
+   * top of the document.
+   *
+   * @code
+   * When I scroll to the element "#footer"
+   * Then the element "#header" should be pinned to the top of the viewport
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should be pinned to the top of the viewport')]
+  public function elementAssertIsPinnedToTop(string $selector): void {
+    $this->elementAssertPinnedToTop($selector, 2, FALSE);
+  }
+
+  /**
+   * Assert that an element is pinned to the top of the viewport within a tolerance.
+   *
+   * @code
+   * Then the element "#header" should be pinned to the top of the viewport within 10 pixels
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should be pinned to the top of the viewport within :tolerance pixels')]
+  public function elementAssertIsPinnedToTopWithTolerance(string $selector, int $tolerance): void {
+    $this->elementAssertPinnedToTop($selector, $tolerance, FALSE);
+  }
+
+  /**
+   * Assert that an element is not pinned to the top of the viewport.
+   *
+   * @code
+   * When I scroll to the element "#footer"
+   * Then the element "#header" should not be pinned to the top of the viewport
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should not be pinned to the top of the viewport')]
+  public function elementAssertIsNotPinnedToTop(string $selector): void {
+    $this->elementAssertPinnedToTop($selector, 2, TRUE);
+  }
+
+  /**
+   * Assert that an element is pinned to the top of the viewport.
+   *
+   * @param string $selector
+   *   The CSS selector.
+   * @param int $tolerance
+   *   The allowed distance, in pixels, between the top edge of the element
+   *   and the top of the viewport.
+   * @param bool $is_inverted
+   *   Whether to assert that the element is not pinned to the top of the
+   *   viewport.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  protected function elementAssertPinnedToTop(string $selector, int $tolerance, bool $is_inverted): void {
+    if ($tolerance < 0) {
+      throw new ExpectationException(sprintf('The tolerance must be 0 or greater, but "%d" was given.', $tolerance), $this->getSession()->getDriver());
+    }
+
+    $element = $this->getSession()->getPage()->find('css', $selector);
+
+    if (!$element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    $script = 'var rect = {{ELEMENT}}.getBoundingClientRect(); return rect.top + "|" + rect.height;';
+    [$top, $height] = explode('|', (string) $this->elementExecuteJs($selector, $script), 2);
+
+    // An element that is not rendered reports a zero-sized box at the origin,
+    // which would otherwise read as pinned.
+    if ((float) $height <= 0) {
+      if ($is_inverted) {
+        return;
+      }
+
+      throw new ExpectationException(sprintf('Expected element "%s" to be pinned to the top of the viewport, but it is not rendered.', $selector), $this->getSession()->getDriver());
+    }
+
+    $is_pinned = abs((float) $top) <= $tolerance;
+
+    if (!$is_inverted && !$is_pinned) {
+      throw new ExpectationException(sprintf('Expected element "%s" to be pinned to the top of the viewport within %d pixel(s), but its top edge is at %s pixels.', $selector, $tolerance, $top), $this->getSession()->getDriver());
+    }
+
+    if ($is_inverted && $is_pinned) {
+      throw new ExpectationException(sprintf('Expected element "%s" to not be pinned to the top of the viewport, but its top edge is at %s pixels.', $selector, $top), $this->getSession()->getDriver());
     }
   }
 

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -856,6 +856,7 @@ Feature: Check that ElementTrait works
     And the element "#css-box" should have the CSS property "backgroundColor" with the value "rgb(0, 0, 255)"
     And the element "#css-box" should have the CSS property "--css-brand" with the value "teal"
     And the element "#css-box" should not have the CSS property "display" with the value "none"
+    And the element "#css-hidden" should have the CSS property "display" with the value "none"
 
   @javascript
   Scenario: Assert "Then the element :selector should have the CSS property :property with the value containing :value" works as expected
@@ -1057,6 +1058,36 @@ Feature: Check that ElementTrait works
     Then it should fail with an error:
       """
       Expected element "#stack-second" to stack below the element "#stack-first", but it stacks above it: both have an effective z-index of 0 and "#stack-first" comes earlier in the document.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector1 should stack above the element :selector2" fails when the first element is nested in the second one
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#stack-behind" should stack above the element "#stack-parent"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#stack-behind" to stack above the element "#stack-parent", but it stacks below it: "#stack-behind" sits inside the stacking context of "#stack-parent" with an effective z-index of -1.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector1 should stack above the element :selector2" fails when the second element is nested in the first one
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#stack-parent" should stack above the element "#stack-child"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#stack-parent" to stack above the element "#stack-child", but it stacks below it: "#stack-child" sits inside the stacking context of "#stack-parent" with an effective z-index of 0.
       """
 
   @javascript

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -847,3 +847,304 @@ Feature: Check that ElementTrait works
       """
       Element matching css "#does-not-exist" not found.
       """
+
+  @javascript
+  Scenario: Assert "Then the element :selector should have the CSS property :property with the value :value" works as expected
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements_css.html"
+    Then the element "#css-box" should have the CSS property "background-color" with the value "rgb(0, 0, 255)"
+    And the element "#css-box" should have the CSS property "backgroundColor" with the value "rgb(0, 0, 255)"
+    And the element "#css-box" should have the CSS property "--css-brand" with the value "teal"
+    And the element "#css-box" should not have the CSS property "display" with the value "none"
+
+  @javascript
+  Scenario: Assert "Then the element :selector should have the CSS property :property with the value containing :value" works as expected
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements_css.html"
+    Then the element "#css-box" should have the CSS property "box-shadow" with the value containing "rgb(255, 0, 0)"
+    And the element "#css-box" should not have the CSS property "box-shadow" with the value containing "inset"
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should have the CSS property :property with the value :value" fails when the element does not exist
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#nonexistent-element" should have the CSS property "display" with the value "block"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css "#nonexistent-element" not found.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should have the CSS property :property with the value :value" fails when the property has no computed value
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#css-box" should have the CSS property "bogus-property" with the value "block"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The CSS property "bogus-property" has no computed value on the element "#css-box".
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should have the CSS property :property with the value :value" fails on a value mismatch
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#css-box" should have the CSS property "background-color" with the value "rgb(255, 0, 0)"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The CSS property "background-color" on the element "#css-box" has a computed value "rgb(0, 0, 255)", but it should have a value "rgb(255, 0, 0)".
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should not have the CSS property :property with the value :value" fails when the value matches
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#css-box" should not have the CSS property "background-color" with the value "rgb(0, 0, 255)"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The CSS property "background-color" on the element "#css-box" has a computed value "rgb(0, 0, 255)", but it should not.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should have the CSS property :property with the value containing :value" fails when the value is not contained
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#css-box" should have the CSS property "box-shadow" with the value containing "inset"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      but it should contain a value "inset".
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should not have the CSS property :property with the value containing :value" fails when the value is contained
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#css-box" should not have the CSS property "box-shadow" with the value containing "rgb(255, 0, 0)"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      containing "rgb(255, 0, 0)", but it should not.
+      """
+
+  @javascript
+  Scenario: Assert "Then the element :selector1 should stack above the element :selector2" compares the z-index of both elements
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements_css.html"
+    Then the element "#stack-high" should stack above the element "#stack-low"
+    And the element "#stack-low" should stack below the element "#stack-high"
+
+  @javascript
+  Scenario: Assert stacking order resolves the effective z-index across stacking contexts
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements_css.html"
+    Then the element "#stack-sibling" should stack above the element "#stack-trap-child"
+    And the element "#stack-trap-child" should stack below the element "#stack-sibling"
+
+  @javascript
+  Scenario: Assert stacking order falls back to document order for an equal z-index
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements_css.html"
+    Then the element "#stack-second" should stack above the element "#stack-first"
+    And the element "#stack-first" should stack below the element "#stack-second"
+
+  @javascript
+  Scenario: Assert stacking order of an element nested in another element
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements_css.html"
+    Then the element "#stack-child" should stack above the element "#stack-parent"
+    And the element "#stack-parent" should stack below the element "#stack-child"
+    And the element "#stack-behind" should stack below the element "#stack-parent"
+    And the element "#stack-parent" should stack above the element "#stack-behind"
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector1 should stack above the element :selector2" fails when the first element does not exist
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#nonexistent-element" should stack above the element "#stack-low"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css "#nonexistent-element" not found.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector1 should stack above the element :selector2" fails when the second element does not exist
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#stack-low" should stack above the element "#nonexistent-element"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css "#nonexistent-element" not found.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector1 should stack above the element :selector2" fails when both selectors match the same element
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#stack-low" should stack above the element "#stack-low"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The selectors "#stack-low" and "#stack-low" match the same element.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector1 should stack above the element :selector2" fails when the element stacks below
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#stack-low" should stack above the element "#stack-high"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#stack-low" to stack above the element "#stack-high", but it stacks below it: their effective z-indexes are 1 and 5.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector1 should stack below the element :selector2" fails when the element stacks above
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#stack-second" should stack below the element "#stack-first"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#stack-second" to stack below the element "#stack-first", but it stacks above it: both have an effective z-index of 0 and "#stack-first" comes earlier in the document.
+      """
+
+  @javascript
+  Scenario: Assert "Then the element :selector should be pinned to the top of the viewport" works as expected
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements_css.html"
+    Then the element "#pinned-header" should be pinned to the top of the viewport
+    And the element "#not-pinned" should not be pinned to the top of the viewport
+    And the element "#pinned-hidden" should not be pinned to the top of the viewport
+
+  @javascript
+  Scenario: Assert "Then the element :selector should be pinned to the top of the viewport within :tolerance pixels" works as expected
+    Given I am an anonymous user
+    When I visit "/sites/default/files/elements_css.html"
+    Then the element "#pinned-offset" should be pinned to the top of the viewport within 25 pixels
+    And the element "#pinned-offset" should not be pinned to the top of the viewport
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should be pinned to the top of the viewport" fails when the element does not exist
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#nonexistent-element" should be pinned to the top of the viewport
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css "#nonexistent-element" not found.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should be pinned to the top of the viewport" fails when the element is not at the top
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#not-pinned" should be pinned to the top of the viewport
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#not-pinned" to be pinned to the top of the viewport within 2 pixel(s), but its top edge is at
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should be pinned to the top of the viewport" fails when the element is not rendered
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#pinned-hidden" should be pinned to the top of the viewport
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#pinned-hidden" to be pinned to the top of the viewport, but it is not rendered.
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should not be pinned to the top of the viewport" fails when the element is pinned
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#pinned-header" should not be pinned to the top of the viewport
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Expected element "#pinned-header" to not be pinned to the top of the viewport, but its top edge is at
+      """
+
+  @trait:ElementTrait
+  Scenario: Assert "Then the element :selector should be pinned to the top of the viewport within :tolerance pixels" fails when the tolerance is negative
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I am an anonymous user
+      When I visit "/sites/default/files/elements_css.html"
+      Then the element "#pinned-header" should be pinned to the top of the viewport within -5 pixels
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The tolerance must be 0 or greater, but "-5" was given.
+      """

--- a/tests/behat/fixtures/elements_css.html
+++ b/tests/behat/fixtures/elements_css.html
@@ -1,0 +1,219 @@
+<!--
+This is a fixture document used to test computed style, stacking order and
+viewport pinning assertions in ElementTrait.
+
+It is kept apart from `elements.html` because the pinning tests need
+`position: fixed` elements, which would overlay content that other fixtures
+rely on being reachable.
+
+Any changes to this document should be copied over manually:
+cp /app/tests/behat/fixtures/elements_css.html /app/build/web/sites/default/files/elements_css.html
+-->
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8">
+  <title>Element CSS Testing Page</title>
+  <style>
+    :root {
+      --css-brand: teal;
+    }
+
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 60px 20px;
+    }
+
+    /* Computed style. */
+    #css-box {
+      display: block;
+      width: 200px;
+      padding: 20px;
+      background-color: rgb(0, 0, 255);
+      box-shadow: 0 0 10px rgb(255, 0, 0);
+      color: rgb(255, 255, 255);
+    }
+
+    #css-hidden {
+      display: none;
+    }
+
+    /* Stacking order: a plain pair, ordered by z-index. */
+    #stack-plain-container {
+      position: relative;
+      height: 100px;
+    }
+
+    #stack-low,
+    #stack-high {
+      position: absolute;
+      top: 0;
+      width: 150px;
+      padding: 10px;
+    }
+
+    #stack-low {
+      left: 0;
+      z-index: 1;
+      background: rgb(255, 200, 200);
+    }
+
+    #stack-high {
+      left: 50px;
+      z-index: 5;
+      background: rgb(200, 255, 200);
+    }
+
+    /*
+     * Stacking order: a trap pair. `#stack-trap` forms its own stacking
+     * context, so the z-index of `#stack-trap-child` only competes inside it
+     * and cannot lift the child above `#stack-sibling`, despite being far
+     * higher as a raw value.
+     */
+    #stack-trap-container {
+      position: relative;
+      height: 100px;
+    }
+
+    #stack-trap {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 150px;
+      padding: 10px;
+      z-index: 1;
+      opacity: 0.99;
+      background: rgb(200, 200, 255);
+    }
+
+    #stack-trap-child {
+      position: relative;
+      z-index: 9999;
+      background: rgb(150, 150, 255);
+    }
+
+    #stack-sibling {
+      position: absolute;
+      top: 0;
+      left: 50px;
+      width: 150px;
+      padding: 10px;
+      z-index: 5;
+      background: rgb(255, 255, 200);
+    }
+
+    /* Stacking order: a pair with equal z-index, ordered by document order. */
+    #stack-order-container {
+      position: relative;
+      height: 100px;
+    }
+
+    #stack-first,
+    #stack-second {
+      position: absolute;
+      top: 0;
+      width: 150px;
+      padding: 10px;
+    }
+
+    #stack-first {
+      left: 0;
+      background: rgb(255, 220, 180);
+    }
+
+    #stack-second {
+      left: 50px;
+      background: rgb(180, 220, 255);
+    }
+
+    /* Stacking order: nesting, including an opted-out descendant. */
+    #stack-parent {
+      position: relative;
+      z-index: 1;
+      padding: 20px;
+      background: rgb(220, 220, 220);
+    }
+
+    #stack-child {
+      padding: 10px;
+      background: rgb(180, 180, 180);
+    }
+
+    #stack-behind {
+      position: relative;
+      z-index: -1;
+      padding: 10px;
+      background: rgb(140, 140, 140);
+    }
+
+    /* Viewport pinning. */
+    #pinned-header {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 40px;
+      background: rgb(0, 128, 0);
+      color: rgb(255, 255, 255);
+    }
+
+    #pinned-offset {
+      position: fixed;
+      top: 20px;
+      right: 0;
+      width: 120px;
+      background: rgb(128, 0, 128);
+      color: rgb(255, 255, 255);
+    }
+
+    #pinned-hidden {
+      position: fixed;
+      top: 0;
+      left: 0;
+      display: none;
+    }
+
+    #not-pinned {
+      padding: 10px;
+      background: rgb(230, 230, 230);
+    }
+  </style>
+</head>
+<body>
+<div id="pinned-header">Pinned header</div>
+<div id="pinned-offset">Offset header</div>
+<div id="pinned-hidden">Hidden header</div>
+
+<h1>Element CSS Testing Page</h1>
+
+<div id="css-box">Element with known computed styles</div>
+<div id="css-hidden">Element that is not rendered</div>
+
+<div id="stack-plain-container">
+  <div id="stack-low">Low</div>
+  <div id="stack-high">High</div>
+</div>
+
+<div id="stack-trap-container">
+  <div id="stack-trap">
+    Trap
+    <div id="stack-trap-child">Trap child</div>
+  </div>
+  <div id="stack-sibling">Sibling</div>
+</div>
+
+<div id="stack-order-container">
+  <div id="stack-first">First</div>
+  <div id="stack-second">Second</div>
+</div>
+
+<div id="stack-parent">
+  Parent
+  <div id="stack-child">Child</div>
+  <div id="stack-behind">Behind</div>
+</div>
+
+<div id="not-pinned">Element in the normal flow</div>
+</body>
+</html>


### PR DESCRIPTION
Closes #698

## Summary

This adds nine new `Then` steps to `ElementTrait` for asserting computed CSS values, real stacking order, and viewport pinning, closing a gap where these could previously only be checked indirectly. Four steps assert a named CSS property's computed value (exact or containing match, each with a negative form), comparing against what the browser actually renders rather than the stylesheet source. Two steps assert stacking order by resolving the effective paint order across stacking contexts instead of trusting a raw `z-index` reading, which is wrong whenever an ancestor forms its own stacking context. Three steps assert an element is pinned to the top of the viewport, with a default 2px tolerance and an explicit-tolerance variant. A dedicated fixture and 27 new scenarios cover the positive paths and every distinct failure message.

## Changes

**Computed CSS property assertions** (`elementAssertHasCssPropertyWithValue`, `elementAssertHasCssPropertyContainingValue`, `elementAssertNotHasCssPropertyWithValue`, `elementAssertNotHasCssPropertyContainingValue`, backed by `elementAssertCssProperty()`): compares a named property's computed value via `window.getComputedStyle(...).getPropertyValue(...)`, so `red` reads as `rgb(255, 0, 0)`. Property names are accepted in kebab-case or camelCase and normalized by `elementNormaliseCssProperty()`; CSS custom properties (`--foo`) are read verbatim. An empty computed value throws in both the positive and negative form, since the realistic cause is a misspelled property name that would otherwise silently satisfy a negative assertion.

**Stacking order assertions** (`elementAssertStacksAbove`, `elementAssertStacksBelow`, backed by `elementAssertStackingOrder()` and `elementResolveStackingOrder()`): resolves the effective paint order across stacking contexts instead of reading the `z-index` property directly, which is only meaningful within an element's own stacking context. The implementation walks both elements' stacking-context chains, compares the participants that branch off their shared context, and breaks ties by document order. This correctly handles a child with `z-index: 9999` inside an `opacity: 0.99` parent at `z-index: 1`, which still paints below an unrelated `z-index: 5` sibling.

**Viewport pinning assertions** (`elementAssertIsPinnedToTop`, `elementAssertIsPinnedToTopWithTolerance`, `elementAssertIsNotPinnedToTop`, backed by `elementAssertPinnedToTop()`): asserts an element's top edge sits within a pixel tolerance (2px default, or explicit) of the viewport top. An element that is not rendered reports a zero-sized box at the origin, so it is rejected rather than read as pinned.

**Tests**: 27 new scenarios in `tests/behat/features/element.feature` - `@javascript` scenarios for the positive paths and `@trait:ElementTrait` subprocess scenarios asserting each distinct failure message - against a new fixture `tests/behat/fixtures/elements_css.html`, kept separate from `elements.html` because the pinning scenarios need `position: fixed` elements that would otherwise overlay content other fixtures rely on.

**Docs**: `STEPS.md` regenerated to document the nine new steps.

## Before / After

```
BEFORE - stacking order can only be checked by reading the raw `z-index`
property directly, which is wrong wherever an ancestor forms its own
stacking context:

    #stack-trap (opacity: 0.99, z-index: 1)
      └── #stack-trap-child (z-index: 9999)        #stack-sibling (z-index: 5)

    "9999 > 5" -> assumed #stack-trap-child paints above #stack-sibling.
    WRONG: opacity: 0.99 on #stack-trap starts its own stacking context,
    so the child's z-index only competes inside it.

AFTER - the new stacking steps walk the stacking-context chain of both
elements and compare where the chains diverge:

    root
     ├── #stack-trap [context: opacity 0.99, z-index: 1]
     │     └── #stack-trap-child [z-index: 9999, competes only inside #stack-trap]
     └── #stack-sibling [z-index: 5]
                         ▲
                         chains diverge here: #stack-trap (z:1) vs #stack-sibling (z:5)
                         #stack-sibling wins, so #stack-trap-child paints below it too

    Then the element "#stack-sibling" should stack above the element "#stack-trap-child"  [PASS]

New assertions added to ElementTrait:
  * computed CSS property value  - exact / containing, positive / negative
  * stacking order               - should stack above / below
  * viewport pinning             - pinned / pinned within :tolerance / not pinned
```
