### PR TITLE
[#708] Returned the newest block when several share an admin label.

### DIFF
--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -356,7 +356,10 @@ trait BlockTrait {
         'settings.label' => $label,
       ]);
 
-    krsort($blocks);
+    // Machine names gain a numeric suffix on collision, so ordering the keys
+    // ascending puts the most recently created block last. This matches how
+    // the other traits resolve a duplicate label.
+    ksort($blocks);
 
     return empty($blocks) ? NULL : end($blocks);
   }

--- a/tests/behat/features/drupal_block.feature
+++ b/tests/behat/features/drupal_block.feature
@@ -33,6 +33,22 @@ Feature: Check that BlockTrait works
     Given the block "[TEST] User Account Menu" does not exist
     And the block "[TEST] User Account Menu" does not exist
 
+  @api
+  Scenario: Assert that the most recently created block wins when two share a label
+    Given the block "[TEST] Duplicate Label" does not exist
+    And the instance of "User account menu" block exists with the following configuration:
+      | label         | [TEST] Duplicate Label |
+      | label_display | 1                      |
+      | region        | content                |
+      | status        | 1                      |
+    And the instance of "User account menu" block exists with the following configuration:
+      | label         | [TEST] Duplicate Label |
+      | label_display | 1                      |
+      | region        | footer_top             |
+      | status        | 1                      |
+    Then the block "[TEST] Duplicate Label" should exist in the "footer_top" region
+    And the block "[TEST] Duplicate Label" should not exist in the "content" region
+
   @trait:Drupal\BlockTrait @api
   Scenario: Assert "block should exist" fails for non-existing block
     Given some behat configuration


### PR DESCRIPTION
Closes #708

## Summary

`Drupal\BlockTrait::blockLoadByLabel()` paired `krsort()` with `end()` when resolving a block by its admin label, which returns the *lowest* machine-name key instead of the newest one. Drupal appends a numeric suffix to a block's machine name on a label collision (via `getUniqueMachineName()`), so the lowest key is always the first block created, meaning a step matching a duplicate label silently resolved to the oldest block rather than the newest. Every sibling trait that resolves entities by title (`ContentTrait`, `MediaTrait`, `ContentBlockTrait`, `TaxonomyTrait`, `SearchApiTrait`) pairs `ksort()` with `end()` instead, matching the convention documented on `ContentTrait` that title-based steps resolve to the most recently created entity. This replaces `krsort()` with `ksort()` so block resolution follows the same convention across traits, and it changes which block a step operates on when labels collide, so it is a behaviour fix rather than a refactor.

## Changes

- `src/Drupal/BlockTrait.php`: replaced `krsort()` with `ksort()` in `blockLoadByLabel()`, with a comment recording that ascending key order paired with `end()` is what selects the most recently created block on a label collision.
- `tests/behat/features/drupal_block.feature`: added a scenario that creates two blocks sharing the label `[TEST] Duplicate Label` in different regions and asserts the region-scoped lookup resolves to the second (newer) block; confirmed this scenario fails against the unfixed code with a region mismatch reported on the older block.

## Before / After

```
Legend
  A = olivero_useraccountmenu    (created first)
  B = olivero_useraccountmenu_2  (created second, newer)

Before: krsort() + end()
┌───────────────────────────┐
│ sorted descending:  B, A  │
│ end() returns:      A     │
│ -> oldest block wins (bug)│
└───────────────────────────┘

After: ksort() + end()
┌───────────────────────────┐
│ sorted ascending:   A, B  │
│ end() returns:      B     │
│ -> newest block wins (fix)│
└───────────────────────────┘
```
