### PR TITLE
[#709] Matched the relative-date token literally and reported the offending value.

### DIFF
--- a/src/DateTrait.php
+++ b/src/DateTrait.php
@@ -100,21 +100,26 @@ trait DateTrait {
     $now = $now ?: strtotime(date('Y-m-d H:i:00', self::dateNow()));
     $now = $now ?: NULL;
 
-    return (string) preg_replace_callback('/\[([relative:]+):([^]\[#]+)(?:#([^]\[]+))?]/', function (array $matches) use ($now): string {
-      $timestamp = strtotime($matches[2], $now);
+    return (string) preg_replace_callback('/\[relative:([^]\[#]+)(?:#([^]\[]+))?]/', function (array $matches) use ($now): string {
+      $offset = $matches[1];
+
+      $timestamp = strtotime($offset, $now);
       if ($timestamp === FALSE) {
-        throw new \RuntimeException(sprintf('The supplied relative date cannot be evaluated: "%s"', $matches[1]));
+        throw new \RuntimeException(sprintf('The relative date offset cannot be evaluated: "%s".', $offset));
       }
 
-      if (isset($matches[3])) {
-        $timestamp = date($matches[3], $timestamp);
+      if (!isset($matches[2])) {
+        return (string) $timestamp;
       }
 
-      if (empty(trim((string) $timestamp))) {
-        throw new \RuntimeException(sprintf('The supplied relative date cannot be evaluated: "%s"', $matches[1]));
+      $format = $matches[2];
+      $formatted = date($format, $timestamp);
+
+      if (trim($formatted) === '') {
+        throw new \RuntimeException(sprintf('The relative date format produced an empty value: "%s".', $format));
       }
 
-      return (string) $timestamp;
+      return $formatted;
     }, $value);
   }
 

--- a/tests/phpunit/src/DateTraitTest.php
+++ b/tests/phpunit/src/DateTraitTest.php
@@ -74,16 +74,30 @@ class DateTraitTest extends UnitTestCase {
         (string) strtotime('+1 day', 1715011200),
         1715011200,
       ],
+      'lookalike token beside a real token is left alone' => [
+        '[relative:-1 day] and [tar:-1 day]',
+        strtotime('-1 day', $timestamp) . ' and [tar:-1 day]',
+      ],
+      'misspelled token is left alone' => [
+        '[relative:-1 day] and [realtive:-1 day]',
+        strtotime('-1 day', $timestamp) . ' and [realtive:-1 day]',
+      ],
+      'offset resolving to the epoch' => [
+        '[relative:@0]',
+        '0',
+      ],
     ];
   }
 
   public function testInvalidRelativeDateTypeThrowsException(): void {
     $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('The relative date offset cannot be evaluated: "invalid date".');
     $this->testObject::dateRelativeProcessValue('[relative:invalid date]');
   }
 
   public function testInvalidRelativeDateFormatThrowsException(): void {
     $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('The relative date format produced an empty value: " ".');
     $this->testObject::dateRelativeProcessValue('[relative:-1 day# ]');
   }
 


### PR DESCRIPTION
Closes #709

## Summary

`DateTrait::dateRelativeProcessValue()` matched its token keyword with a character class, `[relative:]+`, so any run of the letters `r`, `e`, `l`, `a`, `t`, `i`, `v`, `:` was accepted as a token — a misspelling like `[realtive:-1 day]` or an unrelated `[tar:-1 day]` was silently rewritten whenever a genuine `[relative:...]` token also appeared in the same string. Both failure paths interpolated `$matches[1]`, the keyword itself, so an unparseable offset was always blamed on "relative" instead of naming the value that actually failed. An offset resolving to the Unix epoch stringified to `'0'`, which the emptiness guard treated as blank and rejected. All three are fixed here. Tightening the keyword match is a behaviour change for anyone whose fixtures accidentally relied on a misspelled token being processed, so it is worth a release note.

## Changes

**Matched the token keyword literally**
- Replaced the character class `[relative:]+` with the literal `relative:` in the regex — now `/\[relative:([^]\[#]+)(?:#([^]\[]+))?]/` — so only genuine `[relative:...]` tokens are recognized; lookalikes such as `[realtive:-1 day]` or `[tar:-1 day]` are left untouched even when they share a string with a real token.

**Named the offending value in failure messages**
- The "cannot be evaluated" and "empty value" exceptions no longer interpolate the token keyword; each now names the offset or format string that actually failed: `The relative date offset cannot be evaluated: "%s".` and `The relative date format produced an empty value: "%s".`

**Allowed offsets that resolve to the epoch**
- The emptiness check now applies only to the formatted-output branch instead of the raw timestamp string, so `[relative:@0]` resolves to `'0'` instead of throwing.

**Tests**
- Added three data-provider cases to `tests/phpunit/src/DateTraitTest.php` (a lookalike token beside a real token, a misspelled token, and an offset resolving to the epoch) plus exact message assertions on both exception tests.

## Before / After

```
┌─────────────────────────────────────────────────────────────────┐
│ BEFORE: /[relative:]+/ (character class)                        │
├─────────────────────────────────────────────────────────────────┤
│   relative   matches     ->  processed                          │
│   realtive   matches     ->  processed (typo silently applied)  │
│   tar        matches     ->  processed (unrelated word applied) │
│   ::::       matches     ->  processed (punctuation applied)    │
│                                                                 │
│   error always names the keyword: "relative"                    │
├─────────────────────────────────────────────────────────────────┤
│ AFTER: /relative:/ (literal keyword)                            │
├─────────────────────────────────────────────────────────────────┤
│   relative   matches     ->  processed                          │
│   realtive   no match    ->  left untouched                     │
│   tar        no match    ->  left untouched                     │
│   ::::       no match    ->  left untouched                     │
│                                                                 │
│   error names the offending value: "-1 day" or " "              │
└─────────────────────────────────────────────────────────────────┘
```
