### PR TITLE
[#710] Found the first visible modal across all selectors.

### DIFF
--- a/src/ModalTrait.php
+++ b/src/ModalTrait.php
@@ -235,21 +235,22 @@ trait ModalTrait {
    */
   protected function modalFind(): ?NodeElement {
     $page = $this->getSession()->getPage();
+    $first_match = NULL;
 
+    // A visible modal from any selector outranks a hidden one from an earlier
+    // selector, so every selector is examined before falling back. Libraries
+    // such as jQuery UI leave their container in the DOM after closing, which
+    // would otherwise mask a visible modal of a different kind.
     foreach ($this->modalGetSelectors() as $selector) {
-      $first_match = NULL;
       foreach ($page->findAll('css', $selector) as $candidate) {
         $first_match ??= $candidate;
         if ($candidate->isVisible()) {
           return $candidate;
         }
       }
-      if ($first_match !== NULL) {
-        return $first_match;
-      }
     }
 
-    return NULL;
+    return $first_match;
   }
 
   /**

--- a/tests/behat/features/modal.feature
+++ b/tests/behat/features/modal.feature
@@ -133,6 +133,17 @@ Feature: Check that ModalTrait works
     Then the modal should contain "Export modal content"
     And the modal should not contain "Profile modal content"
 
+  @javascript @phpserver
+  Scenario: Assert a visible modal is found when an earlier selector matches a hidden one
+    Given I am an anonymous user
+    When I visit "/sites/default/files/modal_mixed.html"
+    Then I should not see the modal
+    When I click on the element "#open-native"
+    And I wait for the modal to appear
+    Then I should see the modal
+    And the modal should contain "Native modal content"
+    And the modal should not contain "Leftover jQuery UI modal content"
+
   # Negative tests.
 
   @trait:ModalTrait

--- a/tests/behat/fixtures/modal_mixed.html
+++ b/tests/behat/fixtures/modal_mixed.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Mixed Modal Implementations</title>
+</head>
+<body>
+<h1>Page with a leftover jQuery UI container and a native dialog</h1>
+<button id="open-native">Open Native</button>
+
+<!-- A closed jQuery UI dialog leaves its container in the DOM. It matches the
+     first configured modal selector but is not visible. -->
+<div class="ui-dialog" style="display: none;">
+  <div class="ui-dialog-content">
+    <p>Leftover jQuery UI modal content</p>
+  </div>
+</div>
+
+<dialog id="native-dialog">
+  <div class="modal-content">
+    <p>Native modal content</p>
+    <button data-dismiss="modal" class="close-native">Close</button>
+  </div>
+</dialog>
+
+<script>
+  document.getElementById('open-native').addEventListener('click', function() {
+    document.getElementById('native-dialog').showModal();
+  });
+  document.querySelectorAll('[data-dismiss="modal"]').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      this.closest('dialog').close();
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #710

## Summary

`ModalTrait::modalFind()` scanned modal selectors one at a time and returned the first DOM match as soon as any selector matched an element, so a hidden container left behind by an earlier selector could mask a visible modal that a later selector would have found. With the default selector order `.ui-dialog`, `dialog[open]`, `.modal`, a page carrying a closed jQuery UI dialog (which leaves `.ui-dialog` in the DOM after closing) alongside an open native `<dialog>` reported that no modal was visible, because the loop returned the hidden `.ui-dialog` match before ever reaching `dialog[open]`. The visible-element search now spans the entire selector list before falling back to the first DOM match, which is the behaviour the method's own docblock already described. A new fixture and scenario reproduce a page with both a hidden `.ui-dialog` and an open native dialog, and were confirmed to fail against the previous implementation before the fix.

## Changes

- `src/ModalTrait.php`: `modalFind()` now tracks the first DOM match once across all selectors and only falls back to it after every selector has been checked for a visible element, instead of returning a per-selector fallback before moving on to the next selector.
- `tests/behat/fixtures/modal_mixed.html`: new fixture pairing a hidden `.ui-dialog` container with a native `<dialog>` opened via a button click.
- `tests/behat/features/modal.feature`: new scenario asserting the visible native dialog is found and its content is read, even though a hidden `.ui-dialog` matches an earlier selector.

## Before / After

```
┌────────────────────────────────────────────────────────────┐
│ BEFORE - stops at the first selector with a match          │
├────────────────────────────────────────────────────────────┤
│ .ui-dialog     candidate found, hidden                     │
│                -> returned as result (bug)                 │
├────────────────────────────────────────────────────────────┤
│ dialog[open]   never scanned                               │
│ .modal         never scanned                               │
└────────────────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────────────┐
│ AFTER - scans all selectors before falling back            │
├────────────────────────────────────────────────────────────┤
│ .ui-dialog     candidate found, hidden                     │
│                -> kept only as a fallback                  │
├────────────────────────────────────────────────────────────┤
│ dialog[open]   candidate found, visible                    │
│                -> returned as result (fixed)               │
├────────────────────────────────────────────────────────────┤
│ .modal         not needed, already returned                │
└────────────────────────────────────────────────────────────┘
```
