### PR TITLE
Converged source traits onto consistent naming, structure and API shape.

### DIFF
--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -71,10 +71,11 @@ trait AccessibilityTrait {
    * Working directory captured before any test bootstrap can chdir().
    *
    * The default report directory anchors to this rather than a live
-   * `getcwd()` call, which an `@api` bootstrap mutates by chdir()-ing to the
-   * docroot - moving reports out of the path-anchored location used by the
-   * rest of the run. Captured once at `@BeforeSuite`, before the first
-   * scenario, so it records the directory the run was launched from.
+   * `getcwd()` call. An `@api` bootstrap chdir()s to the docroot, so a
+   * live `getcwd()` would move reports out of the path-anchored location
+   * used by the rest of the run. Captured once at `@BeforeSuite`, before
+   * the first scenario, so it records the directory the run was launched
+   * from.
    */
   protected static ?string $accessibilityBaseDir = NULL;
 
@@ -93,7 +94,7 @@ trait AccessibilityTrait {
    *
    * The `@AfterSuite` hook is static and cannot call
    * `accessibilityGetReportDir()` (an instance method, overridable per
-   * consumer), so the resolved directory is captured while a scenario
+   * consumer). The resolved directory is captured while a scenario
    * finalizes and reused when the aggregate is written.
    */
   protected static ?string $accessibilityAggregateReportDir = NULL;
@@ -152,8 +153,9 @@ trait AccessibilityTrait {
   public static function accessibilityCaptureBaseDir(): void {
     if (self::$accessibilityBaseDir === NULL) {
       $cwd = getcwd();
-      // Leave the base unset when getcwd() fails so the report directory
-      // retries it later rather than locking in an empty, root-relative base.
+      // Leave the base unset when getcwd() fails so
+      // accessibilityGetReportDir() retries it later rather than locking in
+      // an empty, root-relative base.
       if ($cwd !== FALSE) {
         self::$accessibilityBaseDir = $cwd;
       }
@@ -404,11 +406,11 @@ trait AccessibilityTrait {
   /**
    * Return the absolute directory used to write per-scenario reports.
    *
-   * Default: `.logs/test_results/accessibility/` under the directory the run
-   * was launched from (captured at `@BeforeSuite`, so it is stable even after
-   * an `@api` bootstrap chdir()s to the docroot), falling back to the live
-   * working directory when the suite hook has not run. Override to return an
-   * already-absolute path.
+   * Default: `.logs/test_results/accessibility/` under the directory the
+   * run was launched from. That base is captured at `@BeforeSuite`, so it
+   * is stable even after an `@api` bootstrap chdir()s to the docroot. When
+   * the suite hook has not run, the live working directory is used.
+   * Override to return an already-absolute path.
    */
   protected function accessibilityGetReportDir(): string {
     $base = self::$accessibilityBaseDir ?? (getcwd() ?: '.');
@@ -432,7 +434,7 @@ trait AccessibilityTrait {
    * Return the default rule identifier passed to the engine.
    *
    * Default: WCAG 2.0/2.1 A and AA tag set. Override to use a different
-   * rule identifier expected by your engine.
+   * rule identifier expected by the engine in use.
    */
   protected function accessibilityGetDefaultRules(): string {
     return 'wcag2a,wcag2aa';
@@ -477,7 +479,7 @@ trait AccessibilityTrait {
   }
 
   /**
-   * Execute the engine against the current page and return RAW results.
+   * Execute the engine against the current page and return raw results.
    *
    * Default: injects `accessibilityGetJs()`, runs the engine with the
    * given rule identifier, returns the engine's native output. Override
@@ -527,8 +529,8 @@ trait AccessibilityTrait {
    *
    * Default: maps each finding into the canonical fields explicitly. The
    * default engine's native shape happens to share field names with the
-   * canonical shape, so this default mostly copies values straight across
-   * - but each field is named at the call site so the method also serves
+   * canonical shape, so this default mostly copies values straight across.
+   * Each field is still named at the call site, so the method also serves
    * as a template for overrides. Override when wiring a different engine
    * to map its native output (e.g. pa11y's `issues[]`, Lighthouse's
    * `audits`) into the canonical structure.
@@ -937,14 +939,15 @@ HTML;
   /**
    * Render the scenario-level JUnit XML report from collected results.
    *
-   * Violations are gated by the scenario's effective threshold, exactly as the
-   * pass/fail gate is: only violations meeting the threshold are serialised as
-   * `<failure>` cases, so an advisory run (threshold `never`) writes a report
-   * with zero failures instead of one that reddens a JUnit-consuming CI check.
-   * Violations below the threshold are recorded as passing cases carrying the
-   * finding in `<system-out>`, so they stay visible without failing the report.
-   * The `tests` and `failures` counts reflect the actual emitted `<testcase>`
-   * elements, one per affected node.
+   * Violations are gated by the scenario's effective threshold, exactly as
+   * the pass/fail gate is: only violations meeting the threshold are
+   * serialised as `<failure>` cases. An advisory run (threshold `never`)
+   * therefore writes a report with zero failures instead of one that fails
+   * a JUnit-consuming CI check. Violations below the threshold are recorded
+   * as passing cases carrying the finding in `<system-out>`, so they stay
+   * visible without failing the report. The `tests` and `failures` counts
+   * reflect the actual emitted `<testcase>` elements, one per affected
+   * node.
    */
   protected function accessibilityRenderJunit(): string {
     $threshold = $this->accessibilityEffectiveThreshold();

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -513,7 +513,7 @@ trait AccessibilityTrait {
     }
 
     if (isset($results['error'])) {
-      throw new \RuntimeException('Accessibility engine failed: ' . $results['error']);
+      throw new \RuntimeException(sprintf('Accessibility engine failed: %s', $results['error']));
     }
 
     return $results;

--- a/src/CookieTrait.php
+++ b/src/CookieTrait.php
@@ -288,7 +288,8 @@ trait CookieTrait {
       /** @var \Symfony\Component\BrowserKit\CookieJar $cookie_jar */
       $cookie_jar = $driver->getClient()->getCookieJar();
 
-      // Use filtered cookies from the Driver's cookie jar and also add more
+      // The allValues() list is filtered for the current URL but holds only
+      // name/value pairs; the full cookie objects supply the remaining
       // properties.
       /** @var \Symfony\Component\BrowserKit\Cookie[] $cookie_objects */
       $cookie_objects = $cookie_jar->all();

--- a/src/CookieTrait.php
+++ b/src/CookieTrait.php
@@ -290,22 +290,22 @@ trait CookieTrait {
 
       // Use filtered cookies from the Driver's cookie jar and also add more
       // properties.
-      /** @var \Symfony\Component\BrowserKit\Cookie[] $cookies_objs */
-      $cookies_objs = $cookie_jar->all();
-      $cookies_names = array_keys($cookie_jar->allValues($driver->getCurrentUrl()));
+      /** @var \Symfony\Component\BrowserKit\Cookie[] $cookie_objects */
+      $cookie_objects = $cookie_jar->all();
+      $cookie_names = array_keys($cookie_jar->allValues($driver->getCurrentUrl()));
 
       $cookies = [];
-      foreach ($cookies_objs as $cookie_obj) {
-        if (!in_array($cookie_obj->getName(), $cookies_names)) {
+      foreach ($cookie_objects as $cookie_object) {
+        if (!in_array($cookie_object->getName(), $cookie_names)) {
           // @codeCoverageIgnoreStart
           continue;
           // @codeCoverageIgnoreEnd
         }
 
         $cookies[] = [
-          'name' => $cookie_obj->getName(),
-          'value' => $cookie_obj->getValue(),
-          'secure' => $cookie_obj->isSecure(),
+          'name' => $cookie_object->getName(),
+          'value' => $cookie_object->getValue(),
+          'secure' => $cookie_object->isSecure(),
         ];
       }
     }

--- a/src/CookieTrait.php
+++ b/src/CookieTrait.php
@@ -25,7 +25,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with the name :name should exist')]
   public function cookieAssertWithNameExists(string $name): void {
-    static::cookieExists($name);
+    $this->cookieExists($name);
   }
 
   /**
@@ -37,7 +37,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with the name :name and the value :value should exist')]
   public function cookieAssertWithNameValueExists(string $name, string $value): void {
-    static::cookieExists($name, $value);
+    $this->cookieExists($name, $value);
   }
 
   /**
@@ -49,7 +49,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with the name :name and a value containing :partial_value should exist')]
   public function cookieAssertWithNamePartialValueExists(string $name, string $partial_value): void {
-    static::cookieExists($name, $partial_value, FALSE, TRUE);
+    $this->cookieExists($name, $partial_value, FALSE, TRUE);
   }
 
   /**
@@ -61,7 +61,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with a name containing :partial_name should exist')]
   public function cookieAssertWithPartialNameExists(string $partial_name): void {
-    static::cookieExists($partial_name, NULL, TRUE);
+    $this->cookieExists($partial_name, NULL, TRUE);
   }
 
   /**
@@ -73,7 +73,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with a name containing :partial_name and the value :value should exist')]
   public function cookieAssertWithPartialNameValueExists(string $partial_name, string $value): void {
-    static::cookieExists($partial_name, $value, TRUE);
+    $this->cookieExists($partial_name, $value, TRUE);
   }
 
   /**
@@ -85,7 +85,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with a name containing :partial_name and a value containing :partial_value should exist')]
   public function cookieAssertWithPartialNamePartialValueExists(string $partial_name, string $partial_value): void {
-    static::cookieExists($partial_name, $partial_value, TRUE, TRUE);
+    $this->cookieExists($partial_name, $partial_value, TRUE, TRUE);
   }
 
   /**
@@ -97,7 +97,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with the name :name should not exist')]
   public function cookieAssertWithNameNotExists(string $name): void {
-    static::cookieNotExists($name);
+    $this->cookieNotExists($name);
   }
 
   /**
@@ -109,7 +109,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with the name :name and the value :value should not exist')]
   public function cookieAssertWithNameValueNotExists(string $name, string $value): void {
-    static::cookieNotExists($name, $value);
+    $this->cookieNotExists($name, $value);
   }
 
   /**
@@ -121,7 +121,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with the name :name and a value containing :partial_value should not exist')]
   public function cookieAssertWithNamePartialValueNotExists(string $name, string $partial_value): void {
-    static::cookieNotExists($name, $partial_value, FALSE, TRUE);
+    $this->cookieNotExists($name, $partial_value, FALSE, TRUE);
   }
 
   /**
@@ -133,7 +133,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with a name containing :partial_name should not exist')]
   public function cookieAssertWithPartialNameNotExists(string $partial_name): void {
-    static::cookieNotExists($partial_name, NULL, TRUE);
+    $this->cookieNotExists($partial_name, NULL, TRUE);
   }
 
   /**
@@ -145,7 +145,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with a name containing :partial_name and the value :value should not exist')]
   public function cookieAssertWithPartialNameValueNotExists(string $partial_name, string $value): void {
-    static::cookieNotExists($partial_name, $value, TRUE);
+    $this->cookieNotExists($partial_name, $value, TRUE);
   }
 
   /**
@@ -157,7 +157,7 @@ trait CookieTrait {
    */
   #[Then('a cookie with a name containing :partial_name and a value containing :partial_value should not exist')]
   public function cookieAssertWithPartialNamePartialValueNotExists(string $partial_name, string $partial_value): void {
-    static::cookieNotExists($partial_name, $partial_value, TRUE, TRUE);
+    $this->cookieNotExists($partial_name, $partial_value, TRUE, TRUE);
   }
 
   /**
@@ -238,7 +238,7 @@ trait CookieTrait {
    *   The cookie or NULL if not found.
    */
   protected function cookieGetByName(string $name, bool $is_partial = FALSE): ?array {
-    $cookies = self::cookieGetAll();
+    $cookies = $this->cookieGetAll();
 
     foreach ($cookies as $cookie) {
       if ($is_partial) {

--- a/src/CookieTrait.php
+++ b/src/CookieTrait.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\Then;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Behat\Step\Then;
 
 /**
  * Verify and inspect browser cookies.

--- a/src/DateTrait.php
+++ b/src/DateTrait.php
@@ -111,7 +111,7 @@ trait DateTrait {
         $timestamp = date($matches[3], $timestamp);
       }
 
-      if (empty(trim((string) strval($timestamp)))) {
+      if (empty(trim((string) $timestamp))) {
         throw new \RuntimeException(sprintf('The supplied relative date cannot be evaluated: "%s"', $matches[1]));
       }
 

--- a/src/DateTrait.php
+++ b/src/DateTrait.php
@@ -41,7 +41,7 @@ trait DateTrait {
    */
   #[Transform('table:*')]
   public function dateRelativeTransformTable(TableNode $table): TableNode {
-    // Inexpensive token detection and early exit.
+    // A cheap substring check skips tables without tokens.
     if (!static::dateRelativeStringHasToken($table->getTableAsString())) {
       return $table;
     }
@@ -90,7 +90,7 @@ trait DateTrait {
    * that relative time within a day use max of 12 hours offset.
    */
   public static function dateRelativeProcessValue(string $value, ?int $now = NULL): string {
-    // Inexpensive token detection and early exit.
+    // A cheap substring check skips values without tokens.
     if (!static::dateRelativeStringHasToken($value)) {
       return $value;
     }
@@ -106,7 +106,6 @@ trait DateTrait {
         throw new \RuntimeException(sprintf('The supplied relative date cannot be evaluated: "%s"', $matches[1]));
       }
 
-      // Convert to date format, if provided.
       if (isset($matches[3])) {
         $timestamp = date($matches[3], $timestamp);
       }

--- a/src/DateTrait.php
+++ b/src/DateTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Transformation\Transform;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Transformation\Transform;
 
 /**
  * Convert relative date expressions into timestamps or formatted dates.

--- a/src/DropzoneTrait.php
+++ b/src/DropzoneTrait.php
@@ -90,7 +90,7 @@ trait DropzoneTrait {
           document.body.appendChild(input);
         }
       })();",
-      json_encode($holder_ids)
+      json_encode($holder_ids, JSON_UNESCAPED_SLASHES)
     ));
 
     foreach ($holder_ids as $index => $holder_id) {
@@ -124,8 +124,8 @@ trait DropzoneTrait {
           }
         }
       })();",
-      json_encode($holder_ids),
-      json_encode($selector)
+      json_encode($holder_ids, JSON_UNESCAPED_SLASHES),
+      json_encode($selector, JSON_UNESCAPED_SLASHES)
     ));
   }
 

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -153,7 +153,6 @@ trait BlockTrait {
    *   Given the block "My block" is enabled
    * @endcode
    *
-   *
    * @throws \Drupal\Core\Entity\EntityStorageException
    *   When the block cannot be saved.
    */
@@ -176,7 +175,6 @@ trait BlockTrait {
    * @code
    *   Given the block "My block" is disabled
    * @endcode
-   *
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    *   When the block cannot be saved.
@@ -249,7 +247,6 @@ trait BlockTrait {
    *   Then the block "My block" should exist
    * @endcode
    *
-   *
    * @throws \Exception
    *   When no block with the specified label is found.
    */
@@ -271,7 +268,6 @@ trait BlockTrait {
    * @code
    *   Then the block "My block" should not exist
    * @endcode
-   *
    *
    * @throws \Exception
    *   When block with the specified label is found.
@@ -296,7 +292,6 @@ trait BlockTrait {
    * @code
    *   Then the block "My block" should exist in the "content" region
    * @endcode
-   *
    *
    * @throws \Exception
    *   When no block with the specified label is found in the given region.
@@ -324,7 +319,6 @@ trait BlockTrait {
    * @code
    *   Then the block "My block" should not exist in the "content" region
    * @endcode
-   *
    *
    * @throws \Exception
    *   When block with the specified label is found in the given region.

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -347,7 +347,7 @@ trait BlockTrait {
    * @throws \Exception
    *   When no block with the specified label is found.
    */
-  private function blockLoadByLabel(string $label): ?Block {
+  protected function blockLoadByLabel(string $label): ?Block {
     $default_theme = \Drupal::config('system.theme')->get('default');
 
     $blocks = \Drupal::entityTypeManager()

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -52,7 +52,7 @@ trait BlockTrait {
 
         $block->set('id', $block_id);
 
-        // Set temporary label to pass to the block configuration step.
+        // Set a temporary label for the 'blockConfigure()' call.
         $settings = $block->get('settings');
         $settings['label'] = $admin_label;
         $block->set('settings', $settings);

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\Given;
-use Behat\Step\Then;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Drupal\block\Entity\Block;
 
 /**

--- a/src/Drupal/CacheTrait.php
+++ b/src/Drupal/CacheTrait.php
@@ -68,8 +68,8 @@ trait CacheTrait {
       throw new \RuntimeException(sprintf('The page cache table "%s" does not exist. Ensure the "%s" cache bin is configured.', $table, $bin));
     }
 
-    // Escape SQL LIKE metacharacters that we do not want to treat as
-    // wildcards, then convert the glob `*` to the SQL `%` wildcard.
+    // Escape SQL LIKE metacharacters so they match literally, then convert
+    // the glob `*` to the SQL `%` wildcard.
     $like = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $path_pattern);
     $like = str_replace('*', '%', $like);
 
@@ -93,8 +93,8 @@ trait CacheTrait {
   /**
    * Get the cache bin used for the page cache.
    *
-   * Override in your `FeatureContext` if the site uses a custom internal page
-   * cache bin name.
+   * Override in the consuming `FeatureContext` if the site uses a custom
+   * internal page cache bin name.
    */
   protected function cacheGetPageCacheBin(): string {
     return 'page';

--- a/src/Drupal/ConfigOverrideTrait.php
+++ b/src/Drupal/ConfigOverrideTrait.php
@@ -118,8 +118,8 @@ trait ConfigOverrideTrait {
   #[BeforeStep]
   public function configOverrideBeforeStep(BeforeStepScope $scope): void {
     if ($this->configOverrideSkipBeforeStep || $this->configOverrideDisabledNames === []) {
-      // Nothing to propagate - make sure the driver-level header is also
-      // cleared so a previously-set value does not survive into this step.
+      // Nothing to propagate - clear the driver-level header too so a
+      // previously-set value does not remain in effect for this step.
       $this->configOverrideClearDriverHeader();
       return;
     }

--- a/src/Drupal/ConfigTrait.php
+++ b/src/Drupal/ConfigTrait.php
@@ -50,9 +50,9 @@ trait ConfigTrait {
   /**
    * Original raw data of configuration objects touched during the scenario.
    *
-   * Keyed by configuration name. Each entry records whether the object existed
-   * before the first write so that revert can delete objects created by the
-   * scenario rather than leaving empty shells behind.
+   * Keyed by configuration name. Each entry records whether the object
+   * existed before the first write so revert deletes objects the scenario
+   * created instead of leaving empty objects behind.
    *
    * @var array<string, array{existed: bool, data: array<int|string, mixed>}>
    */

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -52,7 +52,6 @@ trait ContentBlockTrait {
    *   | [TEST] Contact Form  |
    * @endcode
    *
-   *
    * @throws \Drupal\Core\Entity\EntityStorageException
    *   When the entity cannot be deleted.
    */
@@ -202,7 +201,7 @@ trait ContentBlockTrait {
    *
    * @param string $type
    *   The block content type.
-   * @param array<string,string> $conditions
+   * @param array<string, string> $conditions
    *   Conditions keyed by field names.
    *
    * @return array<int, string>

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -162,8 +162,6 @@ trait ContentBlockTrait {
   /**
    * Create a block content entity with the specified type and field values.
    *
-   * This internal helper method creates and saves a single content block
-   * entity.
    * Created entities are stored in the static $blockContentEntities array for
    * automatic cleanup after the scenario.
    *

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\Then;
-use Behat\Step\Given;
-use Behat\Step\When;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Drupal\block_content\BlockContentTypeInterface;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\Driver\Entity\EntityStub;

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ExpectationException;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Exception\ExpectationException;
 use Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate;
 use Drupal\DrupalExtension\Hook\Scope\BeforeNodeCreateScope;
 use Drupal\node\Entity\Node;

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -66,9 +66,9 @@ trait ContentTrait {
     foreach ($table->getHash() as $node_hash) {
       $nids = $this->contentLoadMultiple($content_type, $node_hash);
 
-      $controller = \Drupal::entityTypeManager()->getStorage('node');
-      $entities = $controller->loadMultiple($nids);
-      $controller->delete($entities);
+      $storage = \Drupal::entityTypeManager()->getStorage('node');
+      $entities = $storage->loadMultiple($nids);
+      $storage->delete($entities);
     }
   }
 

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -220,7 +220,13 @@ trait ContentTrait {
     $node = $this->contentLoadNodeByTitle($content_type, $title);
 
     $handler = \Drupal::entityTypeManager()->getAccessControlHandler('node');
-    assert($handler instanceof NodeAccessControlHandlerInterface);
+
+    // @codeCoverageIgnoreStart
+    if (!$handler instanceof NodeAccessControlHandlerInterface) {
+      throw new \RuntimeException('The node access control handler does not support acquiring grants.');
+    }
+
+    // @codeCoverageIgnoreEnd
     $grants = $handler->acquireGrants($node);
     \Drupal::service('node.grant_storage')->write($node, $grants);
   }

--- a/src/Drupal/DraggableviewsTrait.php
+++ b/src/Drupal/DraggableviewsTrait.php
@@ -40,14 +40,12 @@ trait DraggableviewsTrait {
       $entity_id = $node->id();
 
       // Here and below: copied from draggableviews_views_submit().
-      // Remove old data.
       $database->delete('draggableviews_structure')
         ->condition('view_name', $view_id)
         ->condition('view_display', $view_display_id)
         ->condition('entity_id', $entity_id)
         ->execute();
 
-      // Add new data.
       $record = [
         'view_name' => $view_id,
         'view_display' => $view_display_id,
@@ -59,8 +57,8 @@ trait DraggableviewsTrait {
       $database->insert('draggableviews_structure')->fields($record)->execute();
     }
 
-    // We invalidate the entity list cache, so other views are also aware of the
-    // cache.
+    // Invalidate the entity list cache so other views also reflect the
+    // change.
     $list_cache_tags = \Drupal::entityTypeManager()->getDefinition('node')->getListCacheTags();
     Cache::invalidateTags($list_cache_tags);
   }

--- a/src/Drupal/DraggableviewsTrait.php
+++ b/src/Drupal/DraggableviewsTrait.php
@@ -28,7 +28,7 @@ trait DraggableviewsTrait {
    */
   #[When('I save the draggable views items of the view :view_id and the display :view_display_id for the :bundle content in the following order:')]
   public function draggableViewsSaveBundleOrder(string $view_id, string $view_display_id, string $bundle, TableNode $order_table): void {
-    $connection = Database::getConnection();
+    $database = Database::getConnection();
 
     foreach ($order_table->getColumn(0) as $weight => $title) {
       $node = $this->draggableViewsFindNode($bundle, ['title' => $title]);
@@ -41,7 +41,7 @@ trait DraggableviewsTrait {
 
       // Here and below: copied from draggableviews_views_submit().
       // Remove old data.
-      $connection->delete('draggableviews_structure')
+      $database->delete('draggableviews_structure')
         ->condition('view_name', $view_id)
         ->condition('view_display', $view_display_id)
         ->condition('entity_id', $entity_id)
@@ -56,7 +56,7 @@ trait DraggableviewsTrait {
         'weight' => $weight,
       ];
 
-      $connection->insert('draggableviews_structure')->fields($record)->execute();
+      $database->insert('draggableviews_structure')->fields($record)->execute();
     }
 
     // We invalidate the entity list cache, so other views are also aware of the

--- a/src/Drupal/DraggableviewsTrait.php
+++ b/src/Drupal/DraggableviewsTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\When;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Step\When;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Database\Database;
 use Drupal\node\Entity\Node;

--- a/src/Drupal/EckTrait.php
+++ b/src/Drupal/EckTrait.php
@@ -35,7 +35,6 @@ trait EckTrait {
   #[Given('the following eck :bundle :entity_type entities exist:')]
   public function eckEntitiesCreate(string $bundle, string $entity_type, TableNode $table): void {
     $filtered_table = TableNode::fromList($table->getColumn(0));
-    // Delete entities before creating them.
     $this->eckDeleteEntities($bundle, $entity_type, $filtered_table);
     $this->eckCreateEntities($entity_type, $bundle, $table);
   }

--- a/src/Drupal/EckTrait.php
+++ b/src/Drupal/EckTrait.php
@@ -51,11 +51,11 @@ trait EckTrait {
    */
   #[Given('the following eck :bundle :entity_type entities do not exist:')]
   public function eckDeleteEntities(string $bundle, string $entity_type, TableNode $table): void {
-    foreach ($table->getHash() as $node_hash) {
-      $entity_ids = $this->eckLoadMultiple($entity_type, $bundle, $node_hash);
+    foreach ($table->getHash() as $entity_hash) {
+      $entity_ids = $this->eckLoadMultiple($entity_type, $bundle, $entity_hash);
 
-      $controller = \Drupal::entityTypeManager()->getStorage($entity_type);
-      $entities = $controller->loadMultiple($entity_ids);
+      $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
+      $entities = $storage->loadMultiple($entity_ids);
       foreach ($entities as $entity) {
         $entity->delete();
       }

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -638,7 +638,7 @@ trait EmailTrait {
   /**
    * Get email messages collected during the test.
    *
-   * @return array<string,array<string,mixed>>
+   * @return array<string, array<string, mixed>>
    *   Array of collected emails.
    */
   protected function emailGetCollectedMessages(): array {
@@ -683,7 +683,7 @@ trait EmailTrait {
    * @param bool $exact
    *   Whether to search for an exact match.
    *
-   * @return array<string,string|array<string,mixed>>|null
+   * @return array<string, string|array<string, mixed>>|null
    *   Email message or NULL if not found.
    */
   protected function emailFindMessage(string $field, PyStringNode $string, bool $exact = FALSE): ?array {

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -655,16 +655,16 @@ trait EmailTrait {
     $fields = ['subject', 'body', 'to', 'from', 'cc', 'bcc'];
 
     // Normalize the keys to lowercase.
-    foreach ($messages as $idx => $message) {
-      $messages[$idx] = array_change_key_case($message, CASE_LOWER);
+    foreach ($messages as $index => $message) {
+      $messages[$index] = array_change_key_case($message, CASE_LOWER);
 
       if ($this->emailDebug) {
         printf("----------------------------------------\n");
-        printf("Email message number: %s\n", $idx);
+        printf("Email message number: %s\n", $index);
         printf("----------------------------------------\n");
         foreach ($fields as $field) {
           printf("Field: %s\n", $field);
-          printf("Value: %s\n", $messages[$idx][$field] ?? '<EMPTY>');
+          printf("Value: %s\n", $messages[$index][$field] ?? '<EMPTY>');
           print PHP_EOL;
         }
       }

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -236,9 +236,7 @@ trait EmailTrait {
    */
   #[Then('an email should be sent to the address :address with the content:')]
   public function emailAssertMessageSentToAddressWithContent(string $address, PyStringNode $string): void {
-    // Assert that an email was sent to the specified address.
     $this->emailAssertMessageSentTo($address);
-    // Assert that the email body matches the specified content exactly.
     $this->emailAssertMessageField('body', $string);
   }
 
@@ -254,9 +252,7 @@ trait EmailTrait {
    */
   #[Then('an email should be sent to the address :address with the content containing:')]
   public function emailAssertMessageSentToAddressWithContentContaining(string $address, PyStringNode $string): void {
-    // Assert that an email was sent to the specified address.
     $this->emailAssertMessageSentTo($address);
-    // Assert that the email body contains the specified content.
     $this->emailAssertMessageFieldContains('body', $string);
   }
 
@@ -272,9 +268,7 @@ trait EmailTrait {
    */
   #[Then('an email should be sent to the address :address with the content not containing:')]
   public function emailAssertMessageSentToAddressWithContentNotContaining(string $address, PyStringNode $string): void {
-    // Assert that an email was sent to the specified address.
     $this->emailAssertMessageSentTo($address);
-    // Assert that the email body does not contain the specified content.
     $this->emailAssertMessageFieldNotContains('body', $string);
   }
 
@@ -290,9 +284,7 @@ trait EmailTrait {
    */
   #[Then('an email should not be sent to the address :address with the content:')]
   public function emailAssertMessageNotSentToAddressWithContent(string $address, PyStringNode $string): void {
-    // Assert that no email was sent to the specified address.
     $this->emailAssertNoMessagesSentToAddress($address);
-    // Assert that no email contains the specified content in the body.
     $this->emailAssertMessageFieldNotExact('body', $string);
   }
 
@@ -308,9 +300,7 @@ trait EmailTrait {
    */
   #[Then('an email should not be sent to the address :address with the content containing:')]
   public function emailAssertMessageNotSentToAddressWithContentContaining(string $address, PyStringNode $string): void {
-    // Assert that no email was sent to the specified address.
     $this->emailAssertNoMessagesSentToAddress($address);
-    // Assert that no email body contains the specified content as a substring.
     $this->emailAssertMessageFieldNotContains('body', $string);
   }
 
@@ -458,7 +448,6 @@ trait EmailTrait {
       throw new ExpectationException(sprintf('Unable to find email with subject containing "%s" retrieved from test email collector.', $subject), $this->getSession()->getDriver());
     }
 
-    // Extract the body from the email.
     if (isset($message['params']['body']) && is_string($message['params']['body'])) {
       $body = $message['params']['body'];
     }
@@ -555,16 +544,14 @@ trait EmailTrait {
     foreach ($this->emailHandlerTypes as $type) {
       // Store the original system to restore after the scenario.
       $original_test_system = self::emailGetMailSystemDefault($type);
-      // But store only if previous has not been stored yet.
       if (!self::emailGetMailSystemOriginal($type)) {
         self::emailSetMailSystemOriginal($type, $original_test_system);
       }
-      // Set the test system.
       self::emailSetMailSystemDefault($type, 'test_mail_collector');
     }
 
-    // Flush the email buffer, allowing us to reuse this step definition
-    // to clear existing mail.
+    // Clearing here lets this step definition be reused to clear existing
+    // mail.
     $this->emailClearTestQueue(TRUE);
   }
 
@@ -579,7 +566,6 @@ trait EmailTrait {
   public function emailDisableTestEmailSystem(): void {
     foreach ($this->emailHandlerTypes as $type) {
       $original_test_system = self::emailGetMailSystemOriginal($type);
-      // Restore the original system to after the scenario.
       self::emailSetMailSystemDefault($type, $original_test_system);
     }
 
@@ -600,11 +586,11 @@ trait EmailTrait {
   protected static function emailSetMailSystemDefault(string $type, mixed $value): void {
     \Drupal::configFactory()->getEditable('system.mail')->set('interface.' . $type, $value)->save();
 
-    // Mailsystem module completely takes over default interface, so we need to
-    // update it as well if the module is installed.
-    // @note: For some unknown reasons, we do not need to reset this back to
-    // the original values after the test. The values in the configuration
-    // will not be overridden.
+    // The Mailsystem module completely takes over the default interface, so
+    // update its configuration as well when the module is installed.
+    // For unknown reasons, resetting this back to the original values after
+    // the test is not required: the values in the configuration will not be
+    // overridden.
     // @codeCoverageIgnoreStart
     if (\Drupal::service('module_handler')->moduleExists('mailsystem')) {
       \Drupal::configFactory()->getEditable('mailsystem.settings')
@@ -654,7 +640,6 @@ trait EmailTrait {
 
     $fields = ['subject', 'body', 'to', 'from', 'cc', 'bcc'];
 
-    // Normalize the keys to lowercase.
     foreach ($messages as $index => $message) {
       $messages[$index] = array_change_key_case($message, CASE_LOWER);
 
@@ -717,7 +702,6 @@ trait EmailTrait {
    *   Array of extracted links.
    */
   protected static function emailExtractLinks(string $string): array {
-    // Correct links before extraction.
     $pattern = '(?xi)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))';
     $string = preg_replace_callback(sprintf('#%s#i', $pattern), fn(array $matches): string => preg_match('!^https?://!i', $matches[0]) ? $matches[0] : 'http://' . $matches[0], $string);
 

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -82,7 +82,7 @@ trait EmailTrait {
 
     $this->emailHandlerTypes = array_unique($this->emailHandlerTypes);
 
-    self::emailEnableTestSystem();
+    $this->emailEnableTestSystem();
   }
 
   /**
@@ -95,7 +95,7 @@ trait EmailTrait {
     }
 
     if ($scope->getScenario()->hasTag('email')) {
-      self::emailDisableTestEmailSystem();
+      $this->emailDisableTestEmailSystem();
     }
   }
 
@@ -365,7 +365,7 @@ trait EmailTrait {
       throw new \RuntimeException(sprintf('Invalid message field %s was specified for assertion', $field));
     }
     // @codeCoverageIgnoreEnd
-    $string = strval($string);
+    $string = (string) $string;
     $string = $exact ? $string : $this->helperNormalizeWhitespace($string);
 
     foreach ($this->emailGetCollectedMessages() as $message) {
@@ -402,7 +402,7 @@ trait EmailTrait {
    */
   #[When('I follow link number :link_number in the email with the subject :subject')]
   public function emailFollowLinkNumber(string $link_number, string $subject): void {
-    $link_number = intval($link_number);
+    $link_number = (int) $link_number;
 
     $message = $this->emailFindMessage('subject', new PyStringNode([$subject], 0));
 
@@ -444,7 +444,7 @@ trait EmailTrait {
    */
   #[When('I follow link number :link_number in the email with the subject containing :subject')]
   public function emailFollowLinkNumberWithSubjectContaining(string $link_number, string $subject): void {
-    $link_number = intval($link_number);
+    $link_number = (int) $link_number;
 
     $message = NULL;
     foreach ($this->emailGetCollectedMessages() as $m) {

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\When;
-use Behat\Step\Then;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
-use Behat\Gherkin\Node\PyStringNode;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Then;
+use Behat\Step\When;
 use DrevOps\BehatSteps\HelperTrait;
 use Drupal\Core\Database\Database;
 use Drupal\Core\Database\StatementInterface;

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -138,7 +138,6 @@ trait FileTrait {
   protected function fileCreateEntity(string $path, EntityStub $stub, ?string $uri = NULL): FileInterface {
     $path = ltrim($path, '/');
 
-    // Get fixture file path.
     if (!empty($this->getMinkParameter('files_path'))) {
       $full_path = rtrim((string) realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $path;
       if (is_file($full_path)) {
@@ -223,7 +222,6 @@ trait FileTrait {
     $storage = \Drupal::entityTypeManager()->getStorage('file');
 
     $field_values = $table->getColumn(0);
-    // Get field name of the column header.
     $field_name = array_shift($field_values);
 
     // @codeCoverageIgnoreStart

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -35,7 +35,7 @@ trait FileTrait {
   /**
    * Unmanaged file URIs.
    *
-   * @var array<int,string>
+   * @var array<int, string>
    */
   protected $filesUnmanagedUris = [];
 

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -148,7 +148,7 @@ trait FileTrait {
 
     // @codeCoverageIgnoreStart
     if (!is_readable($path)) {
-      throw new \RuntimeException('Unable to find file "' . $path . '".');
+      throw new \RuntimeException(sprintf('Unable to find file "%s".', $path));
     }
     // @codeCoverageIgnoreEnd
     $destination = 'public://' . basename($path);
@@ -158,7 +158,7 @@ trait FileTrait {
       $dir = \Drupal::service('file_system')->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY + FileSystemInterface::MODIFY_PERMISSIONS);
       // @codeCoverageIgnoreStart
       if (!$dir) {
-        throw new \RuntimeException('Unable to prepare directory "' . $directory . '".');
+        throw new \RuntimeException(sprintf('Unable to prepare directory "%s".', $directory));
       }
       // @codeCoverageIgnoreEnd
     }
@@ -166,7 +166,7 @@ trait FileTrait {
     $content = file_get_contents($path);
     // @codeCoverageIgnoreStart
     if ($content === FALSE) {
-      throw new \RuntimeException('Unable to read file "' . $path . '".');
+      throw new \RuntimeException(sprintf('Unable to read file "%s".', $path));
     }
     // @codeCoverageIgnoreEnd
     $entity = \Drupal::service('file.repository')->writeData($content, $destination, FileExists::Replace);
@@ -276,7 +276,7 @@ trait FileTrait {
     if (!file_exists($directory)) {
       $dir = \Drupal::service('file_system')->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY + FileSystemInterface::MODIFY_PERMISSIONS);
       if (!$dir) {
-        throw new \RuntimeException('Unable to prepare directory "' . $directory . '".');
+        throw new \RuntimeException(sprintf('Unable to prepare directory "%s".', $directory));
       }
     }
     // @codeCoverageIgnoreEnd

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\Given;
-use Behat\Step\Then;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
-use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Driver\Entity\EntityStub;

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -115,11 +115,11 @@ trait FileTrait {
   protected function fileCreateManagedSingle(string $path, EntityStub $stub, ?string $uri = NULL): FileInterface {
     $this->parseEntityFields($stub);
 
-    $saved = $this->fileCreateEntity($path, $stub, $uri);
+    $entity = $this->fileCreateEntity($path, $stub, $uri);
 
-    $this->entityRegister($saved);
+    $this->entityRegister($entity);
 
-    return $saved;
+    return $entity;
   }
 
   /**

--- a/src/Drupal/HelperTrait.php
+++ b/src/Drupal/HelperTrait.php
@@ -56,8 +56,7 @@ trait HelperTrait {
    *
    * Each item is a [entity_type_id, entity_id] pair. Ids are stored as scalars
    * so each entity is reloaded fresh at cleanup time and an already-deleted row
-   * is tolerated. Registering an entity only records it here; deleting
-   * registered entities is a separate concern handled at scenario teardown.
+   * is tolerated.
    *
    * @var array<int, array{0: string, 1: int|string}>
    */
@@ -168,7 +167,7 @@ trait HelperTrait {
    * drupal-driver's FileHandler can read and upload them during entity
    * creation. Skips expansion when a managed file with the same basename
    * already exists in public:// or private://, so existing files take
-   * precedence and behaviour stays backward compatible.
+   * precedence.
    *
    * Requires a Drupal context: the consumer must expose 'getMinkParameter()'
    * and 'getDriver()' (e.g. via MinkContext / RawDrupalContext) and Drupal
@@ -207,11 +206,10 @@ trait HelperTrait {
         continue;
       }
 
-      // Raw compound string (e.g. 'target_id:"foo.jpg", alt:"A"') as written
-      // in the Behat table. Hooks fired by 'RawDrupalContext::nodeCreate()'
-      // run before 'parseEntityFields()', so on the node path the helper sees
-      // the unparsed cell. Rewrite the basename inside the 'target_id:"..."'
-      // segment in place and leave the rest of the cell to the parser.
+      // Hooks fired by 'RawDrupalContext::nodeCreate()' run before
+      // 'parseEntityFields()', so on the node path the value is the raw
+      // compound cell as written in the Behat table
+      // (e.g. 'target_id:"foo.jpg", alt:"A"').
       if (is_string($value) && $this->helperLooksLikeCompoundCell($value)) {
         $rewritten = $this->helperExpandCompoundCellFixtures($value, $fixture_path);
 
@@ -229,9 +227,9 @@ trait HelperTrait {
       // - list of records: [['target_id' => 'foo.jpg', 'alt' => 'A'], ...] (multi-value compound)
       //
       // Numerically-indexed arrays (lists) are iterated element-by-element so
-      // every delta gets resolved. Keyed records and bare scalars are wrapped
-      // in a single-element list, processed once, and unwrapped on the way
-      // back into the stub.
+      // every delta is resolved. Keyed records and bare scalars are wrapped
+      // in a single-element list, processed once, and unwrapped when written
+      // back to the stub.
       $is_list = is_array($value) && array_is_list($value);
       $records = $is_list ? $value : [$value];
       $mutated = FALSE;
@@ -282,9 +280,7 @@ trait HelperTrait {
    * Detect a raw compound cell string of the shape 'key:"..."' or 'key:[...]'.
    *
    * Mirrors the top-level pattern 'EntityFieldParser' uses to enter compound
-   * mode: an identifier, optional whitespace, ':', optional whitespace, then
-   * a '"' or '['. Used to distinguish a compound cell that needs in-string
-   * basename rewriting from a bare scalar basename like 'document.pdf'.
+   * mode.
    */
   protected function helperLooksLikeCompoundCell(string $value): bool {
     return preg_match('/^\s*[a-z_][a-z0-9_]*\s*:\s*[\"\[]/i', $value) === 1;
@@ -329,7 +325,7 @@ trait HelperTrait {
    * Check whether a managed file with the given basename already exists.
    *
    * Mirrors drupal-driver FileHandler::resolveExistingFile() for bare
-   * basenames so callers do not pre-empt the driver's own lookup.
+   * basenames so the driver's own lookup is not pre-empted.
    *
    * @param string $basename
    *   Candidate basename (no path separators).

--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -56,8 +56,8 @@ trait MediaTrait {
     // Delete entities before creating them.
     $this->mediaDelete($media_type, $table);
 
-    foreach ($table->getHash() as $node_hash) {
-      $stub = new EntityStub('media', $media_type, $node_hash);
+    foreach ($table->getHash() as $media_hash) {
+      $stub = new EntityStub('media', $media_type, $media_hash);
       $this->mediaCreateSingle($stub);
     }
   }
@@ -105,11 +105,11 @@ trait MediaTrait {
    */
   #[Given('the following media :media_type do not exist:')]
   public function mediaDelete(string $media_type, TableNode $table): void {
-    foreach ($table->getHash() as $node_hash) {
-      $ids = $this->mediaLoadMultiple($media_type, $node_hash);
-      $controller = \Drupal::entityTypeManager()->getStorage('media');
-      $entities = $controller->loadMultiple($ids);
-      $controller->delete($entities);
+    foreach ($table->getHash() as $media_hash) {
+      $ids = $this->mediaLoadMultiple($media_type, $media_hash);
+      $storage = \Drupal::entityTypeManager()->getStorage('media');
+      $entities = $storage->loadMultiple($ids);
+      $storage->delete($entities);
     }
   }
 
@@ -266,10 +266,10 @@ trait MediaTrait {
    */
   protected function mediaCreateSingle(EntityStub $stub): MediaInterface {
     $this->parseEntityFields($stub);
-    $saved = $this->mediaCreateEntity($stub);
-    $this->entityRegister($saved);
+    $entity = $this->mediaCreateEntity($stub);
+    $this->entityRegister($entity);
 
-    return $saved;
+    return $entity;
   }
 
   /**

--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -53,7 +53,6 @@ trait MediaTrait {
    */
   #[Given('the following media :media_type exist:')]
   public function mediaCreate(string $media_type, TableNode $table): void {
-    // Delete entities before creating them.
     $this->mediaDelete($media_type, $table);
 
     foreach ($table->getHash() as $media_hash) {
@@ -84,7 +83,6 @@ trait MediaTrait {
     $entities = $this->helperTransposeVerticalTable($table);
     $horizontal_table = $this->helperBuildHorizontalTable($entities);
 
-    // Delete entities before creating them.
     $this->mediaDelete($bundle, $horizontal_table);
 
     foreach ($entities as $entity_data) {
@@ -284,7 +282,6 @@ trait MediaTrait {
   protected function mediaCreateEntity(EntityStub $stub): MediaInterface {
     $bundle = $stub->getBundle();
 
-    // Throw an exception if the media type is missing or does not exist.
     // @codeCoverageIgnoreStart
     if (empty($bundle)) {
       throw new \Exception('Cannot create media because it is missing the required bundle.');

--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -287,10 +287,10 @@ trait MediaTrait {
     // Throw an exception if the media type is missing or does not exist.
     // @codeCoverageIgnoreStart
     if (empty($bundle)) {
-      throw new \Exception("Cannot create media because it is missing the required bundle.");
+      throw new \Exception('Cannot create media because it is missing the required bundle.');
     }
 
-    $bundles = \Drupal::getContainer()->get('entity_type.bundle.info')->getBundleInfo('media');
+    $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo('media');
     if (!in_array($bundle, array_keys($bundles))) {
       throw new \Exception(sprintf("Cannot create media because provided bundle '%s' does not exist.", $bundle));
     }

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -156,7 +156,7 @@ trait MenuTrait {
    */
   protected function loadMenuByLabel(string $label): ?MenuInterface {
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
-    $entity_type_manager = \Drupal::getContainer()->get('entity_type.manager');
+    $entity_type_manager = \Drupal::entityTypeManager();
     $menu_ids = $entity_type_manager->getStorage('menu')->getQuery()
       ->accessCheck(FALSE)
       ->condition('label', $label)
@@ -192,7 +192,7 @@ trait MenuTrait {
     // @codeCoverageIgnoreEnd
 
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
-    $entity_type_manager = \Drupal::getContainer()->get('entity_type.manager');
+    $entity_type_manager = \Drupal::entityTypeManager();
 
     $menu_link_ids = $entity_type_manager->getStorage('menu_link_content')->getQuery()
       ->accessCheck(FALSE)

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -60,7 +60,6 @@ trait MenuTrait {
   public function menuCreate(TableNode $table): void {
     foreach ($table->getHash() as $menu_hash) {
       if (empty($menu_hash['id'])) {
-        // Create menu id if one was not provided.
         $menu_id = strtolower((string) $menu_hash['label']);
         $menu_id = preg_replace('/[^a-z0-9_]+/', '_', $menu_id);
         $menu_id = preg_replace('/_+/', '_', (string) $menu_id);
@@ -118,13 +117,11 @@ trait MenuTrait {
     // @codeCoverageIgnoreEnd
     foreach ($table->getHash() as $menu_link_hash) {
       $menu_link_hash['menu_name'] = $menu->id();
-      // Add uri to correct property.
       if (isset($menu_link_hash['uri'])) {
         $menu_link_hash['link'] = [];
         $menu_link_hash['link']['uri'] = (string) $menu_link_hash['uri'];
         unset($menu_link_hash['uri']);
       }
-      // Create parent property in format required.
       if (!empty($menu_link_hash['parent']) && is_string($menu_link_hash['parent'])) {
         $parent_link = $this->loadMenuLinkByTitle($menu_link_hash['parent'], $menu_name);
         if ($parent_link instanceof MenuLinkContent) {

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\Given;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Step\Given;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\system\Entity\Menu;
 use Drupal\system\MenuInterface;

--- a/src/Drupal/ModuleTrait.php
+++ b/src/Drupal/ModuleTrait.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\Given;
-use Behat\Step\Then;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
+use Behat\Step\Given;
+use Behat\Step\Then;
 
 /**
  * Enable and disable Drupal modules with automatic state restoration.

--- a/src/Drupal/ModuleTrait.php
+++ b/src/Drupal/ModuleTrait.php
@@ -50,10 +50,8 @@ trait ModuleTrait {
         $should_disable = str_starts_with($module_spec, '!');
         $module_name = $should_disable ? substr($module_spec, 1) : $module_spec;
 
-        // Store original state.
         $this->moduleStoreOriginalState($module_name);
 
-        // Enable or disable module as specified.
         if ($should_disable) {
           if ($this->moduleIsEnabled($module_name)) {
             $this->moduleDisable($module_name);
@@ -88,7 +86,6 @@ trait ModuleTrait {
       }
     }
 
-    // Clear state tracking.
     $this->moduleOriginalStates = [];
   }
 

--- a/src/Drupal/OverrideTrait.php
+++ b/src/Drupal/OverrideTrait.php
@@ -50,9 +50,8 @@ trait OverrideTrait {
     $type = (string) $type;
     $filtered_table = TableNode::fromList($table->getColumn(0));
     // 6.x driver bootstraps Drupal lazily inside getDriver(); call it
-    // before our pre-delete touches \Drupal::.
+    // before the pre-delete touches \Drupal::.
     $this->getDriver();
-    // Delete entities before creating them.
     $this->contentDelete($type, $filtered_table);
     parent::createNodes($type, $table);
   }
@@ -62,9 +61,8 @@ trait OverrideTrait {
    */
   public function createUsers(TableNode $table): void {
     // 6.x driver bootstraps Drupal lazily inside getDriver(); call it
-    // before our pre-delete touches \Drupal::.
+    // before the pre-delete touches \Drupal::.
     $this->getDriver();
-    // Delete entities before creating them.
     $this->userDelete($table);
     parent::createUsers($table);
   }
@@ -73,10 +71,9 @@ trait OverrideTrait {
    * {@inheritdoc}
    */
   public function iAmLoggedInAsUserWithRole(string $role): void {
-    // Override parent step to allow using 'anonymous user' role without
-    // actually creating a user with role. By default,
-    // iAmLoggedInAsUserWithRole() creates a user with 'authenticated role'
-    // even if 'anonymous user' role is provided.
+    // The parent iAmLoggedInAsUserWithRole() creates a user with the
+    // 'authenticated' role even when the 'anonymous user' role is provided.
+    // The anonymous case is handled here without creating a user.
     if ($role === 'anonymous user' || $role === 'anonymous') {
       // @codeCoverageIgnoreStart
       if (!empty($this->userManager->getCurrentUser())) {

--- a/src/Drupal/ParagraphsTrait.php
+++ b/src/Drupal/ParagraphsTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\Given;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Step\Given;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Driver\DrupalDriverInterface;
 use Drupal\Driver\Entity\EntityStub;

--- a/src/Drupal/ParagraphsTrait.php
+++ b/src/Drupal/ParagraphsTrait.php
@@ -39,16 +39,12 @@ trait ParagraphsTrait {
   public function paragraphsAddWithFields(string $parent_entity_type, string $parent_bundle, string $parent_field, string $parent_lookup_field, string $parent_lookup_value, string $paragraph_type, TableNode $fields): void {
     $this->paragraphsValidateEntityHasField($parent_entity_type, $parent_bundle, $parent_field);
 
-    // Find previously created entity by entity_type, bundle and identifying
-    // field value.
     $parent_entity = $this->paragraphsFindEntity($parent_entity_type, $parent_bundle, $parent_lookup_field, $parent_lookup_value);
 
     if (!$parent_entity) {
       throw new \RuntimeException(sprintf('The parent entity of type "%s" and bundle "%s" with the field "%s" and the value "%s" was not found', $parent_entity_type, $parent_bundle, $parent_lookup_field, $parent_lookup_value));
     }
 
-    // Get fields from scenario, parse them and expand values according to
-    // field tables.
     $stub = new EntityStub('paragraph', $paragraph_type, $fields->getRowsHash());
     $this->parseEntityFields($stub);
     $this->paragraphsExpandEntityFields($stub);

--- a/src/Drupal/SearchApiTrait.php
+++ b/src/Drupal/SearchApiTrait.php
@@ -53,7 +53,7 @@ trait SearchApiTrait {
    */
   #[When('I run search indexing for :count item(s)')]
   public function searchApiDoIndex(string|int $limit): void {
-    $limit = intval($limit);
+    $limit = (int) $limit;
 
     $index_storage = \Drupal::entityTypeManager()->getStorage('search_api_index');
 

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -29,8 +29,8 @@ trait StateTrait {
   /**
    * Original state values captured before the scenario touched them.
    *
-   * Keys absent from Drupal state are stored with a sentinel marker so they
-   * can be deleted on revert rather than reset to NULL.
+   * Keys absent from Drupal state are stored with `exists` set to FALSE so
+   * they can be deleted on revert rather than reset to NULL.
    *
    * @var array<string, array{exists: bool, value: mixed}>
    */

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ExpectationException;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
-use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Exception\ExpectationException;
 use DrevOps\BehatSteps\HelperTrait;
 use Drupal\taxonomy\Entity\Vocabulary;
 

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -28,7 +28,6 @@ trait TaxonomyTrait {
    */
   public function createTerms(mixed $vocabulary, TableNode $table): void {
     $vocabulary = (string) $vocabulary;
-    // Delete entities before creating them.
     $this->taxonomyDeleteTerms($vocabulary, $table);
     parent::createTerms($vocabulary, $table);
   }

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -252,7 +252,7 @@ trait TaxonomyTrait {
    *
    * @param string $vocabulary_machine_name
    *   The term vocabulary.
-   * @param array<string,string> $conditions
+   * @param array<string, string> $conditions
    *   Conditions keyed by field names.
    *
    * @return array<int, string>

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -75,7 +75,7 @@ trait TaxonomyTrait {
     }
 
     foreach ($terms_table->getColumn(0) as $term_name) {
-      $terms = \Drupal::service('entity_type.manager')->getStorage('taxonomy_term')->loadByProperties([
+      $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
         'name' => $term_name,
         'vid' => $vocabulary_machine_name,
       ]);

--- a/src/Drupal/TimeTrait.php
+++ b/src/Drupal/TimeTrait.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\When;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Hook\AfterScenario;
+use Behat\Step\When;
 
 /**
  * Control system time in tests using Drupal state overrides.

--- a/src/Drupal/TimeTrait.php
+++ b/src/Drupal/TimeTrait.php
@@ -51,7 +51,6 @@ trait TimeTrait {
   /**
    * Resets the system time to real time.
    *
-   *
    * @code
    * When I reset system time
    * @endcode

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -410,10 +410,10 @@ trait UserTrait {
   /**
    * Load multiple users with specified conditions.
    *
-   * @param array<string,string> $conditions
+   * @param array<string, string> $conditions
    *   Conditions keyed by field names.
    *
-   * @return array<int,\Drupal\user\UserInterface>
+   * @return array<int, \Drupal\user\UserInterface>
    *   Array of loaded user objects.
    */
   protected function userLoadMultiple(array $conditions = []): array {

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -251,7 +251,8 @@ trait UserTrait {
   public function userVisitOwnPasswordResetLink(): void {
     $current_user = $this->getUserManager()->getCurrentUser();
 
-    // 6.x stores EntityStubInterface stubs; legacy was \stdClass with ->name.
+    // 6.x stores EntityStubInterface stubs; legacy versions store \stdClass
+    // with ->name.
     if ($current_user instanceof EntityStubInterface) {
       $name = (string) $current_user->getValue('name');
     }
@@ -461,7 +462,8 @@ trait UserTrait {
     if ($name === 'current') {
       $user = $this->getUserManager()->getCurrentUser();
 
-      // 6.x stores EntityStubInterface stubs; legacy was \stdClass with ->uid.
+      // 6.x stores EntityStubInterface stubs; legacy versions store
+      // \stdClass with ->uid.
       if ($user instanceof EntityStubInterface) {
         $uid = $user->getId();
       }

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -121,7 +121,7 @@ trait UserTrait {
   public function userSetLastAccessTime(string $name, string $datetime): void {
     $user = $this->userLoadByName($name);
 
-    $timestamp = is_numeric($datetime) ? intval($datetime) : strtotime($datetime);
+    $timestamp = is_numeric($datetime) ? (int) $datetime : strtotime($datetime);
 
     if ($timestamp === FALSE) {
       throw new \RuntimeException('Invalid date format.');
@@ -145,7 +145,7 @@ trait UserTrait {
   public function userSetLastLoginTime(string $name, string $datetime): void {
     $user = $this->userLoadByName($name);
 
-    $timestamp = is_numeric($datetime) ? intval($datetime) : strtotime($datetime);
+    $timestamp = is_numeric($datetime) ? (int) $datetime : strtotime($datetime);
 
     if ($timestamp === FALSE) {
       throw new \RuntimeException('Invalid date format.');

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Drupal;
 
-use Behat\Step\Given;
-use Behat\Step\When;
-use Behat\Step\Then;
 use Behat\Gherkin\Node\TableNode;
-use DrevOps\BehatSteps\HelperTrait;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+use DrevOps\BehatSteps\HelperTrait;
 use Drupal\Core\Url;
 use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\user\Entity\Role;

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -90,12 +90,12 @@ trait WatchdogTrait {
    * @watchdog:my_module_type @watchdog:my_other_module_type
    * @endcode
    *
-   * @param array<int,string> $tags
+   * @param array<int, string> $tags
    *   Array of scenario tags.
    * @param string $prefix
    *   Optional tag prefix to filter by.
    *
-   * @return array<int,string>
+   * @return array<int, string>
    *   Array of message types. 'php' is always added to the list.
    */
   protected function watchdogParseMessageTypes(array $tags = [], string $prefix = 'watchdog:'): array {

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -68,7 +68,7 @@ trait WatchdogTrait {
     $scenario = $scope->getScenario();
 
     // Step scopes carry neither scenario tags nor scenario identity, so both
-    // are resolved here for the step hook to read. An unset start time is what
+    // are resolved here for the step hook to read. An unset start time
     // disables the check.
     if ($scenario->hasTag('behat-steps-skip:watchdogAfterStep') || $scenario->hasTag('error')) {
       return;

--- a/src/Drupal/WebformTrait.php
+++ b/src/Drupal/WebformTrait.php
@@ -105,7 +105,7 @@ trait WebformTrait {
     \Drupal::configFactory()->reset();
 
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
-    $entity_type_manager = \Drupal::getContainer()->get('entity_type.manager');
+    $entity_type_manager = \Drupal::entityTypeManager();
     $storage = $entity_type_manager->getStorage('webform');
     $storage->resetCache();
 

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\Then;
-use Behat\Step\Given;
-use Behat\Step\When;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * Interact with HTML elements using CSS selectors and DOM attributes.

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -195,12 +195,12 @@ trait ElementTrait {
       if (!empty($attribute_value)) {
         $attribute_found = TRUE;
         if ($is_exact) {
-          if ($attribute_value === strval($value)) {
+          if ($attribute_value === (string) $value) {
             $attribute_value_found = TRUE;
             break;
           }
         }
-        elseif (str_contains($attribute_value, strval($value))) {
+        elseif (str_contains($attribute_value, (string) $value)) {
           $attribute_value_found = TRUE;
           break;
         }

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -31,7 +31,7 @@ trait ElementTrait {
    * Returns FALSE to use the legacy scrollIntoView(true) behavior, which
    * aligns the element to the top of the viewport.
    *
-   * Override this method in your context class to change the behavior:
+   * Override this method in the context class to change the behavior:
    * @code
    * class FeatureContext extends DrupalContext {
    *   use ElementTrait;
@@ -296,7 +296,7 @@ trait ElementTrait {
    * Assert the computed value of a CSS property on an element.
    *
    * A property with an empty computed value is reported as an error in both
-   * the positive and the inverted form: the realistic cause is a misspelled
+   * the positive and the inverted form. The realistic cause is a misspelled
    * property name, which must not silently satisfy a negative assertion.
    *
    * @param string $selector
@@ -1049,7 +1049,6 @@ JS;
 
     foreach ($elements as $element) {
       if ($element->isVisible()) {
-        // Success – at least one match is visible.
         return;
       }
     }
@@ -1215,7 +1214,6 @@ JS;
         return failures.length === 0;
       }
     JS;
-    // Include and call visibility assertion function.
     $script = <<<JS
       (function() {
         {$script_function}

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -185,40 +185,40 @@ trait ElementTrait {
       throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
     }
 
-    $attr_found = FALSE;
-    $attr_value_found = FALSE;
+    $attribute_found = FALSE;
+    $attribute_value_found = FALSE;
     foreach ($elements as $element) {
-      $attr_value = (string) $element->getAttribute($attribute);
-      if (!empty($attr_value)) {
-        $attr_found = TRUE;
+      $attribute_value = (string) $element->getAttribute($attribute);
+      if (!empty($attribute_value)) {
+        $attribute_found = TRUE;
         if ($is_exact) {
-          if ($attr_value === strval($value)) {
-            $attr_value_found = TRUE;
+          if ($attribute_value === strval($value)) {
+            $attribute_value_found = TRUE;
             break;
           }
         }
-        elseif (str_contains($attr_value, strval($value))) {
-          $attr_value_found = TRUE;
+        elseif (str_contains($attribute_value, strval($value))) {
+          $attribute_value_found = TRUE;
           break;
         }
       }
     }
 
-    if (!$attr_found) {
+    if (!$attribute_found) {
       throw new ExpectationException(sprintf('The "%s" attribute does not exist on the element "%s".', $attribute, $selector), $this->getSession()->getDriver());
     }
 
-    if ($is_inverted && $attr_value_found) {
+    if ($is_inverted && $attribute_value_found) {
       $message = $is_exact
         ? sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it should not.', $attribute, $selector, $value)
         : sprintf('The "%s" attribute exists on the element "%s" with a value containing "%s", but it should not.', $attribute, $selector, $value);
       throw new ExpectationException($message, $this->getSession()->getDriver());
     }
 
-    if (!$is_inverted && !$attr_value_found) {
+    if (!$is_inverted && !$attribute_value_found) {
       $message = $is_exact
-        ? sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it does not have a value "%s".', $attribute, $selector, $attr_value, $value)
-        : sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it does not contain a value "%s".', $attribute, $selector, $attr_value, $value);
+        ? sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it does not have a value "%s".', $attribute, $selector, $attribute_value, $value)
+        : sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it does not contain a value "%s".', $attribute, $selector, $attribute_value, $value);
       throw new ExpectationException($message, $this->getSession()->getDriver());
     }
   }
@@ -1042,14 +1042,14 @@ JS;
   #[Then('the element :selector should be displayed')]
   public function elementAssertIsVisible(string $selector): void {
     $page = $this->getSession()->getPage();
-    $nodes = $page->findAll('css', $selector);
+    $elements = $page->findAll('css', $selector);
 
-    if ($nodes === []) {
+    if ($elements === []) {
       throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
     }
 
-    foreach ($nodes as $node) {
-      if ($node->isVisible()) {
+    foreach ($elements as $element) {
+      if ($element->isVisible()) {
         // Success – at least one match is visible.
         return;
       }
@@ -1067,11 +1067,11 @@ JS;
    */
   #[Then('the element :selector should not be displayed')]
   public function elementAssertIsNotVisible(string $selector): void {
-    $element = $this->getSession()->getPage();
-    $nodes = $element->findAll('css', $selector);
+    $page = $this->getSession()->getPage();
+    $elements = $page->findAll('css', $selector);
 
-    foreach ($nodes as $node) {
-      if ($node->isVisible()) {
+    foreach ($elements as $element) {
+      if ($element->isVisible()) {
         throw new ExpectationException(sprintf('Element defined by "%s" selector is visible on the page, but should not be.', $selector), $this->getSession()->getDriver());
       }
     }

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -175,7 +175,10 @@ trait ElementTrait {
    * @param bool $is_inverted
    *   Whether to assert the value is not present.
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   *   If no element matches the selector.
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   If the attribute or its value does not match the expectation.
    */
   protected function elementAssertAttributeWithValue(string $selector, string $attribute, mixed $value, bool $is_exact, bool $is_inverted): void {
     $page = $this->getSession()->getPage();
@@ -717,7 +720,6 @@ JS;
    * Given I accept all confirmation dialogs
    * @endcode
    *
-   *
    * @javascript
    */
   #[Given('I accept all confirmation dialogs')]
@@ -732,7 +734,6 @@ JS;
    * Given I do not accept any confirmation dialogs
    * @endcode
    *
-   *
    * @javascript
    */
   #[Given('I do not accept any confirmation dialogs')]
@@ -746,7 +747,6 @@ JS;
    * @code
    * When I click on the element ".button"
    * @endcode
-   *
    *
    * @javascript
    */
@@ -770,7 +770,6 @@ JS;
    * @code
    * When I click on the element ".card" with the index 2
    * @endcode
-   *
    *
    * @javascript
    */

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\Then;
-use Behat\Step\When;
-use Behat\Step\Given;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
@@ -17,6 +14,9 @@ use Behat\Hook\BeforeScenario;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * Manipulate form fields and verify widget functionality.

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -1074,7 +1074,8 @@ JS;
    * @param string $value
    *   The value to set.
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   *   If the datetime field part cannot be located.
    */
   protected function fieldFillDatetimeHelper(string $label, string $part, string $field, string $value): void {
     // Try to find by label element first.

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -601,12 +601,12 @@ JS;
   #[Then('the option :option should exist within the select element :selector')]
   public function fieldAssertSelectOptionExists(string $selector, string $option): void {
     $select_element = $this->getSession()->getPage()->findField($selector);
-    if (is_null($select_element)) {
+    if ($select_element === NULL) {
       throw new \InvalidArgumentException(sprintf('Element "%s" is not found.', $selector));
     }
 
     $option_element = $select_element->find('named', ['option', $option]);
-    if (is_null($option_element)) {
+    if ($option_element === NULL) {
       throw new \InvalidArgumentException(sprintf('Option "%s" is not found in select "%s".', $option, $selector));
     }
   }
@@ -621,12 +621,12 @@ JS;
   #[Then('the option :option should not exist within the select element :selector')]
   public function fieldAssertSelectOptionNotExists(string $selector, string $option): void {
     $select_element = $this->getSession()->getPage()->findField($selector);
-    if (is_null($select_element)) {
+    if ($select_element === NULL) {
       throw new \InvalidArgumentException(sprintf('Element "%s" is not found.', $selector));
     }
 
     $option_element = $select_element->find('named', ['option', $option]);
-    if (!is_null($option_element)) {
+    if ($option_element !== NULL) {
       throw new \InvalidArgumentException(sprintf('Option "%s" is found in select "%s", but should not.', $option, $selector));
     }
   }

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -119,7 +119,7 @@ trait FileDownloadTrait {
 
     // @codeCoverageIgnoreStart
     if (!$this->fileDownloadDownloadedFileInfo['file_path']) {
-      throw new \RuntimeException('Unable to download file from URL ' . $url . '.');
+      throw new \RuntimeException(sprintf('Unable to download file from URL %s.', $url));
     }
     $file_data = file_get_contents($this->fileDownloadDownloadedFileInfo['file_path']);
     if ($file_data === FALSE) {
@@ -171,7 +171,7 @@ trait FileDownloadTrait {
    */
   #[Then('the downloaded file should contain:')]
   public function fileDownloadAssertFileContains(PyStringNode $string): void {
-    $string = strval($string);
+    $string = (string) $string;
     if (!$this->fileDownloadDownloadedFileInfo) {
       throw new \RuntimeException('Downloaded file content has no data.');
     }
@@ -403,7 +403,7 @@ trait FileDownloadTrait {
 
     if (!$content) {
       // @codeCoverageIgnoreStart
-      throw new \RuntimeException('Unable to save temp file from URL ' . $url . '.');
+      throw new \RuntimeException(sprintf('Unable to save temp file from URL %s.', $url));
       // @codeCoverageIgnoreEnd
     }
 
@@ -431,7 +431,7 @@ trait FileDownloadTrait {
     $written = file_put_contents($file_path, $content);
     if ($written === FALSE) {
       // @codeCoverageIgnoreStart
-      throw new \RuntimeException('Unable to write downloaded content into file ' . $file_path . '.');
+      throw new \RuntimeException(sprintf('Unable to write downloaded content into file %s.', $file_path));
       // @codeCoverageIgnoreEnd
     }
 

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -389,18 +389,18 @@ trait FileDownloadTrait {
       CURLOPT_AUTOREFERER => TRUE,
       CURLOPT_CONNECTTIMEOUT => 120,
       CURLOPT_TIMEOUT => 120,
-      CURLOPT_HEADERFUNCTION => function ($ch, $header) use (&$response_headers): int {
+      CURLOPT_HEADERFUNCTION => function ($handle, $header) use (&$response_headers): int {
         $response_headers[] = $header;
 
         return strlen($header);
       },
     ];
 
-    $ch = curl_init($url);
-    curl_setopt_array($ch, $options);
+    $handle = curl_init($url);
+    curl_setopt_array($handle, $options);
 
-    $content = curl_exec($ch);
-    curl_close($ch);
+    $content = curl_exec($handle);
+    curl_close($handle);
 
     if (!$content) {
       // @codeCoverageIgnoreStart

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -407,13 +407,10 @@ trait FileDownloadTrait {
       // @codeCoverageIgnoreEnd
     }
 
-    // Extract meta information from headers.
     $headers = $this->fileDownloadParseHeaders($response_headers);
 
-    // Resolve file path and name.
     $dir = $this->fileDownloadGetTempDir();
 
-    // Try to extract name from the download string.
     $url_file_name = parse_url($url, PHP_URL_PATH);
     $url_file_name = $url_file_name ? basename($url_file_name) : $url_file_name;
     $headers['file_name'] = empty($headers['file_name']) && !empty($url_file_name) ? $url_file_name : $headers['file_name'];
@@ -427,7 +424,6 @@ trait FileDownloadTrait {
 
     $file_name = basename($file_path);
 
-    // Write file contents.
     $written = file_put_contents($file_path, $content);
     if ($written === FALSE) {
       // @codeCoverageIgnoreStart

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\When;
-use Behat\Step\Then;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Hook\AfterScenario;
-use Behat\Hook\BeforeScenario;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Hook\AfterScenario;
+use Behat\Hook\BeforeScenario;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -149,7 +149,6 @@ trait FileDownloadTrait {
    * Assert that an HTML link is present on the page.
    */
   public function fileDownloadAssertLinkPresent(string $link): NodeElement {
-
     $page = $this->getSession()->getPage();
     $link_element = $page->findLink($link);
 
@@ -442,7 +441,7 @@ trait FileDownloadTrait {
   /**
    * Extract downloaded file information from the response headers.
    *
-   * @param array<int,string> $headers
+   * @param array<int, string> $headers
    *   Array of headers from CURL.
    *
    * @return array<string, string>

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -6,8 +6,8 @@ namespace DrevOps\BehatSteps;
 
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
 
 /**
  * Internal generic helper methods for Behat step definitions.

--- a/src/IframeTrait.php
+++ b/src/IframeTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\When;
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Step\When;
 
 /**
  * Switch between iframes and the root document.

--- a/src/JsonTrait.php
+++ b/src/JsonTrait.php
@@ -582,7 +582,7 @@ trait JsonTrait {
       return $value ? 'true' : 'false';
     }
 
-    if (is_null($value)) {
+    if ($value === NULL) {
       return 'null';
     }
 

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -147,7 +147,7 @@ trait KeyboardTrait {
       // supposed to get the very first focus from tab index actually gets it.
       // Note that injecting element and triggering key press on it does not
       // make it focused itself.
-      if (is_null($selector) && $char === 'tab') {
+      if ($selector === NULL && $char === 'tab') {
         $selector = '#injected-focusable';
 
         $script = <<<JS

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\When;
 use Behat\Mink\Driver\BrowserKitDriver;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Behat\Step\When;
 
 /**
  * Simulate keyboard interactions in Drupal browser testing.

--- a/src/LinkTrait.php
+++ b/src/LinkTrait.php
@@ -155,9 +155,9 @@ trait LinkTrait {
   public function linkAssertWithTitleNotExists(string $title): void {
     $title = $this->helperFixStepArgument($title);
 
-    $item = $this->getSession()->getPage()->find('css', 'a[title="' . addslashes((string) $title) . '"]');
+    $element = $this->getSession()->getPage()->find('css', 'a[title="' . addslashes((string) $title) . '"]');
 
-    if ($item) {
+    if ($element) {
       throw new ExpectationException(sprintf('The link with the title "%s" exists, but should not.', $title), $this->getSession()->getDriver());
     }
   }

--- a/src/LinkTrait.php
+++ b/src/LinkTrait.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\Then;
-use Behat\Step\When;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * Verify link elements with attribute and content assertions.

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\Then;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Selector\Xpath\Escaper;
+use Behat\Step\Then;
 
 /**
  * Assert `<meta>` tags and head/SEO markup in page markup.

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -59,7 +59,7 @@ trait MetatagTrait {
     }
 
     if (!$found) {
-      throw new \Exception('Meta tag with specified attributes was not found: ' . json_encode($attributes) . '.');
+      throw new \Exception(sprintf('Meta tag with specified attributes was not found: %s.', json_encode($attributes)));
     }
   }
 
@@ -91,7 +91,7 @@ trait MetatagTrait {
       }
 
       if ($all_attributes_matched) {
-        throw new \Exception('Meta tag with specified attributes should not exist: ' . json_encode($attributes) . '.');
+        throw new \Exception(sprintf('Meta tag with specified attributes should not exist: %s.', json_encode($attributes)));
       }
     }
   }

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -604,9 +604,10 @@ trait MetatagTrait {
    *
    * Absolute URLs are returned unchanged and root-relative URLs are resolved
    * against the base URL's origin. Document-relative URLs (such as "page.html"
-   * or "../en") are resolved against the origin rather than the base path, so
-   * hreflang and canonical markup should use absolute or root-relative URLs, in
-   * line with search-engine guidance to use fully-qualified URLs.
+   * or "../en") are resolved against the origin rather than the base path.
+   * Hreflang and canonical markup should therefore use absolute or
+   * root-relative URLs, in line with search-engine guidance to use
+   * fully-qualified URLs.
    *
    * @param string $url
    *   The URL to resolve.
@@ -624,9 +625,6 @@ trait MetatagTrait {
 
     $base ??= (string) $this->getMinkParameter('base_url');
 
-    // Resolve root-relative URLs against the base URL's origin so that links on
-    // a fetched alternate page resolve against that page's host rather than the
-    // Mink base URL.
     $origin = (string) preg_replace('#^(https?://[^/]+).*$#i', '$1', $base);
 
     return rtrim($origin, '/') . '/' . ltrim($url, '/');

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\Then;
-use Behat\Step\Given;
-use Behat\Step\When;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 /**
  * Navigate and verify paths with URL validation.

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -99,15 +99,9 @@ trait PathTrait {
    */
   #[Then('current url should have the :param parameter')]
   public function pathAssertUrlHasParameter(string $param): void {
-    $url = $this->getSession()->getCurrentUrl();
+    $query = $this->pathGetCurrentUrlQuery();
 
-    $url_query = parse_url((string) $url, PHP_URL_QUERY);
-    $url_query = $url_query === FALSE ? '' : (string) $url_query;
-
-    $q = [];
-    parse_str($url_query, $q);
-
-    if (empty($q[$param])) {
+    if (empty($query[$param])) {
       throw new ExpectationException(sprintf('The param "%s" is not in the URL', $param), $this->getSession()->getDriver());
     }
   }
@@ -123,15 +117,9 @@ trait PathTrait {
   public function pathAssertUrlHasParameterWithValue(string $param, string $value): void {
     $this->pathAssertUrlHasParameter($param);
 
-    $url = $this->getSession()->getCurrentUrl();
+    $query = $this->pathGetCurrentUrlQuery();
 
-    $url_query = parse_url((string) $url, PHP_URL_QUERY);
-    $url_query = $url_query === FALSE ? '' : (string) $url_query;
-
-    $q = [];
-    parse_str($url_query, $q);
-
-    $actual_value = $q[$param] ?? '';
+    $actual_value = $query[$param] ?? '';
 
     if ($actual_value !== $value) {
       throw new ExpectationException(sprintf('The param "%s" is in the URL but with the wrong value "%s"', $param, is_array($actual_value) ? json_encode($actual_value) : $actual_value), $this->getSession()->getDriver());
@@ -147,15 +135,9 @@ trait PathTrait {
    */
   #[Then('current url should not have the :param parameter')]
   public function pathAssertUrlHasNoParameter(string $param): void {
-    $url = $this->getSession()->getCurrentUrl();
+    $query = $this->pathGetCurrentUrlQuery();
 
-    $url_query = parse_url((string) $url, PHP_URL_QUERY);
-    $url_query = $url_query === FALSE ? '' : (string) $url_query;
-
-    $q = [];
-    parse_str($url_query, $q);
-
-    if (!empty($q[$param])) {
+    if (!empty($query[$param])) {
       throw new ExpectationException(sprintf('The param "%s" is in the URL but should not be', $param), $this->getSession()->getDriver());
     }
   }
@@ -169,19 +151,13 @@ trait PathTrait {
    */
   #[Then('current url should not have the :param parameter with the :value value')]
   public function pathAssertUrlHasNoParameterWithValue(string $param, string $value): void {
-    $url = $this->getSession()->getCurrentUrl();
+    $query = $this->pathGetCurrentUrlQuery();
 
-    $url_query = parse_url((string) $url, PHP_URL_QUERY);
-    $url_query = $url_query === FALSE ? '' : (string) $url_query;
-
-    $q = [];
-    parse_str($url_query, $q);
-
-    if (empty($q[$param])) {
+    if (empty($query[$param])) {
       return;
     }
 
-    if ($q[$param] === $value) {
+    if ($query[$param] === $value) {
       throw new ExpectationException(sprintf('The param "%s" with value "%s" is in the URL but should not be', $param, $value), $this->getSession()->getDriver());
     }
   }
@@ -208,6 +184,24 @@ trait PathTrait {
   #[When('I go back')]
   public function pathGoBack(): void {
     $this->getSession()->back();
+  }
+
+  /**
+   * Get the query parameters of the current URL.
+   *
+   * @return array<int|string, mixed>
+   *   Query parameters keyed by name, empty when the URL carries no query.
+   */
+  protected function pathGetCurrentUrlQuery(): array {
+    $url = $this->getSession()->getCurrentUrl();
+
+    $url_query = parse_url((string) $url, PHP_URL_QUERY);
+    $url_query = $url_query === FALSE ? '' : (string) $url_query;
+
+    $query = [];
+    parse_str($url_query, $query);
+
+    return $query;
   }
 
 }

--- a/src/ResponseTrait.php
+++ b/src/ResponseTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\Then;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Step\Then;
 
 /**
  * Verify HTTP responses with status code and header checks.

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -187,7 +187,6 @@ trait ResponsiveTrait {
    * When I set the viewport to the "desktop" breakpoint
    * @endcode
    *
-   *
    * @param string $breakpoint
    *   The breakpoint name.
    *
@@ -207,7 +206,6 @@ trait ResponsiveTrait {
    * When I set the viewport width to "768"
    * @endcode
    *
-   *
    * @param string $width
    *   The width in pixels.
    */
@@ -225,7 +223,6 @@ trait ResponsiveTrait {
    * When I set the viewport height to "900"
    * @endcode
    *
-   *
    * @param string $height
    *   The height in pixels.
    */
@@ -242,7 +239,6 @@ trait ResponsiveTrait {
    * When I set the viewport to "1920" by "1080"
    * When I set the viewport to "375" by "667"
    * @endcode
-   *
    *
    * @param string $width
    *   The width in pixels.

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -130,7 +130,6 @@ trait ResponsiveTrait {
   public function responsiveBeforeScenario(BeforeScenarioScope $scope): void {
     $tags = $scope->getScenario()->getTags();
 
-    // Collect all breakpoint tags.
     $breakpoint_tags = [];
     foreach ($tags as $tag) {
       if (str_starts_with($tag, 'breakpoint:')) {
@@ -138,20 +137,16 @@ trait ResponsiveTrait {
       }
     }
 
-    // No breakpoint tags found - nothing to do.
     if (empty($breakpoint_tags)) {
       return;
     }
 
-    // Multiple breakpoint tags - throw exception.
     if (count($breakpoint_tags) > 1) {
       throw new \RuntimeException(sprintf('Only one @breakpoint tag is allowed per scenario. Found: @%s', implode(', @', $breakpoint_tags)));
     }
 
-    // Single breakpoint tag - validate and process.
     $tag = $breakpoint_tags[0];
 
-    // Validate that @javascript tag is present.
     if (!in_array('javascript', $tags)) {
       throw new \RuntimeException(sprintf('@%s tag requires @javascript tag to resize viewport', $tag));
     }
@@ -335,7 +330,6 @@ trait ResponsiveTrait {
    *   Array with 'width' and 'height' keys.
    */
   protected function responsiveGetCurrentDimensions(): array {
-    // Default dimensions if unable to determine current size.
     $default_width = 1280;
     $default_height = 800;
 
@@ -365,7 +359,6 @@ trait ResponsiveTrait {
    */
   protected function responsiveResize(int $width, int $height): void {
     try {
-      // Ensure session is started before resizing.
       if (!$this->getSession()->isStarted()) {
         // @codeCoverageIgnoreStart
         $this->getSession()->start();

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
-use Behat\Step\Given;
-use Behat\Step\When;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Hook\BeforeScenario;
 use Behat\Hook\BeforeStep;
+use Behat\Step\Given;
+use Behat\Step\When;
 
 /**
  * Test responsive layouts with viewport control.

--- a/src/RestTrait.php
+++ b/src/RestTrait.php
@@ -83,7 +83,7 @@ trait RestTrait {
   #[When('I send a REST :method request to :url with body:')]
   public function restSendRequestWithBody(string $method, string $url, PyStringNode $body): void {
     $client = $this->restGetClient();
-    $client->request(strtoupper($method), $this->restResolveUrl($url), [], [], $this->restCreateServerArray(), (string) $body);
+    $client->request(strtoupper($method), $this->restResolveUrl($url), [], [], $this->restCreateServerArray(), $body->getRaw());
   }
 
   /**

--- a/src/TableTrait.php
+++ b/src/TableTrait.php
@@ -269,7 +269,7 @@ trait TableTrait {
    *   An array of trimmed header texts.
    */
   protected function tableGetHeaders(NodeElement $table): array {
-    return array_map(static fn(NodeElement $el): string => trim($el->getText()), $table->findAll('css', $this->tableGetHeaderSelector()));
+    return array_map(static fn(NodeElement $element): string => trim($element->getText()), $table->findAll('css', $this->tableGetHeaderSelector()));
   }
 
   /**

--- a/src/WaitTrait.php
+++ b/src/WaitTrait.php
@@ -22,7 +22,7 @@ trait WaitTrait {
    * @endcode
    */
   #[When('I wait for :seconds second(s)')]
-  public function waitWaitForSeconds(int|string $seconds): void {
+  public function waitWaitForSeconds(string|int $seconds): void {
     sleep((int) $seconds);
   }
 
@@ -38,7 +38,7 @@ trait WaitTrait {
    */
   #[When('I wait for :seconds second(s) for AJAX to finish')]
   public function waitForAjaxToFinish(string|int $seconds): void {
-    $seconds = intval($seconds);
+    $seconds = (int) $seconds;
 
     if (!$this->helperIsJavascriptSupported()) {
       $driver = $this->getSession()->getDriver();

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -52,7 +52,6 @@ trait XmlTrait {
     libxml_use_internal_errors(TRUE);
     libxml_clear_errors();
 
-    // Clear cached document state to ensure fresh start.
     $this->xmlDocument = NULL;
     $this->xmlXpath = NULL;
     $this->xmlContentHash = NULL;
@@ -134,8 +133,7 @@ trait XmlTrait {
    */
   #[Then('the response should not be in XML format')]
   public function xmlAssertResponseIsNotXml(): void {
-    // Resolve content the same way as xmlEnsureDocument(): prefer content set
-    // by the fixture steps, falling back to the live page content.
+    // Resolve content the same way as xmlEnsureDocument().
     $content = $this->xmlTestContent ?? $this->getSession()->getPage()->getContent();
 
     $document = new \DOMDocument();
@@ -704,7 +702,6 @@ trait XmlTrait {
 
     $this->xmlXpath = new \DOMXPath($this->xmlDocument);
 
-    // Register namespaces for XPath queries.
     $namespaces = $this->xmlExtractNamespaces();
     foreach ($namespaces as $prefix => $uri) {
       if (is_string($prefix) && !empty($prefix)) {
@@ -722,7 +719,6 @@ trait XmlTrait {
    *   If no document is loaded.
    */
   protected function xmlEnsureDocument(): void {
-    // Use directly set test content if available.
     if ($this->xmlTestContent !== NULL) {
       if ($this->xmlDocument === NULL) {
         $this->xmlLoadDocument($this->xmlTestContent);
@@ -733,7 +729,6 @@ trait XmlTrait {
     $content = $this->getSession()->getPage()->getContent();
     $content_hash = md5((string) $content);
 
-    // Reload document if it's not loaded or content has changed.
     if ($this->xmlDocument === NULL || $this->xmlContentHash !== $content_hash) {
       $this->xmlLoadDocument($content);
       $this->xmlContentHash = $content_hash;
@@ -756,7 +751,6 @@ trait XmlTrait {
     $namespaces = [];
     $xpath = new \DOMXPath($this->xmlDocument);
 
-    // Query for all namespace declarations.
     $query = '//namespace::*';
     $nodes = $xpath->query($query);
 
@@ -861,13 +855,13 @@ trait XmlTrait {
   /**
    * Validate the response against a DTD.
    *
-   * The DTD is embedded as an internal subset and the response reloaded with
-   * validation enabled, so a DTD from a file and an inline DTD share one code
-   * path without exposing external-entity loading.
+   * The DTD is embedded as an internal subset and the response is reloaded
+   * with validation enabled. A DTD from a file and an inline DTD share this
+   * code path without exposing external-entity loading.
    *
    * DTDs are namespace-unaware, so a namespaced response is validated verbatim
-   * and its `xmlns` attributes must be declared in the DTD, matching native DTD
-   * validation semantics.
+   * and its `xmlns` attributes must be declared in the DTD. This matches
+   * native DTD validation semantics.
    *
    * @param string $dtd
    *   The DTD source (element, attribute and entity declarations).

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -138,9 +138,9 @@ trait XmlTrait {
     // by the fixture steps, falling back to the live page content.
     $content = $this->xmlTestContent ?? $this->getSession()->getPage()->getContent();
 
-    $doc = new \DOMDocument();
+    $document = new \DOMDocument();
     libxml_clear_errors();
-    $loaded = @$doc->loadXML($content);
+    $loaded = @$document->loadXML($content);
     $errors = libxml_get_errors();
     libxml_clear_errors();
 

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -688,7 +688,7 @@ trait XmlTrait {
    * @param string $content
    *   The XML content to load.
    *
-   * @throws \Exception
+   * @throws \RuntimeException
    *   If the XML cannot be loaded.
    */
   protected function xmlLoadDocument(string $content): void {
@@ -718,7 +718,7 @@ trait XmlTrait {
    *
    * Reloads the document if the page content has changed since last load.
    *
-   * @throws \Exception
+   * @throws \RuntimeException
    *   If no document is loaded.
    */
   protected function xmlEnsureDocument(): void {


### PR DESCRIPTION
# Source convergence pass

Drove `src/` toward internal consistency: one canonical form per concept across naming, structure and imports, API shape, and architecture, then converged source comments onto the technical register. Every change is behavior-preserving. No step text, method name, property name or Behat tag changed, so there is nothing for a consumer to update.

`STEPS.md` is byte-identical before and after.

## What converged

### Naming (`2d66160`)

67 local-variable renames across 12 files. Body locals only - no signature, member or step text touched.

- Locals named after the wrong entity: media and ECK table rows named `$node_hash`, a page object named `$element`, `findAll()` results named `$nodes` beside siblings calling them `$elements`.
- Abbreviations that already had a spelled-out twin in the same file or a sibling trait: `$doc`, `$ch`, `$attr_*`, `$item`, `$el`, `$idx`, `$cookies_objs`, `$saved`.
- Entity storage handlers unified on `$storage`; `$controller` was Drupal 7/8-era terminology and split the population 3-3.
- Database connection unified on `$database`.

### Structure and imports (`7124921`, `0231115`)

- Import blocks alphabetized in 25 files. Roughly half the traits hoisted the `Behat\Step\*` imports above everything else and several were internally unsorted; the block is now a single flat list sorted case-insensitively by FQCN. Applied by script, so it is idempotent.
- Generic array annotations always carry a space after the comma.
- 16 doubled blank comment lines collapsed to a single separator, plus the one stray blank line after a method's opening brace.
- Three `@throws \Exception` tags replaced with the exception types the methods actually throw.

### API shape (`1bb9400`)

- The single `assert()` type check became an instanceof guard that throws, and the single `private` helper became `protected` - both required by the project rules.
- `strval()`/`intval()` replaced with cast operators, one double cast collapsed, and the two `waitFor` union types aligned.
- `is_null()` replaced with strict `=== NULL`, eliminating the third of three null-checking forms.
- Container access uses the dedicated `\Drupal` facade where one exists, never `getContainer()->get()`.
- Concatenated exception messages use `sprintf()`, with byte-identical output.
- Instance helpers reached through `self::`/`static::` are now called on `$this`.
- `PyStringNode` bodies convert through `getRaw()`; JS-embedded JSON uses `JSON_UNESCAPED_SLASHES` everywhere.

### Architecture (`b652254`)

The seven-line block that fetches the current URL, extracts its query string and parses it was copied verbatim into all four `PathTrait` query-parameter assertions. It now lives in `pathGetCurrentUrlQuery()`. All 27 `path.feature` scenarios pass unchanged.

### Comment register (`0fd241a`)

Comment-only diff: 27 files, 85 insertions, 145 deletions. Comments that only restated the statement below them were deleted; the rest were reworded to state what the code does rather than narrate it.

Scope was inline comments and the prose of protected-helper and property docblocks. Trait docblocks, step docblocks and their `@code` examples were deliberately left alone - they are the published documentation that `docs.php` renders into `STEPS.md`.

**This pass is incomplete.** It reached 27 of 51 files before the run was cut short. Not processed: `FieldTrait`, `TableTrait`, `KeyboardTrait`, `LinkTrait`, `CommandTrait`, `JavascriptTrait`, `DiagnosticsTrait`, the generic `HelperTrait`, `WaitTrait`. Processed only in part: `EmailTrait`, `UserTrait`, `ConfigTrait`, `MetatagTrait`, `FileDownloadTrait`, `CookieTrait`, `PathTrait`, `DateTrait`, `ResponsiveTrait`. Re-running the pass over those files is safe and idempotent.

One constraint worth recording, hit independently by every reviewer: the Drupal phpcs standard mandates a docblock on every method and property, so a summary that merely restates the member name cannot be deleted even though it earns nothing. Those were treated as contract - register-checked, never removed.

## Comments found factually wrong or stale

None of these were fixed. A comment that misstates what the code does is a behavior-documentation defect and deserves its own reviewed change, not a line buried in a wording diff.

| Location | Claim | Reality |
|---|---|---|
| `ModalTrait.php:231` | "Find the first visible modal, or fall back to the first DOM match" | The fallback is per selector, not global. The first selector in `modalGetSelectors()` with any match wins, so an invisible `.ui-dialog` is returned even when a later selector matches a genuinely visible modal. This one looks like a real defect, not just a wrong comment. |
| `ContentBlockTrait.php:168` | Entities are stored in "the static `$blockContentEntities` array" | No such property exists. Cleanup goes through `entityRegister()`. |
| `MediaTrait.php:347` | `@param` "The node type", `@return` "Array of node ids" | The method queries media entities and returns media IDs. |
| `MediaTrait.php:309` | "re-use of the functionality provided by DrupalExtension" | `expandEntityFields()` lives in `drupal/drupal-driver`, not DrupalExtension. |
| `UserTrait.php:442` | `userLoadByName()` returns `?UserInterface`, NULL when missing | It throws instead; the nullable branch is dead. |
| `MenuTrait.php:15` | Trait "asserts menu items" and "menu link visibility" | The trait defines only `Given` steps; no assertions exist. |
| `BlockTrait.php:353` | `@throws \Exception` when no block is found | The method never throws; it returns NULL. |
| `WatchdogTrait.php:182` | "all logged entries for PHP channel" | Filters on every configured type, not only `php`. |
| `WatchdogTrait.php:169` | "no errors above the severity threshold" | Entries at the threshold fail too; the `@throws` line says "at or above". |
| `TestmodeTrait.php:40` | "Disable test mode before test run" | It is an `AfterScenario` hook. |
| `AccessibilityTrait.php:66` | JS cache "fetched once per run" | The cache is static, so per process; a parallel run spans several. |
| `AccessibilityTrait.php:527` | "see class docblock for the full structure" | The trait docblock never documents that structure. |
| `ElementTrait.php:1177` | JS copied from `tests/behat/fixtures/relative.html` | That file does not exist; the fixture is `elements_relative.html`. |
| `ElementTrait.php:1177` | `elementIsVisuallyVisible()` returns `bool` | No native return type; returns the raw `mixed` from `evaluateScript()`. |
| `ElementTrait.php:1171` | `@param` "(optional) ... Defaults to 0" | The parameter has no default. |
| `KeyboardTrait.php:86` | `$selector` behavior applies "if omitted" | The parameter has no default and cannot be omitted. |
| `KeyboardTrait.php:132` | Exception text points at `keyPress($char)` | No such method exists. |
| `FieldTrait.php:409` | `fieldGetRequiredMarkerSelectors()` is the override point used by `fieldIsMarkedRequired()` | It is never called; the checks are hardcoded. |
| `XmlTrait.php:762` | "Skip the default XML namespace" | Skips the reserved `xml:` namespace; a default namespace is an unprefixed `xmlns=`. |
| `DateTrait.php:82` | `@code` example begins `Give content ...` | Malformed Gherkin keyword; the example would not parse. |
| `CookieTrait.php:95` | `@code` shows `a cookie with name "old_session"` | The registered pattern requires `the name`; the example would not match. |
| `PathTrait.php:165` | Summary duplicated from the no-parameter variant | It misdescribes one of the two steps. |
| `XmlTrait.php:858` | `xmlValidateDtd()` shares one code path "without exposing external-entity loading" | Verified on this project's runtime (PHP 8.3.30, libxml 2.13.9): under plain `LIBXML_DTDVALID` a `SYSTEM` entity **is** dereferenced - a nonexistent path yields `failed to load "file:///..."`. The entity content is *not* substituted into the document, because `LIBXML_NOENT` is not passed, so there is no read-and-exfiltrate path; but "without exposing external-entity loading" overstates the guarantee. Pre-existing on `main`; the comment pass restructured the sentence without touching the claim, exactly as its rules require. |

## Judgment calls deferred to you

Full-auto applies confident, behavior-preserving convergences and leaves the rest to a human. These are real findings with evidence, not oversights.

### Public surface - every one of these is a breaking change for consumers

These traits are mixed into consumer `FeatureContext` classes, so step text, method names, property names and tag names are all public API.

- **Step-text rule violations.** `Given I accept all confirmation dialogs` and its negative violate the no-`Given I` rule; `I should (not) see the modal` violates Then-entity-first; `:number` is used for a pixel offset where siblings use `:tolerance`; 11 steps carry optional `(s)` tokens.
- **Step-text drift.** Placeholder names for one concept (`:attribute`/`:attribute_name`, `:text`/`:value`, `:vocabulary`/`:vocabulary_machine_name`/`:machine_name`, `:content_type`/`:type`, `:media_type`/`:bundle`, `:locator`/`:selector`) across ~30 steps; article and label drift across ~15; ~15 `Given` steps that use `is`/`has been` instead of `exists`/`have`.
- **Method-name rule violations.** `MenuTrait`'s `loadMenuByLabel()`/`loadMenuLinkByTitle()` carry no trait prefix; Drupal `HelperTrait` uses an `entity*` family rather than `helper*`; `draggableViews*` capitalises the V against its own trait name; `waitWaitForSeconds` doubles the prefix.
- **Naming drift.** `Normalize` (4) vs `Normalise` (2); six coexisting negation shapes (`NotExists`, `IsNot`, `HasNo`, `AssertNo`, antonyms) across ~25 methods; `Get*` getters vs bare-noun getters on 11 documented override points.
- **Visibility and shape.** Three public non-step callables; `DateTrait`'s all-static paradigm against instance helpers everywhere else; the unprefixed `DEFAULT_WAIT_TIMEOUT` constant; `FieldTrait` composing `KeyboardTrait` without ever calling it (removing it would strip keyboard steps from consumers).
- **Tag mechanics.** `behat-steps-skip:` uses `__FUNCTION__` tokens in 13 places and PascalCase trait names in 4; eight hooks support no skip tag at all.

### Behavior-changing

- **Assertion exception type.** `ExpectationException` dominates (~200 sites) but `\Exception` is used in ~50, plus `\RuntimeException` leaking from `xmlAssertResponseIsXml` where the JSON twin throws `ExpectationException`. Structurally blocked in places: `CommandTrait` and `ConfigTrait` have no Mink session, so the driver argument is unavailable.
- **Duplicate-entity tie-break.** `blockLoadByLabel()` uses `krsort()` + `end()`, returning the *oldest* match, while every sibling uses `ksort()` + `end()` for the newest. Likely a latent bug.
- **Comparison strictness.** Five `in_array()` calls without the strict flag, six loose `==`/`!=` scalar comparisons.
- **Missing contrib-module guards.** `MenuTrait` imports `menu_link_content` and `DraggableviewsTrait` writes a contrib table with no availability guard; `SearchApiTrait` calls `search_api_entity_insert()` unguarded.
- **Guard outcome.** Silent-return versus throw for the same class of failure, across JS-driver gating, `EmailTrait`'s `StatementInterface` fallback, and `LinkTrait`'s negative step passing when the container is missing.
- **Exception message trailing period.** The plan sized this at 16 sites; it is actually about 50 of roughly 400 messages. The omissions are not random - `CommandTrait`, `PathTrait`, `JsonTrait`, `XmlTrait`, `ModuleTrait` and `EmailTrait` consistently drop the period when the message ends in an interpolated value (`: %s`, `"%s"`). Several are asserted verbatim by in-repo BDD features. At that size and with that coupling it stops being a surgical wording fix, so it is left for a deliberate decision.
- **`DateTrait` regex and capture.** Both failure branches interpolate `$matches[1]` (the token keyword) rather than the offending value, and the token match uses a `[relative:]+` character class instead of a literal.
- **`emailFollowLinkNumber()` accepts an out-of-range link number.** Confirmed by walking the code: with a link number of `0`, the bound check `count($links) < $link_number` is false, so execution reaches `$links[-1]`, which is undefined on a zero-indexed list. PHP 8 emits `Undefined array key -1` and evaluates to `NULL`, which then reaches `Session::visit()`. Negative numbers behave the same. Pre-existing - this branch only changed `intval($link_number)` to `(int) $link_number`, which is exactly equivalent - and it applies to `emailFollowLinkNumberWithSubjectContaining()` too. Fixing it needs a guard plus a test for the `0` and negative cases.

### Genuine ties - no canonical form to pick

- Truthiness `!$x` (~40) versus strict `=== NULL` (~35) for nullable objects, with opposing per-trait majorities.
- `empty($array)` (~30) versus `$array === []` (~25), with the newest code leaning strict.
- `self::` versus `static::` for static helpers (13 each); switching to `static::` would widen consumer override semantics and should be a deliberate design decision.
- `@param`-before-`@code` (7) versus `@code`-before-`@param` (6), and flush versus indented `@code` examples.

### Left to a dedicated pass

- Member ordering within traits: the dominant layout is clear, but reordering reshuffles `STEPS.md` output for zero runtime gain.
- Remaining duplication: verbatim twins across traits (`xmlReadFile`/`jsonReadFile`, the JS error-buffer read, the module-exists check), duplicates that have drifted behaviorally (two cURL implementations with different timeouts and status handling, two cookie driver-sniffing cascades), and ~35 in-file twin bodies.
- `@codeCoverageIgnore` marker drift: equivalent defensive guards are marked in some traits and not others. `codecov/patch` and `codecov/project` are required checks, so unifying needs a coverage re-baseline rather than a mechanical sweep.

## Verification

- **Full BDD suite: 1036 scenarios, 1036 passed; 4376 steps, 4376 passed.** Browser scenarios included - 197 `@javascript` scenarios ran, `modal.feature` and `dropzone.feature` among them.
- `ahoy lint` (phpcs, phpstan level 7, rector dry-run, gherkinlint): green after every class.
- `ahoy test-unit`: 392 tests, 677 assertions, green after every class.
- `ahoy lint-docs`: `STEPS.md` unchanged throughout.
- `path.feature` run on its own after the `PathTrait` extraction: 27 scenarios, 105 steps, green.

Two earlier full-suite attempts aborted with Chrome `tab crashed` - at `modal.feature:9` once and at `cookie.feature:84` (a vendor `I visit` step) the next time. The crash moved between runs over identical code and both features passed in isolation, so it is a browser resource flake; the clean run above confirms it. Worth knowing that Behat throws out of the whole run when this happens, so every feature after the crash point silently goes unexecuted while the exit code reads as a normal failure.

Also worth knowing for future narrowing: passing `--tags` on the command line *replaces* the `~@skipped` filter that `behat.yml` sets, rather than intersecting with it, so `@skipped` scenarios start running and failing. Compose it as `~@skipped&&<your tag>`.

On CI, one matrix job (`PHP 8.3, Drupal 10, Deps normal`) failed on the first run at 1m34s while its twelve siblings each took 10-16 minutes. The log showed `502 Bad Gateway` from `registry-1.docker.io` while pulling a `uselagoon/php-8.3-cli-drupal` layer, so it never reached the test suite. A single re-trigger cleared it and that job now passes in 13m41s.

## Before / After

The clearest single instance of "many copies, one canonical form" is `PathTrait`'s query-parameter assertions, where an extracted helper replaced four verbatim copies of the same parsing block. The same collapse-to-one-form pattern repeats without extraction across the naming, import-ordering and API-shape convergences elsewhere in `src/`.

```
BEFORE - PathTrait
┌────────────────────────────────────────────────────────────────┐
│ pathAssertUrlHasParameter()              ┐                     │
│ pathAssertUrlHasParameterWithValue()     │  each repeats the   │
│ pathAssertUrlHasNoParameter()            │  same 7 lines       │
│ pathAssertUrlHasNoParameterWithValue()   ┘                     │
│                                                                │
│     $url = $this->getSession()->getCurrentUrl();               │
│     $url_query = parse_url((string) $url, PHP_URL_QUERY);      │
│     $url_query = $url_query === FALSE ? '' : (string) ...;     │
│     $q = [];                                                   │
│     parse_str($url_query, $q);                                 │
│                                                                │
│ 4 copies, byte-identical, free to drift apart unnoticed        │
└────────────────────────────────────────────────────────────────┘

AFTER - PathTrait
┌────────────────────────────────────────────────────────────────┐
│ pathGetCurrentUrlQuery()   the 7 lines, defined exactly once   │
│                                                                │
│ pathAssertUrlHasParameter()              ┐                     │
│ pathAssertUrlHasParameterWithValue()     │  $query = $this->   │
│ pathAssertUrlHasNoParameter()            │  pathGetCurrentUrl  │
│ pathAssertUrlHasNoParameterWithValue()   ┘  Query();           │
│                                                                │
│ 1 helper + 4 one-line call sites, one place to fix or extend   │
└────────────────────────────────────────────────────────────────┘
```
