### PR TITLE
[#707] Rejected out-of-range link numbers in the email follow-link steps.

### DIFF
--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -392,7 +392,7 @@ trait EmailTrait {
    */
   #[When('I follow link number :link_number in the email with the subject :subject')]
   public function emailFollowLinkNumber(string $link_number, string $subject): void {
-    $link_number = (int) $link_number;
+    $link_number = $this->emailAssertLinkNumber($link_number);
 
     $message = $this->emailFindMessage('subject', new PyStringNode([$subject], 0));
 
@@ -434,7 +434,7 @@ trait EmailTrait {
    */
   #[When('I follow link number :link_number in the email with the subject containing :subject')]
   public function emailFollowLinkNumberWithSubjectContaining(string $link_number, string $subject): void {
-    $link_number = (int) $link_number;
+    $link_number = $this->emailAssertLinkNumber($link_number);
 
     $message = NULL;
     foreach ($this->emailGetCollectedMessages() as $m) {
@@ -708,6 +708,29 @@ trait EmailTrait {
     preg_match_all(sprintf('#%s#i', $pattern), (string) $string, $matches);
 
     return empty($matches[0]) ? [] : $matches[0];
+  }
+
+  /**
+   * Convert a link number step argument into a positive integer.
+   *
+   * Links are numbered from 1. Anything below that would index the link list
+   * out of range further down, so it is rejected here.
+   *
+   * @param string $link_number
+   *   The link number as provided in the step.
+   *
+   * @return int
+   *   The link number as a positive integer.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   When the link number is not a positive integer.
+   */
+  protected function emailAssertLinkNumber(string $link_number): int {
+    if (!ctype_digit(trim($link_number)) || (int) $link_number < 1) {
+      throw new ExpectationException(sprintf('The link number must be a positive integer, but "%s" was provided.', $link_number), $this->getSession()->getDriver());
+    }
+
+    return (int) $link_number;
   }
 
 }

--- a/tests/behat/features/drupal_email.feature
+++ b/tests/behat/features/drupal_email.feature
@@ -462,6 +462,45 @@ Feature: Check that EmailTrait works
       """
 
   @trait:Drupal\EmailTrait
+  Scenario Outline: Assert that following link in email fails when link number is not a positive integer
+    Given some behat configuration
+    And scenario steps tagged with "@api @email":
+      """
+      When I send test email to "test@example.com" with:
+        '''
+        Email with one link: http://example.com
+        '''
+      Then I follow link number "<number>" in the email with the subject "Test Email"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The link number must be a positive integer, but "<number>" was provided.
+      """
+    Examples:
+      | number |
+      | 0      |
+      | -1     |
+      | abc    |
+
+  @trait:Drupal\EmailTrait
+  Scenario: Assert that following link by subject substring fails when link number is zero
+    Given some behat configuration
+    And scenario steps tagged with "@api @email":
+      """
+      When I send test email to "test@example.com" with:
+        '''
+        Email with one link: http://example.com
+        '''
+      Then I follow link number "0" in the email with the subject containing "Test"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The link number must be a positive integer, but "0" was provided.
+      """
+
+  @trait:Drupal\EmailTrait
   Scenario: Assert that following link by subject substring fails when subject not found
     Given some behat configuration
     And scenario steps tagged with "@api @email":


### PR DESCRIPTION
Closes #707

## Summary

`Drupal\EmailTrait`'s two follow-link steps, `emailFollowLinkNumber()` and `emailFollowLinkNumberWithSubjectContaining()`, cast the step argument with `(int)` and only bound-checked the upper end, so `0`, a negative number, or a non-numeric value passed validation and then evaluated `$links[-1]`, producing an `Undefined array key -1` warning and passing `NULL` to `Session::visit()`. Both steps now resolve the argument through a new protected `emailAssertLinkNumber()` helper that rejects anything that is not a positive integer and names the offending value in the thrown exception.

## Changes

- Added a protected `emailAssertLinkNumber()` helper to `src/Drupal/EmailTrait.php` that validates the step argument is a positive integer via `ctype_digit()` plus a lower-bound check, throwing an `ExpectationException` naming the offending value otherwise.
- Routed `emailFollowLinkNumber()` and `emailFollowLinkNumberWithSubjectContaining()` through the new helper instead of casting the argument with `(int)`.
- Added a Scenario Outline to `tests/behat/features/drupal_email.feature` covering `0`, `-1`, and `abc` for `emailFollowLinkNumber()`, plus a scenario covering `0` for the subject-containing variant.

## Before / After

```
┌──────────────────────────────────────────────────────┐
│ BEFORE                                               │
├──────────────────────────────────────────────────────┤
│ link_number = (int) "0"                              │
│ upper-bound check only: 0 <= count($links) -> passes │
│ $links[0 - 1] => $links[-1]  (key does not exist)    │
│ PHP warning: Undefined array key -1                  │
│ $this->getSession()->visit(NULL)                     │
└──────────────────────────────────────────────────────┘

┌──────────────────────────────────────────────────────┐
│ AFTER                                                │
├──────────────────────────────────────────────────────┤
│ link_number = $this->emailAssertLinkNumber("0")      │
│ guard: ctype_digit(...) and (int) value >= 1         │
│ "0" fails the guard                                  │
│ throws ExpectationException before any array access  │
│ message: The link number must be a positive integer, │
│          but "0" was provided.                       │
└──────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added shared `emailAssertLinkNumber()` validation for email link numbers.
- Both email follow-link steps now reject zero, negative, and non-numeric values before link indexing.
- Invalid values now raise an `ExpectationException` that identifies the supplied value.
- Added Behat coverage for invalid link numbers in both steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->