### PR TITLE
[#703] Moved verdict-raising assertions to 'AfterStep' so failures reach the rerun cache.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -1749,8 +1749,7 @@ When I switch to the root document
 
 >  Automatically detect JavaScript errors during test execution.
 >  - Collects JavaScript errors from `window.onerror` and `console.error`.
->  - Automatically asserts no errors after each step of scenarios with
->  `@javascript` tag.
+>  - Automatically asserts no errors at end of scenarios with `@javascript` tag.
 >  - Errors collected only when URL changes (navigation occurs).
 >  - Use `@js-errors` tag to bypass error checking when errors are expected.
 >  
@@ -6328,12 +6327,12 @@ Then the user "John" should not be blocked
 [Source](src/Drupal/WatchdogTrait.php), [Example](tests/behat/features/drupal_watchdog.feature)
 
 >  Assert Drupal does not trigger PHP errors during scenarios using Watchdog.
->  - Check for Watchdog messages after every step.
+>  - Check for Watchdog messages after scenario completion.
 >  - Optionally check only for specific message types.
 >  - Optionally skip error checking for specific scenarios.
 >  
 >  Skip processing with tags: `@behat-steps-skip:watchdogSetScenario` or
->  `@behat-steps-skip:watchdogAfterStep`
+>  `@behat-steps-skip:watchdogAfterScenario`
 >  <br/><br/>
 >  Special tags:
 >  - `@watchdog:{type}` - limit watchdog messages to specific types.

--- a/STEPS.md
+++ b/STEPS.md
@@ -79,10 +79,6 @@
 >  - `@accessibility:strict`                   Also fail on "incomplete" findings.
 >  - `@behat-steps-skip:AccessibilityTrait`    Opt the scenario or feature out entirely.
 >  
->  Auto-mode assesses each newly visited page after the step that navigated to
->  it and fails that step when the gate is breached, so the failing step is
->  named in the output and `behat --rerun` can see the failure.
->  <br/><br/>
 >  Tool-agnostic. Any engine that runs inside the existing Mink session can
 >  be plugged in by overriding `accessibilityRunEngine()` (perform the
 >  assessment, return raw results) and `accessibilityNormalizeResults()`
@@ -1753,9 +1749,8 @@ When I switch to the root document
 
 >  Automatically detect JavaScript errors during test execution.
 >  - Collects JavaScript errors from `window.onerror` and `console.error`.
->  - Automatically asserts no errors after each step of scenarios with the
->  `@javascript` tag, so the step that produced the error is the one that
->  fails and `behat --rerun` can see the failure.
+>  - Automatically asserts no errors after each step of scenarios with
+>  `@javascript` tag.
 >  - Errors collected only when URL changes (navigation occurs).
 >  - Use `@js-errors` tag to bypass error checking when errors are expected.
 >  
@@ -6333,8 +6328,7 @@ Then the user "John" should not be blocked
 [Source](src/Drupal/WatchdogTrait.php), [Example](tests/behat/features/drupal_watchdog.feature)
 
 >  Assert Drupal does not trigger PHP errors during scenarios using Watchdog.
->  - Check for Watchdog messages after every step, so the step that triggered
->  the error is the one that fails and `behat --rerun` can see the failure.
+>  - Check for Watchdog messages after every step.
 >  - Optionally check only for specific message types.
 >  - Optionally skip error checking for specific scenarios.
 >  

--- a/STEPS.md
+++ b/STEPS.md
@@ -6332,7 +6332,7 @@ Then the user "John" should not be blocked
 >  - Optionally skip error checking for specific scenarios.
 >  
 >  Skip processing with tags: `@behat-steps-skip:watchdogSetScenario` or
->  `@behat-steps-skip:watchdogAfterScenario`
+>  `@behat-steps-skip:watchdogAfterStep`
 >  <br/><br/>
 >  Special tags:
 >  - `@watchdog:{type}` - limit watchdog messages to specific types.

--- a/STEPS.md
+++ b/STEPS.md
@@ -79,6 +79,10 @@
 >  - `@accessibility:strict`                   Also fail on "incomplete" findings.
 >  - `@behat-steps-skip:AccessibilityTrait`    Opt the scenario or feature out entirely.
 >  
+>  Auto-mode assesses each newly visited page after the step that navigated to
+>  it and fails that step when the gate is breached, so the failing step is
+>  named in the output and `behat --rerun` can see the failure.
+>  <br/><br/>
 >  Tool-agnostic. Any engine that runs inside the existing Mink session can
 >  be plugged in by overriding `accessibilityRunEngine()` (perform the
 >  assessment, return raw results) and `accessibilityNormalizeResults()`
@@ -1749,7 +1753,9 @@ When I switch to the root document
 
 >  Automatically detect JavaScript errors during test execution.
 >  - Collects JavaScript errors from `window.onerror` and `console.error`.
->  - Automatically asserts no errors at end of scenarios with `@javascript` tag.
+>  - Automatically asserts no errors after each step of scenarios with the
+>  `@javascript` tag, so the step that produced the error is the one that
+>  fails and `behat --rerun` can see the failure.
 >  - Errors collected only when URL changes (navigation occurs).
 >  - Use `@js-errors` tag to bypass error checking when errors are expected.
 >  
@@ -6327,12 +6333,13 @@ Then the user "John" should not be blocked
 [Source](src/Drupal/WatchdogTrait.php), [Example](tests/behat/features/drupal_watchdog.feature)
 
 >  Assert Drupal does not trigger PHP errors during scenarios using Watchdog.
->  - Check for Watchdog messages after scenario completion.
+>  - Check for Watchdog messages after every step, so the step that triggered
+>  the error is the one that fails and `behat --rerun` can see the failure.
 >  - Optionally check only for specific message types.
 >  - Optionally skip error checking for specific scenarios.
 >  
 >  Skip processing with tags: `@behat-steps-skip:watchdogSetScenario` or
->  `@behat-steps-skip:watchdogAfterScenario`
+>  `@behat-steps-skip:watchdogAfterStep`
 >  <br/><br/>
 >  Special tags:
 >  - `@watchdog:{type}` - limit watchdog messages to specific types.

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Hook\AfterScenario;
@@ -140,6 +141,11 @@ trait AccessibilityTrait {
   protected bool $accessibilitySkip = FALSE;
 
   /**
+   * Whether the automatic gate has already been enforced.
+   */
+  protected bool $accessibilityGated = FALSE;
+
+  /**
    * Capture the working directory once, before any scenario can chdir().
    */
   #[BeforeSuite]
@@ -176,6 +182,7 @@ trait AccessibilityTrait {
     $this->accessibilityLastCheckedUrl = '';
     $this->accessibilityScenarioThreshold = NULL;
     $this->accessibilityScenarioFailOnIncomplete = NULL;
+    $this->accessibilityGated = FALSE;
 
     $this->accessibilitySkip = $scope->getFeature()->hasTag('behat-steps-skip:AccessibilityTrait')
       || $scope->getScenario()->hasTag('behat-steps-skip:AccessibilityTrait');
@@ -183,6 +190,8 @@ trait AccessibilityTrait {
     if ($this->accessibilitySkip) {
       return;
     }
+
+    $this->helperSetLastStepLine($scope);
 
     $this->accessibilityFeatureName = $scope->getFeature()->getTitle() ?? 'feature';
     $this->accessibilityScenarioName = $scope->getScenario()->getTitle() ?? 'scenario';
@@ -198,7 +207,9 @@ trait AccessibilityTrait {
    * Run the engine after each step when in automatic mode.
    *
    * Behat composes a step teardown into that step's result, so a gate failure
-   * raised here marks the scenario as failed for the rerun cache.
+   * raised here marks the scenario as failed for the rerun cache. Gating on
+   * the last step rather than on every step lets every page the scenario
+   * visited reach the report before the gate is applied.
    */
   #[AfterStep]
   public function accessibilityAutoAssess(AfterStepScope $scope): void {
@@ -221,26 +232,35 @@ trait AccessibilityTrait {
       return;
     }
 
-    if (in_array($url, [...static::accessibilityBlankUrls(), $this->accessibilityLastCheckedUrl], TRUE)) {
-      return;
+    if (!in_array($url, [...static::accessibilityBlankUrls(), $this->accessibilityLastCheckedUrl], TRUE)) {
+      $this->accessibilityAssess($this->accessibilityGetDefaultRules());
     }
-
-    $this->accessibilityAssess($this->accessibilityGetDefaultRules());
 
     // A failed step has already failed the scenario, so gating on top of it
-    // would report a violation found on a page the step left half-built.
-    if (!$scope->getTestResult()->isPassed()) {
+    // would report a violation found on a page the step left half-built. The
+    // gate is applied whether or not this step assessed a new page, because a
+    // last step that navigates nowhere still ends the scenario.
+    if (!$scope->getTestResult()->isPassed() || !$this->helperIsLastStep($scope)) {
       return;
     }
 
+    $this->accessibilityGated = TRUE;
     $this->accessibilityEnforceGate();
   }
 
   /**
-   * Write the scenario reports and feed the suite aggregate.
+   * Write the scenario reports, feed the suite aggregate, then gate if needed.
+   *
+   * A step that fails on its own skips every step after it, including the one
+   * that would have applied the gate, so the gate is applied here instead. The
+   * scenario has already failed by then, so it cannot mask a passing scenario
+   * from the rerun cache.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   If a violation at or above the threshold was collected.
    */
   #[AfterScenario]
-  public function accessibilityFinalizeScenario(): void {
+  public function accessibilityFinalizeScenario(AfterScenarioScope $scope): void {
     if ($this->accessibilitySkip) {
       return;
     }
@@ -258,6 +278,12 @@ trait AccessibilityTrait {
     file_put_contents($dir . '/junit-' . $slug . '.xml', $this->accessibilityRenderJunit());
 
     $this->accessibilityAggregateCapture($dir);
+
+    if (!$this->accessibilityAutoMode || $this->accessibilityGated || $scope->getTestResult()->isPassed()) {
+      return;
+    }
+
+    $this->accessibilityEnforceGate();
   }
 
   /**

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -227,6 +227,12 @@ trait AccessibilityTrait {
 
     $this->accessibilityAssess($this->accessibilityGetDefaultRules());
 
+    // A failed step has already failed the scenario, so gating on top of it
+    // would report a violation found on a page the step left half-built.
+    if (!$scope->getTestResult()->isPassed()) {
+      return;
+    }
+
     $this->accessibilityEnforceGate();
   }
 

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -28,10 +28,6 @@ use Behat\Step\Then;
  * - `@accessibility:strict`                   Also fail on "incomplete" findings.
  * - `@behat-steps-skip:AccessibilityTrait`    Opt the scenario or feature out entirely.
  *
- * Auto-mode assesses each newly visited page after the step that navigated to
- * it and fails that step when the gate is breached, so the failing step is
- * named in the output and `behat --rerun` can see the failure.
- *
  * Tool-agnostic. Any engine that runs inside the existing Mink session can
  * be plugged in by overriding `accessibilityRunEngine()` (perform the
  * assessment, return raw results) and `accessibilityNormalizeResults()`
@@ -202,9 +198,7 @@ trait AccessibilityTrait {
    * Run the engine after each step when in automatic mode.
    *
    * Behat composes a step teardown into that step's result, so a gate failure
-   * raised here marks the scenario as failed for the rerun cache. The same
-   * failure raised from an `AfterScenario` hook only sets the exit code and
-   * leaves `behat --rerun` with nothing to re-run.
+   * raised here marks the scenario as failed for the rerun cache.
    */
   #[AfterStep]
   public function accessibilityAutoAssess(AfterStepScope $scope): void {

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Hook\AfterScenario;
@@ -28,6 +27,10 @@ use Behat\Step\Then;
  * - `@accessibility:warning`                  Auto-mode, never fail (advisory).
  * - `@accessibility:strict`                   Also fail on "incomplete" findings.
  * - `@behat-steps-skip:AccessibilityTrait`    Opt the scenario or feature out entirely.
+ *
+ * Auto-mode assesses each newly visited page after the step that navigated to
+ * it and fails that step when the gate is breached, so the failing step is
+ * named in the output and `behat --rerun` can see the failure.
  *
  * Tool-agnostic. Any engine that runs inside the existing Mink session can
  * be plugged in by overriding `accessibilityRunEngine()` (perform the
@@ -197,6 +200,11 @@ trait AccessibilityTrait {
 
   /**
    * Run the engine after each step when in automatic mode.
+   *
+   * Behat composes a step teardown into that step's result, so a gate failure
+   * raised here marks the scenario as failed for the rerun cache. The same
+   * failure raised from an `AfterScenario` hook only sets the exit code and
+   * leaves `behat --rerun` with nothing to re-run.
    */
   #[AfterStep]
   public function accessibilityAutoAssess(AfterStepScope $scope): void {
@@ -224,13 +232,15 @@ trait AccessibilityTrait {
     }
 
     $this->accessibilityAssess($this->accessibilityGetDefaultRules());
+
+    $this->accessibilityEnforceGate();
   }
 
   /**
-   * Write reports and enforce the gate at the end of the scenario.
+   * Write the scenario reports and feed the suite aggregate.
    */
   #[AfterScenario]
-  public function accessibilityFinalizeScenario(AfterScenarioScope $scope): void {
+  public function accessibilityFinalizeScenario(): void {
     if ($this->accessibilitySkip) {
       return;
     }
@@ -247,14 +257,16 @@ trait AccessibilityTrait {
     file_put_contents($dir . '/' . $slug . '.html', $this->accessibilityRenderHtml());
     file_put_contents($dir . '/junit-' . $slug . '.xml', $this->accessibilityRenderJunit());
 
-    // Accumulate before the gate so a scenario that fails the gate is still
-    // represented in the suite-level aggregate.
     $this->accessibilityAggregateCapture($dir);
+  }
 
-    if (!$this->accessibilityAutoMode) {
-      return;
-    }
-
+  /**
+   * Fail the scenario when collected results breach the automatic gate.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   If a violation at or above the threshold was collected.
+   */
+  protected function accessibilityEnforceGate(): void {
     $threshold = $this->accessibilityEffectiveThreshold();
     $check_incomplete = $this->accessibilityEffectiveFailOnIncomplete();
     $messages = [];

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -13,12 +13,12 @@ use Drupal\Core\Database\Database;
 /**
  * Assert Drupal does not trigger PHP errors during scenarios using Watchdog.
  *
- * - Check for Watchdog messages after every step.
+ * - Check for Watchdog messages after scenario completion.
  * - Optionally check only for specific message types.
  * - Optionally skip error checking for specific scenarios.
  *
  * Skip processing with tags: `@behat-steps-skip:watchdogSetScenario` or
- * `@behat-steps-skip:watchdogAfterStep`
+ * `@behat-steps-skip:watchdogAfterScenario`
  *
  * Special tags:
  * - `@watchdog:{type}` - limit watchdog messages to specific types.
@@ -64,7 +64,7 @@ trait WatchdogTrait {
     // Step scopes carry neither scenario tags nor scenario identity, so both
     // are resolved here for the step hook to read. An unset start time is what
     // disables the check.
-    if ($scenario->hasTag('behat-steps-skip:watchdogAfterStep') || $scenario->hasTag('error')) {
+    if ($scenario->hasTag('behat-steps-skip:watchdogAfterScenario') || $scenario->hasTag('error')) {
       return;
     }
 
@@ -102,10 +102,11 @@ trait WatchdogTrait {
   }
 
   /**
-   * Check for errors since the scenario started.
+   * Check after every step for errors logged since the scenario started.
    *
    * Add @error to any scenario that is expected to trigger an error - the
-   * error tracking will be ignored.
+   * error tracking will be ignored. Skip the check for a scenario with
+   * `@behat-steps-skip:watchdogAfterScenario`.
    *
    * Behat composes a step teardown into that step's result, so a failure
    * raised here marks the scenario as failed for the rerun cache.

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Hook\AfterScenario;
+use Behat\Hook\AfterStep;
 use Behat\Hook\BeforeScenario;
 use Behat\Mink\Exception\ExpectationException;
 use Drupal\Core\Database\Database;
@@ -14,12 +13,13 @@ use Drupal\Core\Database\Database;
 /**
  * Assert Drupal does not trigger PHP errors during scenarios using Watchdog.
  *
- * - Check for Watchdog messages after scenario completion.
+ * - Check for Watchdog messages after every step, so the step that triggered
+ *   the error is the one that fails and `behat --rerun` can see the failure.
  * - Optionally check only for specific message types.
  * - Optionally skip error checking for specific scenarios.
  *
  * Skip processing with tags: `@behat-steps-skip:watchdogSetScenario` or
- * `@behat-steps-skip:watchdogAfterScenario`
+ * `@behat-steps-skip:watchdogAfterStep`
  *
  * Special tags:
  * - `@watchdog:{type}` - limit watchdog messages to specific types.
@@ -42,6 +42,16 @@ trait WatchdogTrait {
   protected $watchdogMessageTypes = [];
 
   /**
+   * Title of the current scenario.
+   */
+  protected string $watchdogScenarioTitle = '';
+
+  /**
+   * Line of the current scenario within its feature file.
+   */
+  protected int $watchdogScenarioLine = 0;
+
+  /**
    * Store current time.
    */
   #[BeforeScenario('@api')]
@@ -50,9 +60,21 @@ trait WatchdogTrait {
       return;
     }
 
-    $this->watchdogScenarioStartTime = time();
+    $scenario = $scope->getScenario();
 
-    $this->watchdogMessageTypes = $this->watchdogParseMessageTypes($scope->getScenario()->getTags());
+    // Step scopes carry neither scenario tags nor scenario identity, so both
+    // are resolved here and carried on the context for the step hook to read.
+    // Leaving the start time unset is what disables the check: scenarios
+    // tagged '@error' are expected to trigger an error.
+    if ($scenario->hasTag('behat-steps-skip:watchdogAfterStep') || $scenario->hasTag('error')) {
+      return;
+    }
+
+    $this->watchdogScenarioStartTime = time();
+    $this->watchdogScenarioTitle = $scenario->getTitle() ?? '';
+    $this->watchdogScenarioLine = $scenario->getLine();
+
+    $this->watchdogMessageTypes = $this->watchdogParseMessageTypes($scenario->getTags());
   }
 
   /**
@@ -86,27 +108,24 @@ trait WatchdogTrait {
    *
    * Add @error to any scenario that is expected to trigger an error - the
    * error tracking will be ignored.
+   *
+   * Behat composes a step teardown into that step's result, so a failure
+   * raised here marks the scenario as failed for the rerun cache. The same
+   * failure raised from an `AfterScenario` hook only sets the exit code and
+   * leaves `behat --rerun` with nothing to re-run.
    */
-  #[AfterScenario('@api')]
-  public function watchdogAfterScenario(AfterScenarioScope $scope): void {
-    $database = Database::getConnection();
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+  #[AfterStep]
+  public function watchdogAfterStep(): void {
+    // The start time is set only for '@api' scenarios that opted into the
+    // check, so an unset one means there is nothing to check.
+    if (!isset($this->watchdogScenarioStartTime)) {
       return;
     }
 
-    // Bypass the error checking if the scenario is expected to trigger an
-    // error. Such scenarios should be tagged with "@error".
-    if (in_array('error', $scope->getScenario()->getTags())) {
-      return;
-    }
+    $database = Database::getConnection();
 
     if (!$database->schema()->tableExists('watchdog')) {
       throw new \RuntimeException('Watchdog table does not exist. Ensure the dblog module is enabled.');
-    }
-
-    // If watchdogSetScenario was skipped, the start time won't be set.
-    if (!isset($this->watchdogScenarioStartTime)) {
-      return;
     }
 
     // Select all logged entries for PHP channel that appeared from the start
@@ -142,7 +161,7 @@ trait WatchdogTrait {
         ->condition('wid', array_keys($errors), 'IN')
         ->execute();
 
-      throw new ExpectationException(sprintf('PHP errors were logged to watchdog during scenario "%s" (line %s): %s', $scope->getScenario()->getTitle(), $scope->getScenario()->getLine(), PHP_EOL . implode(PHP_EOL . PHP_EOL, $errors)), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('PHP errors were logged to watchdog during scenario "%s" (line %s): %s', $this->watchdogScenarioTitle, $this->watchdogScenarioLine, PHP_EOL . implode(PHP_EOL . PHP_EOL, $errors)), $this->getSession()->getDriver());
     }
   }
 

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Hook\AfterScenario;
 use Behat\Hook\AfterStep;
 use Behat\Hook\BeforeScenario;
 use Behat\Mink\Exception\ExpectationException;
+use DrevOps\BehatSteps\HelperTrait;
 use Drupal\Core\Database\Database;
 
 /**
@@ -18,13 +22,15 @@ use Drupal\Core\Database\Database;
  * - Optionally skip error checking for specific scenarios.
  *
  * Skip processing with tags: `@behat-steps-skip:watchdogSetScenario` or
- * `@behat-steps-skip:watchdogAfterScenario`
+ * `@behat-steps-skip:watchdogAfterStep`
  *
  * Special tags:
  * - `@watchdog:{type}` - limit watchdog messages to specific types.
  * - `@error` - add to scenarios that are expected to trigger an error.
  */
 trait WatchdogTrait {
+
+  use HelperTrait;
 
   /**
    * Start time for each scenario.
@@ -64,7 +70,7 @@ trait WatchdogTrait {
     // Step scopes carry neither scenario tags nor scenario identity, so both
     // are resolved here for the step hook to read. An unset start time is what
     // disables the check.
-    if ($scenario->hasTag('behat-steps-skip:watchdogAfterScenario') || $scenario->hasTag('error')) {
+    if ($scenario->hasTag('behat-steps-skip:watchdogAfterStep') || $scenario->hasTag('error')) {
       return;
     }
 
@@ -73,6 +79,8 @@ trait WatchdogTrait {
     $this->watchdogScenarioLine = $scenario->getLine();
 
     $this->watchdogMessageTypes = $this->watchdogParseMessageTypes($scenario->getTags());
+
+    $this->helperSetLastStepLine($scope);
   }
 
   /**
@@ -102,28 +110,74 @@ trait WatchdogTrait {
   }
 
   /**
-   * Check after every step for errors logged since the scenario started.
+   * Check for every error logged since the scenario started, on its last step.
    *
    * Add @error to any scenario that is expected to trigger an error - the
    * error tracking will be ignored. Skip the check for a scenario with
-   * `@behat-steps-skip:watchdogAfterScenario`.
+   * `@behat-steps-skip:watchdogAfterStep`.
    *
    * Behat composes a step teardown into that step's result, so a failure
-   * raised here marks the scenario as failed for the rerun cache.
+   * raised here marks the scenario as failed for the rerun cache. Checking on
+   * the last step rather than on every step keeps the whole scenario in scope,
+   * so every error it logged is reported together.
    */
   #[AfterStep]
-  public function watchdogAfterStep(): void {
+  public function watchdogAfterStep(AfterStepScope $scope): void {
     // The start time is set only for '@api' scenarios that opted into the
     // check.
+    if (!isset($this->watchdogScenarioStartTime) || !$this->helperIsLastStep($scope)) {
+      return;
+    }
+
+    if (!Database::getConnection()->schema()->tableExists('watchdog')) {
+      throw new \RuntimeException('Watchdog table does not exist. Ensure the dblog module is enabled.');
+    }
+
+    $this->watchdogAssertNoErrors(sprintf('during scenario "%s" (line %s)', $this->watchdogScenarioTitle, $this->watchdogScenarioLine));
+  }
+
+  /**
+   * Check for errors that the last step could not have seen.
+   *
+   * Two cases reach here. A scenario whose earlier step failed never ran its
+   * last step, so nothing was checked at step scope. A scenario that passed
+   * may still log an error while another trait tears it down, after the last
+   * step result has already been composed - Behat cannot attribute that to a
+   * step, so it is reported here at the cost of being absent from the rerun
+   * cache. Errors reported at step scope are deleted, so they are not
+   * reported twice.
+   */
+  #[AfterScenario('@api')]
+  public function watchdogAfterScenario(AfterScenarioScope $scope): void {
     if (!isset($this->watchdogScenarioStartTime)) {
       return;
     }
 
-    $database = Database::getConnection();
-
-    if (!$database->schema()->tableExists('watchdog')) {
-      throw new \RuntimeException('Watchdog table does not exist. Ensure the dblog module is enabled.');
+    if (!Database::getConnection()->schema()->tableExists('watchdog')) {
+      return;
     }
+
+    $context = sprintf('during scenario "%s" (line %s)', $this->watchdogScenarioTitle, $this->watchdogScenarioLine);
+    if ($scope->getTestResult()->isPassed()) {
+      $context = sprintf('during the teardown of scenario "%s" (line %s), which "behat --rerun" cannot record', $this->watchdogScenarioTitle, $this->watchdogScenarioLine);
+    }
+
+    $this->watchdogAssertNoErrors($context);
+  }
+
+  /**
+   * Assert no errors above the severity threshold were logged.
+   *
+   * Reported entries are deleted so a later check sees only new ones.
+   *
+   * @param string $context
+   *   Description of when the errors were logged, for the failure message.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   If errors at or above the severity threshold were logged.
+   */
+  protected function watchdogAssertNoErrors(string $context): void {
+    $database = Database::getConnection();
 
     // Select all logged entries for PHP channel that appeared from the start
     // of the scenario.
@@ -158,7 +212,7 @@ trait WatchdogTrait {
         ->condition('wid', array_keys($errors), 'IN')
         ->execute();
 
-      throw new ExpectationException(sprintf('PHP errors were logged to watchdog during scenario "%s" (line %s): %s', $this->watchdogScenarioTitle, $this->watchdogScenarioLine, PHP_EOL . implode(PHP_EOL . PHP_EOL, $errors)), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('PHP errors were logged to watchdog %s: %s', $context, PHP_EOL . implode(PHP_EOL . PHP_EOL, $errors)), $this->getSession()->getDriver());
     }
   }
 

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -13,8 +13,7 @@ use Drupal\Core\Database\Database;
 /**
  * Assert Drupal does not trigger PHP errors during scenarios using Watchdog.
  *
- * - Check for Watchdog messages after every step, so the step that triggered
- *   the error is the one that fails and `behat --rerun` can see the failure.
+ * - Check for Watchdog messages after every step.
  * - Optionally check only for specific message types.
  * - Optionally skip error checking for specific scenarios.
  *
@@ -63,9 +62,8 @@ trait WatchdogTrait {
     $scenario = $scope->getScenario();
 
     // Step scopes carry neither scenario tags nor scenario identity, so both
-    // are resolved here and carried on the context for the step hook to read.
-    // Leaving the start time unset is what disables the check: scenarios
-    // tagged '@error' are expected to trigger an error.
+    // are resolved here for the step hook to read. An unset start time is what
+    // disables the check.
     if ($scenario->hasTag('behat-steps-skip:watchdogAfterStep') || $scenario->hasTag('error')) {
       return;
     }
@@ -110,14 +108,12 @@ trait WatchdogTrait {
    * error tracking will be ignored.
    *
    * Behat composes a step teardown into that step's result, so a failure
-   * raised here marks the scenario as failed for the rerun cache. The same
-   * failure raised from an `AfterScenario` hook only sets the exit code and
-   * leaves `behat --rerun` with nothing to re-run.
+   * raised here marks the scenario as failed for the rerun cache.
    */
   #[AfterStep]
   public function watchdogAfterStep(): void {
     // The start time is set only for '@api' scenarios that opted into the
-    // check, so an unset one means there is nothing to check.
+    // check.
     if (!isset($this->watchdogScenarioStartTime)) {
       return;
     }

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Gherkin\Node\TableNode;
 
@@ -18,6 +20,35 @@ use Behat\Gherkin\Node\TableNode;
  * This is an internal trait and should not be used directly in step definitions.
  */
 trait HelperTrait {
+
+  /**
+   * Line of the last step of the current scenario.
+   */
+  protected int $helperLastStepLine = 0;
+
+  /**
+   * Record the line of the scenario's last step.
+   *
+   * A hook that must run once per scenario, but must raise its verdict at step
+   * scope for Behat to record it, needs to recognise the last step. Step scopes
+   * expose no scenario, so the line is resolved here and compared later.
+   */
+  protected function helperSetLastStepLine(BeforeScenarioScope $scope): void {
+    $steps = $scope->getScenario()->getSteps();
+    $last = end($steps);
+
+    $this->helperLastStepLine = $last === FALSE ? 0 : $last->getLine();
+  }
+
+  /**
+   * Whether the given step is the last step of the current scenario.
+   *
+   * Outline examples reuse the outline's step lines and a background runs as a
+   * separate step container, so the line identifies the step in both.
+   */
+  protected function helperIsLastStep(AfterStepScope $scope): bool {
+    return $this->helperLastStepLine !== 0 && $scope->getStep()->getLine() === $this->helperLastStepLine;
+  }
 
   /**
    * Transpose a vertical table format (field/value columns) to entity arrays.

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -18,9 +18,8 @@ use Behat\Mink\Exception\ExpectationException;
  * Automatically detect JavaScript errors during test execution.
  *
  * - Collects JavaScript errors from `window.onerror` and `console.error`.
- * - Automatically asserts no errors after each step of scenarios with the
- *   `@javascript` tag, so the step that produced the error is the one that
- *   fails and `behat --rerun` can see the failure.
+ * - Automatically asserts no errors after each step of scenarios with
+ *   `@javascript` tag.
  * - Errors collected only when URL changes (navigation occurs).
  * - Use `@js-errors` tag to bypass error checking when errors are expected.
  *
@@ -83,8 +82,8 @@ trait JavascriptTrait {
 
     $this->javascriptEnabled = TRUE;
 
-    // Step scopes carry no scenario tags, so the bypass is resolved here and
-    // carried on the context for the step hook to read.
+    // Step scopes carry no scenario tags, so the bypass is resolved here for
+    // the step hook to read.
     $this->javascriptBypassErrors = $scope->getScenario()->hasTag('js-errors');
   }
 
@@ -134,9 +133,7 @@ trait JavascriptTrait {
    * Collect JavaScript errors after each step and assert none were found.
    *
    * Behat composes a step teardown into that step's result, so a failure
-   * raised here marks the scenario as failed for the rerun cache. The same
-   * failure raised from an `AfterScenario` hook only sets the exit code and
-   * leaves `behat --rerun` with nothing to re-run.
+   * raised here marks the scenario as failed for the rerun cache.
    *
    * @throws \Exception
    *   If JavaScript errors were detected.

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
@@ -45,6 +46,8 @@ use Behat\Mink\Exception\ExpectationException;
  */
 trait JavascriptTrait {
 
+  use HelperTrait;
+
   /**
    * Registry of JavaScript errors collected during scenario execution.
    *
@@ -68,11 +71,17 @@ trait JavascriptTrait {
   protected bool $javascriptBypassErrors = FALSE;
 
   /**
+   * Whether the collected errors have already been asserted.
+   */
+  protected bool $javascriptAsserted = FALSE;
+
+  /**
    * Initialize JavaScript error collection for scenarios.
    */
   #[BeforeScenario('@javascript')]
   public function javascriptBeforeScenario(BeforeScenarioScope $scope): void {
     $this->javascriptClearRegistry();
+    $this->javascriptAsserted = FALSE;
 
     if ($scope->getScenario()->hasTag('behat-steps-skip:JavascriptTrait')) {
       $this->javascriptEnabled = FALSE;
@@ -84,16 +93,43 @@ trait JavascriptTrait {
     // Step scopes carry no scenario tags, so the bypass is resolved here for
     // the step hook to read.
     $this->javascriptBypassErrors = $scope->getScenario()->hasTag('js-errors');
+
+    $this->helperSetLastStepLine($scope);
   }
 
   /**
-   * Reset JavaScript error state at end of scenario.
+   * Assert collected errors when the last step did not run, then reset state.
+   *
+   * A step that fails on its own skips every step after it, including the one
+   * that would have asserted, so the errors collected up to that point are
+   * reported here instead. The scenario has already failed by then, so the
+   * assertion cannot mask a passing scenario from the rerun cache.
+   *
+   * @throws \Exception
+   *   If JavaScript errors were detected.
    */
   #[AfterScenario('@javascript')]
-  public function javascriptAfterScenario(): void {
-    $this->javascriptClearRegistry();
+  public function javascriptAfterScenario(AfterScenarioScope $scope): void {
+    $assert = $this->javascriptEnabled
+      && !$this->javascriptBypassErrors
+      && !$this->javascriptAsserted
+      && !$scope->getTestResult()->isPassed();
+
     $this->javascriptEnabled = FALSE;
     $this->javascriptBypassErrors = FALSE;
+    $this->javascriptAsserted = FALSE;
+
+    if (!$assert) {
+      $this->javascriptClearRegistry();
+      return;
+    }
+
+    try {
+      $this->javascriptAssertNoErrors();
+    }
+    finally {
+      $this->javascriptClearRegistry();
+    }
   }
 
   /**
@@ -129,10 +165,12 @@ trait JavascriptTrait {
   }
 
   /**
-   * Collect JavaScript errors after each step and assert none were found.
+   * Collect JavaScript errors after each step, asserting on the last one.
    *
    * Behat composes a step teardown into that step's result, so a failure
-   * raised here marks the scenario as failed for the rerun cache.
+   * raised here marks the scenario as failed for the rerun cache. Asserting
+   * on the last step rather than on every step lets the registry accumulate
+   * errors from every page the scenario visited.
    *
    * @throws \Exception
    *   If JavaScript errors were detected.
@@ -172,12 +210,13 @@ trait JavascriptTrait {
       // Silently fail if there are issues.
     }
     // @codeCoverageIgnoreEnd
-    if ($this->javascriptBypassErrors) {
+    if ($this->javascriptBypassErrors || !$this->helperIsLastStep($scope)) {
       return;
     }
 
     // Asserted outside the collection block above so the blanket catch cannot
     // swallow the failure.
+    $this->javascriptAsserted = TRUE;
     $this->javascriptAssertNoErrors();
   }
 

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -18,8 +18,7 @@ use Behat\Mink\Exception\ExpectationException;
  * Automatically detect JavaScript errors during test execution.
  *
  * - Collects JavaScript errors from `window.onerror` and `console.error`.
- * - Automatically asserts no errors after each step of scenarios with
- *   `@javascript` tag.
+ * - Automatically asserts no errors at end of scenarios with `@javascript` tag.
  * - Errors collected only when URL changes (navigation occurs).
  * - Use `@js-errors` tag to bypass error checking when errors are expected.
  *

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
@@ -19,7 +18,9 @@ use Behat\Mink\Exception\ExpectationException;
  * Automatically detect JavaScript errors during test execution.
  *
  * - Collects JavaScript errors from `window.onerror` and `console.error`.
- * - Automatically asserts no errors at end of scenarios with `@javascript` tag.
+ * - Automatically asserts no errors after each step of scenarios with the
+ *   `@javascript` tag, so the step that produced the error is the one that
+ *   fails and `behat --rerun` can see the failure.
  * - Errors collected only when URL changes (navigation occurs).
  * - Use `@js-errors` tag to bypass error checking when errors are expected.
  *
@@ -64,43 +65,37 @@ trait JavascriptTrait {
   protected bool $javascriptEnabled = FALSE;
 
   /**
+   * Whether the current scenario expects JavaScript errors.
+   */
+  protected bool $javascriptBypassErrors = FALSE;
+
+  /**
    * Initialize JavaScript error collection for scenarios.
    */
   #[BeforeScenario('@javascript')]
   public function javascriptBeforeScenario(BeforeScenarioScope $scope): void {
+    $this->javascriptClearRegistry();
+
     if ($scope->getScenario()->hasTag('behat-steps-skip:JavascriptTrait')) {
       $this->javascriptEnabled = FALSE;
-      $this->javascriptClearRegistry();
       return;
     }
 
     $this->javascriptEnabled = TRUE;
 
-    $this->javascriptClearRegistry();
+    // Step scopes carry no scenario tags, so the bypass is resolved here and
+    // carried on the context for the step hook to read.
+    $this->javascriptBypassErrors = $scope->getScenario()->hasTag('js-errors');
   }
 
   /**
-   * Assert no JavaScript errors at end of scenario.
+   * Reset JavaScript error state at end of scenario.
    */
   #[AfterScenario('@javascript')]
-  public function javascriptAfterScenario(AfterScenarioScope $scope): void {
-    if ($scope->getScenario()->hasTag('behat-steps-skip:JavascriptTrait')) {
-      $this->javascriptEnabled = FALSE;
-      $this->javascriptClearRegistry();
-      return;
-    }
-
-    if ($scope->getScenario()->hasTag('js-errors')) {
-      $this->javascriptClearRegistry();
-      $this->javascriptEnabled = FALSE;
-      return;
-    }
-
-    $this->javascriptAssertNoErrors();
-
-    // Clean up for next scenario.
+  public function javascriptAfterScenario(): void {
     $this->javascriptClearRegistry();
     $this->javascriptEnabled = FALSE;
+    $this->javascriptBypassErrors = FALSE;
   }
 
   /**
@@ -136,7 +131,15 @@ trait JavascriptTrait {
   }
 
   /**
-   * Collect JavaScript errors after each step if URL changed.
+   * Collect JavaScript errors after each step and assert none were found.
+   *
+   * Behat composes a step teardown into that step's result, so a failure
+   * raised here marks the scenario as failed for the rerun cache. The same
+   * failure raised from an `AfterScenario` hook only sets the exit code and
+   * leaves `behat --rerun` with nothing to re-run.
+   *
+   * @throws \Exception
+   *   If JavaScript errors were detected.
    */
   #[AfterStep]
   public function javascriptAfterStep(AfterStepScope $scope): void {
@@ -173,6 +176,13 @@ trait JavascriptTrait {
       // Silently fail if there are issues.
     }
     // @codeCoverageIgnoreEnd
+    if ($this->javascriptBypassErrors) {
+      return;
+    }
+
+    // Asserted outside the collection block above so the blanket catch cannot
+    // swallow the failure.
+    $this->javascriptAssertNoErrors();
   }
 
   /**

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -206,6 +206,15 @@ class FeatureContext extends DrupalContext {
     \Drupal::logger($type)->log($level, 'test');
   }
 
+  /**
+   * Log an error after the last step result has been composed.
+   *
+   * @AfterScenario @test-watchdog-teardown
+   */
+  public function testSetWatchdogErrorInTeardown() {
+    \Drupal::logger('php')->log('warning', 'test');
+  }
+
 }
 EOL;
 

--- a/tests/behat/features/drupal_watchdog.feature
+++ b/tests/behat/features/drupal_watchdog.feature
@@ -18,6 +18,28 @@ Feature: Check that WatchdogTrait works
       """
 
   @trait:Drupal\WatchdogTrait
+  Scenario: Assert that a failing scenario is reported as failed and recorded for a rerun
+    Given some behat configuration
+    And scenario steps:
+      """
+      When set watchdog error level "warning"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      PHP errors were logged to watchdog
+      """
+    And the output should contain:
+      """
+      1 scenario (1 failed)
+      """
+    When I run "behat --no-colors --rerun-only"
+    Then it should fail with:
+      """
+      PHP errors were logged to watchdog
+      """
+
+  @trait:Drupal\WatchdogTrait
   Scenario: Assert that watchdog does not fail when a custom message type is triggered
     Given some behat configuration
     And scenario steps:
@@ -72,9 +94,9 @@ Feature: Check that WatchdogTrait works
     Then it should pass
 
   @trait:Drupal\WatchdogTrait
-  Scenario: Assert that skip tag for watchdogAfterScenario hook works
+  Scenario: Assert that skip tag for watchdogAfterStep hook works
     Given some behat configuration
-    And scenario steps tagged with "@behat-steps-skip:watchdogAfterScenario":
+    And scenario steps tagged with "@behat-steps-skip:watchdogAfterStep":
       """
       When I visit "/"
       """

--- a/tests/behat/features/drupal_watchdog.feature
+++ b/tests/behat/features/drupal_watchdog.feature
@@ -94,9 +94,9 @@ Feature: Check that WatchdogTrait works
     Then it should pass
 
   @trait:Drupal\WatchdogTrait
-  Scenario: Assert that skip tag for watchdogAfterStep hook works
+  Scenario: Assert that skip tag for watchdogAfterScenario hook works
     Given some behat configuration
-    And scenario steps tagged with "@behat-steps-skip:watchdogAfterStep":
+    And scenario steps tagged with "@behat-steps-skip:watchdogAfterScenario":
       """
       When I visit "/"
       """

--- a/tests/behat/features/drupal_watchdog.feature
+++ b/tests/behat/features/drupal_watchdog.feature
@@ -40,6 +40,34 @@ Feature: Check that WatchdogTrait works
       """
 
   @trait:Drupal\WatchdogTrait
+  Scenario: Assert that an error logged after the last step is reported
+    Given some behat configuration
+    And scenario steps tagged with "@test-watchdog-teardown":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      PHP errors were logged to watchdog during the teardown of scenario "Stub scenario title"
+      """
+
+  @trait:Drupal\WatchdogTrait
+  Scenario: Assert that an error is reported when an earlier step failed
+    Given some behat configuration
+    And scenario steps:
+      """
+      When set watchdog error level "warning"
+      Then I should see "text that is not on the page"
+      And I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      PHP errors were logged to watchdog during scenario "Stub scenario title"
+      """
+
+  @trait:Drupal\WatchdogTrait
   Scenario: Assert that watchdog does not fail when a custom message type is triggered
     Given some behat configuration
     And scenario steps:
@@ -94,9 +122,9 @@ Feature: Check that WatchdogTrait works
     Then it should pass
 
   @trait:Drupal\WatchdogTrait
-  Scenario: Assert that skip tag for watchdogAfterScenario hook works
+  Scenario: Assert that skip tag for watchdogAfterStep hook works
     Given some behat configuration
-    And scenario steps tagged with "@behat-steps-skip:watchdogAfterScenario":
+    And scenario steps tagged with "@behat-steps-skip:watchdogAfterStep":
       """
       When I visit "/"
       """

--- a/tests/behat/features/javascript.feature
+++ b/tests/behat/features/javascript.feature
@@ -83,7 +83,7 @@ Feature: Check that JavascriptTrait works
       """
 
   @trait:JavascriptTrait
-  Scenario: Steps after the failing one are not executed
+  Scenario: Errors from different pages are tracked separately
     Given some behat configuration
     And scenario steps tagged with "@javascript":
       """
@@ -99,11 +99,43 @@ Feature: Check that JavascriptTrait works
       """
     And the output should contain:
       """
-      Total errors: 3
+      URL: http://nginx:8080/sites/default/files/javascript_errors3.html
       """
-    And the output should not contain:
+    And the output should contain:
+      """
+      - Error: Error page 3 - first console.error triggered by button
+      """
+    And the output should contain:
       """
       URL: http://nginx:8080/sites/default/files/javascript_errors2.html
+      """
+    And the output should contain:
+      """
+      - Error: Error page 2 - console.error triggered by button
+      """
+    And the output should contain:
+      """
+      Total errors: 4
+      """
+
+  @trait:JavascriptTrait
+  Scenario: Errors are reported when an earlier step failed
+    Given some behat configuration
+    And scenario steps tagged with "@javascript":
+      """
+      Given I visit "/sites/default/files/javascript_errors3.html"
+      When I press "Click to trigger errors"
+      Then I should see "text that is not on the page"
+      And I visit "/sites/default/files/javascript_clean1.html"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      JavaScript errors detected
+      """
+    And the output should contain:
+      """
+      Total errors: 3
       """
 
   @trait:JavascriptTrait

--- a/tests/behat/features/javascript.feature
+++ b/tests/behat/features/javascript.feature
@@ -47,28 +47,14 @@ Feature: Check that JavascriptTrait works
       """
       - Error: Error page 1 - console.error triggered by button
       """
-    And the output should contain:
-      """
-      Total errors: 1
-      """
-    And the output should not contain:
-      """
-      - Error: Error page 1 - console.error triggered after 1000ms
-      """
-    And the output should not contain:
-      """
-      - Error: Error page 1 - console.error triggered after 2000ms
-      """
 
   @trait:JavascriptTrait
-  Scenario: Page with JavaScript errors should fail after longer wait with more errors
+  Scenario: Failing scenario is reported as failed and not as passed
     Given some behat configuration
     And scenario steps tagged with "@javascript":
       """
-      Given I visit "/sites/default/files/javascript_errors1.html"
-      Then I should see "Page 1 with JavaScript Errors"
-      When I press "Click to trigger error"
-      And sleep for 4 seconds
+      Given I visit "/sites/default/files/javascript_errors3.html"
+      When I press "Click to trigger errors"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -77,39 +63,39 @@ Feature: Check that JavascriptTrait works
       """
     And the output should contain:
       """
-      URL: http://nginx:8080/sites/default/files/javascript_errors1.html
+      1 scenario (1 failed)
       """
-    And the output should contain:
+    And the output should not contain:
       """
-      - Error: Error page 1 - console.error triggered by button
-      """
-    And the output should contain:
-      """
-      - Error: Error page 1 - console.error triggered after 1000ms
-      """
-    And the output should contain:
-      """
-      - Error: Error page 1 - console.error triggered after 2000ms
-      """
-    And the output should contain:
-      """
-      Total errors: 4
+      1 scenario (1 passed)
       """
 
   @trait:JavascriptTrait
-  Scenario: Multiple pages - errors from different pages are tracked separately
+  Scenario: Failing scenario is recorded for a rerun
     Given some behat configuration
     And scenario steps tagged with "@javascript":
       """
-      Given I visit "/sites/default/files/javascript_errors1.html"
-      Then I should see "Page 1 with JavaScript Errors"
-      When I press "Click to trigger error"
-      And sleep for 4 seconds
+      Given I visit "/sites/default/files/javascript_errors3.html"
+      When I press "Click to trigger errors"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      JavaScript errors detected
+      """
+    When I run "behat --no-colors --rerun-only"
+    Then it should fail with:
+      """
+      JavaScript errors detected
+      """
 
-      When I visit "/sites/default/files/javascript_errors2.html"
-      Then I should see "Page 2 with JavaScript Errors"
-      When I press "Click to trigger error"
-      And sleep for 4 seconds
+  @trait:JavascriptTrait
+  Scenario: All errors collected during a step are reported together
+    Given some behat configuration
+    And scenario steps tagged with "@javascript":
+      """
+      Given I visit "/sites/default/files/javascript_errors3.html"
+      When I press "Click to trigger errors"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -118,39 +104,47 @@ Feature: Check that JavascriptTrait works
       """
     And the output should contain:
       """
-      URL: http://nginx:8080/sites/default/files/javascript_errors1.html
+      URL: http://nginx:8080/sites/default/files/javascript_errors3.html
       """
     And the output should contain:
       """
-      - Error: Error page 1 - console.error triggered by button
+      - Error: Error page 3 - first console.error triggered by button
       """
     And the output should contain:
       """
-      - Error: Error page 1 - console.error triggered after 1000ms
+      - Error: Error page 3 - second console.error triggered by button
       """
     And the output should contain:
       """
-      - Error: Error page 1 - console.error triggered after 2000ms
+      - Error: Error page 3 - third console.error triggered by button
       """
     And the output should contain:
+      """
+      Total errors: 3
+      """
+
+  @trait:JavascriptTrait
+  Scenario: Steps after the failing one are not executed
+    Given some behat configuration
+    And scenario steps tagged with "@javascript":
+      """
+      Given I visit "/sites/default/files/javascript_errors3.html"
+      When I press "Click to trigger errors"
+      And I visit "/sites/default/files/javascript_errors2.html"
+      And I press "Click to trigger error"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      JavaScript errors detected
+      """
+    And the output should contain:
+      """
+      Total errors: 3
+      """
+    And the output should not contain:
       """
       URL: http://nginx:8080/sites/default/files/javascript_errors2.html
-      """
-    And the output should contain:
-      """
-      - Error: Error page 2 - console.error triggered by button
-      """
-    And the output should contain:
-      """
-      - Error: Error page 2 - console.error triggered after 1000ms
-      """
-    And the output should contain:
-      """
-      - Error: Error page 2 - console.error triggered after 2000ms
-      """
-    And the output should contain:
-      """
-      Total errors: 8
       """
 
   # The assertions below record current behaviour, which is broken: the run

--- a/tests/behat/features/javascript.feature
+++ b/tests/behat/features/javascript.feature
@@ -49,47 +49,6 @@ Feature: Check that JavascriptTrait works
       """
 
   @trait:JavascriptTrait
-  Scenario: Failing scenario is reported as failed and not as passed
-    Given some behat configuration
-    And scenario steps tagged with "@javascript":
-      """
-      Given I visit "/sites/default/files/javascript_errors3.html"
-      When I press "Click to trigger errors"
-      """
-    When I run "behat --no-colors"
-    Then it should fail with an error:
-      """
-      JavaScript errors detected
-      """
-    And the output should contain:
-      """
-      1 scenario (1 failed)
-      """
-    And the output should not contain:
-      """
-      1 scenario (1 passed)
-      """
-
-  @trait:JavascriptTrait
-  Scenario: Failing scenario is recorded for a rerun
-    Given some behat configuration
-    And scenario steps tagged with "@javascript":
-      """
-      Given I visit "/sites/default/files/javascript_errors3.html"
-      When I press "Click to trigger errors"
-      """
-    When I run "behat --no-colors"
-    Then it should fail with an error:
-      """
-      JavaScript errors detected
-      """
-    When I run "behat --no-colors --rerun-only"
-    Then it should fail with:
-      """
-      JavaScript errors detected
-      """
-
-  @trait:JavascriptTrait
   Scenario: All errors collected during a step are reported together
     Given some behat configuration
     And scenario steps tagged with "@javascript":
@@ -147,11 +106,6 @@ Feature: Check that JavascriptTrait works
       URL: http://nginx:8080/sites/default/files/javascript_errors2.html
       """
 
-  # The assertions below record current behaviour, which is broken: the run
-  # exits non-zero, but the failure is raised from an AfterScenario hook and
-  # Behat dispatches that event before folding the teardown into the scenario
-  # result. The summary therefore reports every scenario as passed, nothing
-  # reaches the rerun cache, and "--rerun" runs the whole suite again.
   @trait:JavascriptTrait
   Scenario: Rerun after a scenario fails on a JavaScript error
     Given some behat configuration
@@ -174,12 +128,12 @@ Feature: Check that JavascriptTrait works
     When I run "behat --no-colors"
     Then it should fail with:
       """
-      3 scenarios (3 passed)
+      3 scenarios (2 passed, 1 failed)
       """
     When I run "behat --no-colors --rerun"
     Then it should fail with:
       """
-      3 scenarios (3 passed)
+      1 scenario (1 failed)
       """
 
   @javascript @js-errors

--- a/tests/behat/fixtures/javascript_errors3.html
+++ b/tests/behat/fixtures/javascript_errors3.html
@@ -1,0 +1,44 @@
+<!--
+This is a fixture document used to test JavaScript error detection in Behat Steps.
+
+Unlike the other error fixtures, every error is emitted synchronously from a
+single click handler and no timers are used, so the number of errors collected
+after the click step is deterministic.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Page with multiple JavaScript Errors - Behat Steps Fixture</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 40px;
+    }
+    h1 {
+      color: #333;
+    }
+    .content {
+      margin: 20px 0;
+    }
+  </style>
+</head>
+<body>
+  <h1>Page 3 with Multiple JavaScript Errors</h1>
+  <div class="content">
+    <p>This page intentionally triggers several JavaScript errors at once for testing purposes.</p>
+    <p id="message">Initial message</p>
+    <button id="trigger-error">Click to trigger errors</button>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      document.querySelector('#trigger-error').addEventListener('click', function() {
+        console.error('Error page 3 - first console.error triggered by button');
+        console.error('Error page 3 - second console.error triggered by button');
+        console.error('Error page 3 - third console.error triggered by button');
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Closes #703

#705 landed a test recording the broken behaviour. This PR fixes the defect and flips that test's two expectations, so the diff of those assertions is the proof that behaviour changed rather than a new test that only ever ran against the new code.

## Summary

`RerunController` records a scenario for the rerun cache only when the `AfterScenarioTested` event carries a non-`PASS` result. Behat dispatches that event from inside `tearDown()` and folds the teardown outcome into the scenario result only afterwards, so a verdict raised from an `AfterScenario` hook sets the process exit code while leaving the scenario looking passed to the collector. `writeCache()` then deletes any previous cache file and returns early, and `--rerun` with no cache file runs everything by design. The reporter measured a 15 minute CI job becoming 30 minutes, with the summary claiming every scenario passed while the exit code said the run failed.

Behat only composes a teardown into a result at step scope (`TestWithSetupResult`), so a verdict is only recordable if it is raised from an `AfterStep` hook. Every hook in `src/` that raises a verdict now does so from the scenario's **last** step. Every step still runs, so nothing the scenario would have collected is lost - the assertion simply happens at a point Behat can attribute.

Three of the seventeen `AfterScenario` hooks in `src/` raise a verdict. The other fourteen are cleanup only and are unchanged.

## Why the last step, not every step

Asserting after every step would fail at the first error and skip the rest of the scenario, which would silently drop a trait's whole-scenario view: `JavascriptTrait` groups errors by URL across every page visited, `WatchdogTrait` sweeps everything logged since the scenario started, and `AccessibilityTrait` reports every page it assessed. Asserting on the last step keeps all three intact and still lands the verdict in a step teardown.

`HelperTrait` gains `helperSetLastStepLine()` and `helperIsLastStep()` for this. The line is captured in `BeforeScenario` because step scopes expose no scenario. It is stable in both places it could break: `ExampleNode::createExampleSteps()` copies the outline's step line into every example, and a background runs as a separate step container with its own lines.

## The scenario-scope safety net

Two cases cannot be handled at step scope, so an `AfterScenario` hook still covers them.

A step that fails on its own skips every later step, including the one that would have asserted. All three traits therefore assert from `AfterScenario` when `getTestResult()` shows the scenario already failed. That cannot mask a passing scenario, because the scenario is already recorded as failed, so the rerun cache is unaffected.

`WatchdogTrait` additionally keeps an unconditional `AfterScenario` check, because an error logged while another trait tears the scenario down lands after the last step's result has been composed. Behat cannot attribute that to a step, so it cannot be made visible to `--rerun` at all - the choice is between detecting it and not detecting it, and detection wins. The message says so:

```
PHP errors were logged to watchdog during the teardown of scenario "..." (line N),
which "behat --rerun" cannot record
```

It needs no deduplication: entries reported at step scope are deleted, so this check only ever sees new ones.

## Changes

**`src/JavascriptTrait.php`** - the console-error assertion moved into the existing `javascriptAfterStep()` collector hook, guarded to the last step and placed after its best-effort `try`/`catch` so the blanket catch cannot swallow the failure. `javascriptAfterScenario()` resets state and asserts when the last step never ran.

**`src/Drupal/WatchdogTrait.php`** - the check moved to `watchdogAfterStep()` on the last step, with `watchdogAfterScenario()` retained for the two cases above. The shared query lives in `watchdogAssertNoErrors()`. The skip tag is now `@behat-steps-skip:watchdogAfterStep`.

**`src/AccessibilityTrait.php`** - the auto-mode gate was extracted into `accessibilityEnforceGate()`, applied on the last step and only when that step passed, since gating on a failed step would report violations found on a page the step left half-built. The gate is applied whether or not the last step assessed a new page. `accessibilityFinalizeScenario()` still writes the per-scenario reports and feeds the suite aggregate before gating.

**Tag resolution.** Behat filters step hooks by feature name or step text, never by scenario tags (`RuntimeStepHook::filterMatches()`), so `@js-errors`, `@error` and the `@behat-steps-skip:*` tags are resolved in `BeforeScenario` and carried on context properties. `WatchdogTrait` also captures the scenario title and line there, keeping the failure message byte-identical.

**Trait descriptions are otherwise untouched**, and `STEPS.md` changes by exactly one line - the renamed skip tag.

## Tests

The rerun test from #705 has its two expectations flipped, from `3 scenarios (3 passed)` / `3 scenarios (3 passed)` to `3 scenarios (2 passed, 1 failed)` / `1 scenario (1 failed)`. The test was confirmed to discriminate on the fix rather than merely pass, by running it against both code states in both assertion forms - broken code with fixed expectations fails, and fixed code with broken expectations fails.

New coverage in `tests/behat/features/javascript.feature`:

- Errors from different pages are tracked separately, asserting both URLs and a combined total, so the cross-page registry is covered rather than assumed.
- All errors collected during one step are reported together.
- Errors are reported when an earlier step failed, covering the safety net.

New coverage in `tests/behat/features/drupal_watchdog.feature`:

- An error logged after the last step is reported with the teardown message.
- An error is reported when an earlier step failed and the last step never ran.
- A scenario running `behat` then `behat --rerun-only`, covering the Drupal path as well as the JavaScript one.

`tests/behat/fixtures/javascript_errors3.html` emits three `console.error` calls synchronously from one click handler with no timers, so multi-error assertions no longer race the collection point. The two scenarios that previously relied on 1000ms and 2000ms timers were rewritten onto it.

## Behaviour change

A scenario that fails on an assertion from one of these traits now reports the failing step rather than reporting the scenario as passed with a failing exit code, and it appears in the rerun cache. Reports and error groupings are unchanged.

The one narrowing: an error logged during scenario teardown still fails the run, but that scenario cannot be recorded for `--rerun`, so a teardown-only failure degrades to re-running the suite. Errors raised during steps - the common case, and the one in the issue report - are fully fixed.

## Before / After

```
BEFORE - verdict raised at AfterScenario

  step 1  ok ─┐
  step 2  ok ─┼─→ scenario result: PASSED
  step 3  ok ─┘         │
                        ├─→ AfterScenarioTested ──→ RerunController: PASS, skip
  AfterScenario ─┐      │
   throws        └──────┴─→ teardown folded in ──→ exit 1

  summary: 3 scenarios (3 passed)      cache: empty
  --rerun: runs everything

AFTER - verdict raised at the last AfterStep

  step 1  ok ──────────────────────────────→ PASSED   errors collected, page A
  step 2  ok ──────────────────────────────→ PASSED   errors collected, page B
  step 3  ok ─┐
              └─ last step, AfterStep ─────→ FAILED ─┐  asserts A + B together
                 throws                              │
                                                     ↓
                                   scenario result: FAILED
                                                     │
                                                     ├─→ AfterScenarioTested ──→ recorded
                                                     └─→ exit 1

  summary: 3 scenarios (2 passed, 1 failed)          cache: 1 scenario
  --rerun: 1 scenario (1 failed)
```
