### PR TITLE
[#703] Added a test recording that 'behat --rerun' re-runs the whole suite.

### DIFF
--- a/tests/behat/features/javascript.feature
+++ b/tests/behat/features/javascript.feature
@@ -153,6 +153,41 @@ Feature: Check that JavascriptTrait works
       Total errors: 8
       """
 
+  # The assertions below record current behaviour, which is broken: the run
+  # exits non-zero, but the failure is raised from an AfterScenario hook and
+  # Behat dispatches that event before folding the teardown into the scenario
+  # result. The summary therefore reports every scenario as passed, nothing
+  # reaches the rerun cache, and "--rerun" runs the whole suite again.
+  @trait:JavascriptTrait
+  Scenario: Rerun after a scenario fails on a JavaScript error
+    Given some behat configuration
+    And a file named "features/stub.feature" with:
+      """
+      Feature: Stub feature
+        @javascript
+        Scenario: Passing scenario before the failure
+          Given I visit "/sites/default/files/javascript_clean1.html"
+
+        @javascript
+        Scenario: Scenario with a JavaScript error
+          Given I visit "/sites/default/files/javascript_errors1.html"
+          When I press "Click to trigger error"
+
+        @javascript
+        Scenario: Passing scenario after the failure
+          Given I visit "/sites/default/files/javascript_clean2.html"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with:
+      """
+      3 scenarios (3 passed)
+      """
+    When I run "behat --no-colors --rerun"
+    Then it should fail with:
+      """
+      3 scenarios (3 passed)
+      """
+
   @javascript @js-errors
   Scenario: Bypass tag allows page with errors to pass
     Given I visit "/sites/default/files/javascript_errors1.html"


### PR DESCRIPTION
Refs #703

## Summary

This adds a single failing-behaviour test for the `behat --rerun` defect described in #703, with no production change. The assertions record what the library does today, so this branch is green: they are the "before" half of a red/green pair, and the fix PR flips them.

The defect is that `RerunController` records a scenario for the rerun cache only when the `AfterScenarioTested` event carries a non-`PASS` result, but Behat dispatches that event from inside `tearDown()` and folds the teardown outcome into the scenario result only afterwards. A verdict raised from an `AfterScenario` hook therefore sets the process exit code while leaving the scenario looking passed to the collector, so `writeCache()` writes nothing and `--rerun` falls back to running everything.

Landing the observation on its own makes the fix reviewable: the diff that changes these two expectations is the proof that behaviour changed, rather than a new test that only ever ran against the new code.

## Changes

`tests/behat/features/javascript.feature` gains one `@trait:JavascriptTrait` scenario that writes a three-scenario stub feature, where the middle scenario triggers a JavaScript console error and the two around it pass. It runs `behat`, then runs `behat --rerun`, and asserts on the summary line of each.

Both runs exit non-zero and both report `3 scenarios (3 passed)`. The first count is the reporting symptom: the run failed, but no scenario is marked failed. The second is the cost: `--rerun` re-ran all three scenarios instead of the one that failed. On the suite in the issue report that is the difference between re-running 1 scenario and re-running 296.

A Gherkin comment above the scenario states that the expectations record broken behaviour, so nobody reads `3 passed` on a failing run as a mistake in the test.

The scenario is named for what it observes ("Rerun after a scenario fails on a JavaScript error") rather than for either outcome, so the name stays accurate once the expectations flip.

## Verification

The test discriminates on the fix rather than merely passing, confirmed by running it against both code states:

| Source | Expectations | Result |
| --- | --- | --- |
| this branch | fixed (`2 passed, 1 failed` / `1 scenario`) | fails |
| this branch | broken (`3 passed` / `3 scenarios`) | passes |
| fix applied | broken | fails |
| fix applied | fixed | passes |

Under the current code the first run also prints a `--- Failed hooks:` section naming `javascriptAfterScenario()` while printing no `--- Failed scenarios:` section at all. That missing section is precisely what feeds the rerun cache.

## Before / After

```
behat                                    behat --rerun
┌───────────────────────────────┐        ┌───────────────────────────────┐
│ scenario 1  ok                │        │                               │
│ scenario 2  JS console error  │        │  no cache file                │
│ scenario 3  ok                │        │        ↓                      │
├───────────────────────────────┤        │  run everything               │
│ AfterScenario hook throws     │        ├───────────────────────────────┤
│        ↓                      │        │ 3 scenarios (3 passed)        │
│ event already dispatched      │        │ exit 1                        │
│        ↓                      │        └───────────────────────────────┘
│ RerunController sees PASS     │
│        ↓                      │        the one failing scenario is
│ writeCache() writes nothing   │        indistinguishable from the rest
├───────────────────────────────┤
│ 3 scenarios (3 passed)        │
│ exit 1                        │
└───────────────────────────────┘

           ^ this PR asserts the above, so the fix PR can flip it to:

             3 scenarios (2 passed, 1 failed)
             1 scenario  (1 failed)
```
