### PR TITLE
Corrected docblock claims that misstated what the code does.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -3687,7 +3687,7 @@ Then the response should be a valid Atom feed
 
 >  Manage Drupal blocks.
 >  - Create and configure blocks with custom visibility conditions.
->  - Place blocks in regions and verify their rendering in the page.
+>  - Place blocks in regions and assert their configured region.
 >  - Created blocks are automatically removed at the end of the scenario.
 
 
@@ -4495,7 +4495,7 @@ When I save the draggable views items of the view "draggableviews_demo" and the 
 
 >  Manage Drupal ECK entities with custom type and bundle creation.
 >  - Create structured ECK entities with defined field values.
->  - Assert entity type registration and visit entity pages.
+>  - Visit and edit ECK entity pages.
 >  - Created entities are automatically removed at the end of the scenario.
 
 
@@ -4525,8 +4525,8 @@ Remove custom entities by field
 
 ```gherkin
 Given the following eck "contact" "contact_type" entities do not exist:
-  | field        | value           |
-  | field_a      | Entity label    |
+  | title           |
+  | Entity label    |
 
 ```
 
@@ -5047,7 +5047,8 @@ Then an unmanaged file at the URI "public://config.txt" should not contain "debu
 
 >  Manage Drupal media entities with type-specific field handling.
 >  - Create structured media items with proper file reference handling.
->  - Assert media browser functionality and edit media entity fields.
+>  - Assert media type and media item existence.
+>  - Visit media view, edit, delete and revision pages.
 >  - Support for multiple media types with field value expansion handling.
 >  - Created entities are automatically removed at the end of the scenario.
 
@@ -5256,7 +5257,7 @@ Given the menu "Test Menu" does not exist
   <summary><code>@Given the following menus:</code></summary>
 
 <br/>
-Create a menu if one does not exist
+Create menus
 <br/><br/>
 
 ```gherkin
@@ -6007,7 +6008,7 @@ When I reset system time
 >  - Create user accounts
 >  - Create user roles
 >  - Visit user profile pages for editing and deletion.
->  - Assert user roles and permissions.
+>  - Assert user roles.
 >  - Assert user account status (active/inactive).
 
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -2715,7 +2715,7 @@ Then the path should not be "<front>"
   <summary><code>@Then current url should have the :param parameter</code></summary>
 
 <br/>
-Assert that current URL has a query parameter
+Assert that current URL has a query parameter with a non-empty value
 <br/><br/>
 
 ```gherkin
@@ -2743,7 +2743,7 @@ Then current url should have the "filter" parameter with the "recent" value
   <summary><code>@Then current url should not have the :param parameter</code></summary>
 
 <br/>
-Assert that current URL does not have a query parameter
+Assert that current URL has no query parameter with a non-empty value
 <br/><br/>
 
 ```gherkin

--- a/STEPS.md
+++ b/STEPS.md
@@ -387,7 +387,7 @@ Assert that a cookie does not exist
 <br/><br/>
 
 ```gherkin
-Then a cookie with name "old_session" should not exist
+Then a cookie with the name "old_session" should not exist
 
 ```
 
@@ -2743,7 +2743,7 @@ Then current url should have the "filter" parameter with the "recent" value
   <summary><code>@Then current url should not have the :param parameter</code></summary>
 
 <br/>
-Assert that current URL doesn't have a query parameter with specific value
+Assert that current URL does not have a query parameter
 <br/><br/>
 
 ```gherkin
@@ -2757,7 +2757,7 @@ Then current url should not have the "filter" parameter
   <summary><code>@Then current url should not have the :param parameter with the :value value</code></summary>
 
 <br/>
-Assert that current URL doesn't have a query parameter with specific value
+Assert that current URL does not have a query parameter with a value
 <br/><br/>
 
 ```gherkin
@@ -5233,9 +5233,8 @@ Then the "image" media with the name "Test media image" should not exist
 [Source](src/Drupal/MenuTrait.php), [Example](tests/behat/features/drupal_menu.feature)
 
 >  Manage Drupal menu systems and menu link rendering.
->  - Assert menu items by label, path, and containment hierarchy.
->  - Assert menu link visibility and active states in different regions.
->  - Create and manage menu hierarchies with parent-child relationships.
+>  - Create and remove menus by label.
+>  - Create and remove menu links, including parent-child hierarchies.
 >  - Created menus and menu links are automatically removed at the end of the scenario.
 
 

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -63,7 +63,7 @@ trait AccessibilityTrait {
   public const IMPACT_MINOR = 'minor';
 
   /**
-   * In-memory cache for the engine JavaScript source - fetched once per run.
+   * In-memory cache for the engine JavaScript source, fetched once per process.
    */
   protected static ?string $accessibilityCachedJs = NULL;
 
@@ -524,7 +524,7 @@ trait AccessibilityTrait {
   /**
    * Normalize raw engine output into the canonical shape used by the trait.
    *
-   * Canonical shape (see class docblock for the full structure):
+   * Canonical shape:
    * `['violations' => [...], 'incomplete' => [...], 'passes' => [...]]`
    *
    * Default: maps each finding into the canonical fields explicitly. The

--- a/src/CookieTrait.php
+++ b/src/CookieTrait.php
@@ -92,7 +92,7 @@ trait CookieTrait {
    * Assert that a cookie does not exist.
    *
    * @code
-   * Then a cookie with name "old_session" should not exist
+   * Then a cookie with the name "old_session" should not exist
    * @endcode
    */
   #[Then('a cookie with the name :name should not exist')]

--- a/src/DateTrait.php
+++ b/src/DateTrait.php
@@ -79,7 +79,7 @@ trait DateTrait {
    * [relative:-1 day#Y-m-d] would be converted to 2017-11-5
    *
    * @code
-   * Give content "article" exists:
+   * Given the following "article" content:
    *   | title        | created           |
    *   | test article | [relative:-1 day] |
    * @endcode

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -14,7 +14,7 @@ use Drupal\block\Entity\Block;
  * Manage Drupal blocks.
  *
  * - Create and configure blocks with custom visibility conditions.
- * - Place blocks in regions and verify their rendering in the page.
+ * - Place blocks in regions and assert their configured region.
  * - Created blocks are automatically removed at the end of the scenario.
  */
 trait BlockTrait {

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -342,10 +342,7 @@ trait BlockTrait {
    *   The visible label of the block to find.
    *
    * @return \Drupal\block\Entity\Block|null
-   *   The loaded block entity or NULL if not found.
-   *
-   * @throws \Exception
-   *   When no block with the specified label is found.
+   *   The loaded block entity, or NULL when no block carries that label.
    */
   protected function blockLoadByLabel(string $label): ?Block {
     $default_theme = \Drupal::config('system.theme')->get('default');

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -162,8 +162,8 @@ trait ContentBlockTrait {
   /**
    * Create a block content entity with the specified type and field values.
    *
-   * Created entities are stored in the static $blockContentEntities array for
-   * automatic cleanup after the scenario.
+   * Created entities are registered with the shared entity registry so that
+   * they are removed at the end of the scenario.
    *
    * @param string $type
    *   The machine name of the block content type.

--- a/src/Drupal/EckTrait.php
+++ b/src/Drupal/EckTrait.php
@@ -15,7 +15,7 @@ use Drupal\Driver\Entity\EntityStub;
  * Manage Drupal ECK entities with custom type and bundle creation.
  *
  * - Create structured ECK entities with defined field values.
- * - Assert entity type registration and visit entity pages.
+ * - Visit and edit ECK entity pages.
  * - Created entities are automatically removed at the end of the scenario.
  */
 trait EckTrait {
@@ -44,8 +44,8 @@ trait EckTrait {
    *
    * @code
    * Given the following eck "contact" "contact_type" entities do not exist:
-   *   | field        | value           |
-   *   | field_a      | Entity label    |
+   *   | title           |
+   *   | Entity label    |
    * @endcode
    */
   #[Given('the following eck :bundle :entity_type entities do not exist:')]

--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -18,7 +18,8 @@ use Drupal\media\MediaInterface;
  * Manage Drupal media entities with type-specific field handling.
  *
  * - Create structured media items with proper file reference handling.
- * - Assert media browser functionality and edit media entity fields.
+ * - Assert media type and media item existence.
+ * - Visit media view, edit, delete and revision pages.
  * - Support for multiple media types with field value expansion handling.
  * - Created entities are automatically removed at the end of the scenario.
  */

--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -306,7 +306,7 @@ trait MediaTrait {
   /**
    * Expand parsed fields into expected field values based on field type.
    *
-   * This is a re-use of the functionality provided by DrupalExtension.
+   * Reuses the protected expansion provided by the Drupal driver core.
    *
    * @param \Drupal\Driver\Entity\EntityStub $stub
    *   The entity stub.
@@ -342,12 +342,12 @@ trait MediaTrait {
    * Load multiple media entities with specified type and conditions.
    *
    * @param string $type
-   *   The node type.
+   *   The media type.
    * @param array<string, mixed> $conditions
    *   Conditions keyed by field names.
    *
    * @return array<int, string>
-   *   Array of node ids.
+   *   Array of media ids.
    */
   protected function mediaLoadMultiple(string $type, array $conditions = []): array {
     $query = \Drupal::entityQuery('media')

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -13,9 +13,8 @@ use Drupal\system\MenuInterface;
 /**
  * Manage Drupal menu systems and menu link rendering.
  *
- * - Assert menu items by label, path, and containment hierarchy.
- * - Assert menu link visibility and active states in different regions.
- * - Create and manage menu hierarchies with parent-child relationships.
+ * - Create and remove menus by label.
+ * - Create and remove menu links, including parent-child hierarchies.
  * - Created menus and menu links are automatically removed at the end of the scenario.
  */
 trait MenuTrait {

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -40,7 +40,7 @@ trait MenuTrait {
   }
 
   /**
-   * Create a menu if one does not exist.
+   * Create menus.
    *
    * Provide menu data in the following format:
    *

--- a/src/Drupal/ParagraphsTrait.php
+++ b/src/Drupal/ParagraphsTrait.php
@@ -56,7 +56,7 @@ trait ParagraphsTrait {
    * Create a paragraphs item from a stub and attach it to an entity.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $parent_entity
-   *   Node to attach paragraph to.
+   *   Entity to attach the paragraphs item to.
    * @param string $parent_field_name
    *   Field name on the entity that refers paragraphs item.
    * @param string $paragraph_bundle
@@ -65,7 +65,8 @@ trait ParagraphsTrait {
    *   Stub with filled-in fields. Fields are merged with created
    *   paragraphs item object.
    * @param bool $save_entity
-   *   Flag to save node after attaching a paragraphs item. Defaults to TRUE.
+   *   Flag to save the parent entity after attaching a paragraphs item.
+   *   Defaults to TRUE.
    *
    * @return \Drupal\paragraphs\ParagraphInterface
    *   Created paragraphs item.

--- a/src/Drupal/TestmodeTrait.php
+++ b/src/Drupal/TestmodeTrait.php
@@ -22,7 +22,7 @@ use Drupal\testmode\Testmode;
 trait TestmodeTrait {
 
   /**
-   * Enable test mode before a scenario tagged with @testmode.
+   * Enable test mode before an @api scenario tagged with @testmode.
    */
   #[BeforeScenario('@api')]
   public function testmodeBeforeScenario(BeforeScenarioScope $scope): void {
@@ -37,7 +37,7 @@ trait TestmodeTrait {
   }
 
   /**
-   * Disable test mode after the scenario for scenarios tagged with @testmode.
+   * Disable test mode after an @api scenario tagged with @testmode.
    */
   #[AfterScenario('@api')]
   public function testmodeAfterScenario(AfterScenarioScope $scope): void {

--- a/src/Drupal/TestmodeTrait.php
+++ b/src/Drupal/TestmodeTrait.php
@@ -22,7 +22,7 @@ use Drupal\testmode\Testmode;
 trait TestmodeTrait {
 
   /**
-   * Enable test mode before test run for scenarios tagged with @testmode.
+   * Enable test mode before a scenario tagged with @testmode.
    */
   #[BeforeScenario('@api')]
   public function testmodeBeforeScenario(BeforeScenarioScope $scope): void {

--- a/src/Drupal/TestmodeTrait.php
+++ b/src/Drupal/TestmodeTrait.php
@@ -37,7 +37,7 @@ trait TestmodeTrait {
   }
 
   /**
-   * Disable test mode before test run for scenarios tagged with @testmode.
+   * Disable test mode after the scenario for scenarios tagged with @testmode.
    */
   #[AfterScenario('@api')]
   public function testmodeAfterScenario(AfterScenarioScope $scope): void {

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -22,7 +22,7 @@ use Drupal\user\UserInterface;
  * - Create user accounts
  * - Create user roles
  * - Visit user profile pages for editing and deletion.
- * - Assert user roles and permissions.
+ * - Assert user roles.
  * - Assert user account status (active/inactive).
  */
 trait UserTrait {

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -438,7 +438,12 @@ trait UserTrait {
    *   The user name.
    *
    * @return \Drupal\user\UserInterface|null
-   *   The loaded user object or NULL if not found.
+   *   The loaded user object. The nullable return type is retained for
+   *   compatibility, but a missing user raises an exception rather than
+   *   returning NULL.
+   *
+   * @throws \RuntimeException
+   *   When no user with the specified name exists.
    */
   protected function userLoadByName(string $name): ?UserInterface {
     $users = $this->userLoadMultiple(['name' => $name]);

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -57,7 +57,7 @@ trait WatchdogTrait {
   protected int $watchdogScenarioLine = 0;
 
   /**
-   * Store current time.
+   * Store the scenario identity, tags and start time.
    */
   #[BeforeScenario('@api')]
   public function watchdogSetScenario(BeforeScenarioScope $scope): void {

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -57,7 +57,7 @@ trait WatchdogTrait {
   protected int $watchdogScenarioLine = 0;
 
   /**
-   * Store the scenario identity, tags and start time.
+   * Store the scenario identity, tracked message types and start time.
    */
   #[BeforeScenario('@api')]
   public function watchdogSetScenario(BeforeScenarioScope $scope): void {

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -166,7 +166,7 @@ trait WatchdogTrait {
   }
 
   /**
-   * Assert no errors above the severity threshold were logged.
+   * Assert no errors at or above the severity threshold were logged.
    *
    * Reported entries are deleted so a later check sees only new ones.
    *
@@ -179,8 +179,8 @@ trait WatchdogTrait {
   protected function watchdogAssertNoErrors(string $context): void {
     $database = Database::getConnection();
 
-    // Select all logged entries for PHP channel that appeared from the start
-    // of the scenario.
+    // Select entries for every tracked message type that appeared from the
+    // start of the scenario.
     $entries = $database->select('watchdog', 'w')
       ->fields('w')
       ->condition('w.type', $this->watchdogMessageTypes, 'IN')

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -1162,20 +1162,21 @@ JS;
   }
 
   /**
-   * Assert that an element is displayed within a viewport using different FE techniques.
+   * Check whether an element is displayed within the viewport.
    *
    * @param string $selector
    *   CSS query selector.
    * @param int $offset
-   *   (optional) Vertical element offset in pixels. Defaults to 0.
+   *   Vertical element offset in pixels.
    *
-   * @return bool
-   *   TRUE if an element is displayed within a viewport, FALSE if not.
+   * @return mixed
+   *   The raw result of the browser evaluation, truthy when the element is
+   *   displayed within the viewport.
    */
   protected function elementIsVisuallyVisible(string $selector, int $offset) {
     $selector_js = json_encode($selector, JSON_UNESCAPED_SLASHES);
     // The contents of this JS function should be copied as-is from the <script>
-    // section in the bottom of the tests/behat/fixtures/relative.html file.
+    // section at the bottom of tests/behat/fixtures/elements_relative.html.
     $script_function = <<<JS
       function isElemVisible(selector, offset = 0) {
         var failures = [];

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -400,8 +400,9 @@ trait FieldTrait {
   /**
    * CSS selectors that indicate a required-field marker.
    *
-   * Override in a subclass to customise the selectors used by
-   * ::fieldIsMarkedRequired() when walking a field's label/wrapper.
+   * Nothing consumes this list yet: ::fieldIsMarkedRequired() probes for the
+   * `required` attribute and the `form-required` class directly. It is kept as
+   * the intended override point for that check.
    *
    * @return array<int, string>
    *   CSS selectors to probe for a required marker.

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -111,8 +111,8 @@ trait HelperTrait {
       $field_name = array_shift($row);
 
       // Assign each value to corresponding entity.
-      // Note: Gherkin's TableNode automatically pads missing cells with empty
-      // strings, so we don't need to validate row length.
+      // Gherkin rejects a table whose rows have differing column counts, so
+      // row length needs no validation here.
       foreach ($row as $index => $value) {
         $entities[$index][$field_name] = $value;
       }

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -218,8 +218,8 @@ JS;
   /**
    * Trigger key on the element.
    *
-   * Use Syn library injected by original Selenium2 class to trigger browser
-   * events.
+   * The Selenium2 driver triggers events through the bundled Syn library;
+   * other drivers dispatch native DevTools key events.
    *
    * @param string $xpath
    *   XPath string for an element to trigger the key on.

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -83,9 +83,9 @@ trait KeyboardTrait {
    *
    * @param string $char
    *   Character or one of the pre-defined special keyboard keys.
-   * @param string $selector
-   *   Optional CSS selector for an element to trigger the key on. If omitted,
-   *   the key will be triggered on the 'html' element of the page.
+   * @param string|null $selector
+   *   CSS selector for an element to trigger the key on. Pass NULL to trigger
+   *   the key on the 'html' element of the page.
    *
    * @throws \Behat\Mink\Exception\UnsupportedDriverActionException
    *   If method is used for invalid driver.
@@ -129,7 +129,7 @@ trait KeyboardTrait {
 
     // Convert provided character sequence to special keys.
     if (strlen($char) < 1) {
-      throw new \InvalidArgumentException('keyPress($char) was invoked but the $char parameter was empty.');
+      throw new \InvalidArgumentException('The keyboard key must not be empty.');
     }
 
     // Consider provided characters string longer then 1 to be a keyboard key.

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -85,7 +85,8 @@ trait KeyboardTrait {
    *   Character or one of the pre-defined special keyboard keys.
    * @param string|null $selector
    *   CSS selector for an element to trigger the key on. Pass NULL to trigger
-   *   the key on the 'html' element of the page.
+   *   the key on the currently focused element. An exception is raised when no
+   *   element is focused.
    *
    * @throws \Behat\Mink\Exception\UnsupportedDriverActionException
    *   If method is used for invalid driver.

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -127,7 +127,7 @@ trait PathTrait {
   }
 
   /**
-   * Assert that current URL doesn't have a query parameter with specific value.
+   * Assert that current URL does not have a query parameter.
    *
    * @code
    * Then current url should not have the "filter" parameter
@@ -143,7 +143,7 @@ trait PathTrait {
   }
 
   /**
-   * Assert that current URL doesn't have a query parameter with specific value.
+   * Assert that current URL does not have a query parameter with a value.
    *
    * @code
    * Then current url should not have the "filter" parameter with the "recent" value

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -91,7 +91,9 @@ trait PathTrait {
   }
 
   /**
-   * Assert that current URL has a query parameter.
+   * Assert that current URL has a query parameter with a non-empty value.
+   *
+   * A parameter carrying an empty string or "0" counts as absent.
    *
    * @code
    * Then current url should have the "filter" parameter
@@ -108,6 +110,8 @@ trait PathTrait {
 
   /**
    * Assert that current URL has a query parameter with a specific value.
+   *
+   * A parameter carrying an empty string or "0" counts as absent.
    *
    * @code
    * Then current url should have the "filter" parameter with the "recent" value
@@ -127,7 +131,9 @@ trait PathTrait {
   }
 
   /**
-   * Assert that current URL does not have a query parameter.
+   * Assert that current URL has no query parameter with a non-empty value.
+   *
+   * A parameter carrying an empty string or "0" counts as absent.
    *
    * @code
    * Then current url should not have the "filter" parameter
@@ -144,6 +150,8 @@ trait PathTrait {
 
   /**
    * Assert that current URL does not have a query parameter with a value.
+   *
+   * A parameter carrying an empty string or "0" counts as absent.
    *
    * @code
    * Then current url should not have the "filter" parameter with the "recent" value

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -759,7 +759,8 @@ trait XmlTrait {
         $prefix = $node->localName;
         $uri = $node->nodeValue;
 
-        // Skip the default XML namespace.
+        // Skip the reserved namespace bound to the 'xml' prefix, which every
+        // document declares implicitly.
         if ($uri !== 'http://www.w3.org/XML/1998/namespace') {
           $namespaces[$prefix] = $uri;
         }
@@ -856,8 +857,12 @@ trait XmlTrait {
    * Validate the response against a DTD.
    *
    * The DTD is embedded as an internal subset and the response is reloaded
-   * with validation enabled. A DTD from a file and an inline DTD share this
-   * code path without exposing external-entity loading.
+   * with validation enabled, so a DTD from a file and an inline DTD share this
+   * code path.
+   *
+   * Validation runs with `LIBXML_DTDVALID` and without `LIBXML_NOENT`, so a
+   * `SYSTEM` entity declared in the DTD is dereferenced during validation but
+   * its content is never substituted into the document.
    *
    * DTDs are namespace-unaware, so a namespaced response is validated verbatim
    * and its `xmlns` attributes must be declared in the DTD. This matches

--- a/tests/behat/features/keyboard.feature
+++ b/tests/behat/features/keyboard.feature
@@ -78,7 +78,7 @@ Feature: Check that KeyboardTrait works
     When I run "behat --no-colors"
     Then it should fail with a "InvalidArgumentException" exception:
       """
-      keyPress($char) was invoked but the $char parameter was empty.
+      The keyboard key must not be empty.
       """
 
   @trait:KeyboardTrait


### PR DESCRIPTION
Closes #732

## Summary

This PR corrects docblock and comment claims across the library that no longer matched the code they describe, each verified by checking the claim against the implementation it documents. None of the corrections change behaviour except one: an exception message in `KeyboardTrait` named a `keyPress($char)` method that does not exist in the trait, and now states the actual failure instead. The `XmlTrait` DTD-validation docblock changes from an incorrect claim of no external-entity exposure to a description of what was measured on PHP 8.3.30 with libxml 2.13.9; the underlying external-entity dereferencing is tracked separately for a code fix in issue #721 and is out of scope here.

A second batch of twelve claims was found by a subsequent audit of every trait in `src/` and is included here, since it is the same class of change. Seven of those are rendered into `STEPS.md`, so they were documentation users read. They are catalogued in #732.

## Changes

- `ContentBlockTrait`: removed the claim that created entities are stored in a static `blockContentEntities` array; cleanup goes through the shared entity registry instead.
- `MediaTrait::mediaLoadMultiple()`: corrected the `$type` and return docs from node type and node ids to media type and media ids.
- `MediaTrait::mediaExpandEntityFields()`: corrected the attribution from DrupalExtension to the Drupal driver core.
- `UserTrait::userLoadByName()`: corrected the documented NULL return for a missing user; the method throws instead, and a `@throws` tag was added.
- `MenuTrait`: replaced the advertised assertion steps for menu items, paths, hierarchy, link visibility and active state with a description of the Given steps the trait actually defines.
- `BlockTrait::blockLoadByLabel()`: removed the `@throws` tag from a method that returns NULL and never throws.
- `WatchdogTrait`: corrected the query comment from the PHP channel to every tracked message type, and fixed the assertion summary so entries at the severity threshold are described as failing too.
- `TestmodeTrait`: corrected the AfterScenario hook description from running before the test run to running after the scenario.
- `AccessibilityTrait`: corrected the static cache lifetime from per run to per process, and removed a pointer to a canonical structure the class docblock never documents.
- `ElementTrait::elementIsVisuallyVisible()`: corrected the return type from bool to the raw browser-evaluation result, removed the false claim of an optional parameter with a default, and fixed the fixture file pointer to the file that actually exists.
- `FieldTrait::fieldGetRequiredMarkerSelectors()`: corrected the docblock; nothing consumes this list yet, since the required-marker check probes the `required` attribute and `form-required` class directly.
- `XmlTrait`: corrected the reserved `xml` namespace description from default namespace to reserved namespace, and replaced the "without exposing external-entity loading" claim with a description of the measured SYSTEM entity dereferencing during DTD validation.
- `DateTrait`, `CookieTrait`: fixed `@code` examples that would not parse or did not match their own registered step.
- `PathTrait`: split one summary shared by two assertions into two summaries that each describe their own assertion.
- `KeyboardTrait`: corrected an omittable-parameter claim to reflect the `?string $selector` signature, and replaced the empty-key exception message (which named a nonexistent `keyPress($char)` method) with a description of the actual failure; `tests/behat/features/keyboard.feature` was updated to match the new message.

### Second batch (#732)

- `EckTrait`: the delete step's `@code` example used a generic `| field | value |` header row, which `getHash()` reads as fields literally named `field` and `value`, so the published example could not work if copied. It now uses a real field-name header, matching both the sibling create step and the shape `eckEntitiesCreate()` itself passes in. The trait summary also claimed assertion steps, and the trait defines no `Then` methods at all.
- `MenuTrait::menuCreate()`: the summary claimed a menu is created only if one does not exist; every row is created unconditionally via `Menu::create()->save()`.
- `MediaTrait`: the trait summary claimed media browser assertions, and no media browser step exists.
- `UserTrait`: the trait summary claimed permission assertions; only roles are asserted, and the one permissions step is a `Given` that creates a role.
- `BlockTrait`: the trait summary claimed verification of rendering in the page; the assertions read the block config entity and never inspect rendered output.
- `TestmodeTrait`: the BeforeScenario hook summary said before test run; it runs before each scenario.
- `HelperTrait`: the transpose comment claimed Gherkin pads missing cells with empty strings; `TableNode::__construct()` throws on ragged rows instead. The conclusion held, but for the opposite reason.
- `KeyboardTrait::keyboardTriggerKey()`: the docblock described Syn unconditionally; Syn is used only in the Selenium2 branch, and CDP drivers dispatch native DevTools key events.
- `ParagraphsTrait`: two `@param` descriptions said node where the parameter is any `ContentEntityInterface`, and taxonomy terms are explicitly supported.
- `WatchdogTrait::watchdogSetScenario()`: the summary said it stores the current time; it also stores the scenario title and line and resolves message types from tags.
- `STEPS.md`: regenerated with `ahoy update-docs` to reflect the corrected docblocks.

## Before / After

```
┌────────────────────────────────────────────────────────────────────────┐
│ EckTrait: documented delete example                                    │
├────────────────────────────────────────────────────────────────────────┤
│ BEFORE                                                                 │
│   | field        | value           |   ->  getHash() yields            │
│   | field_a      | Entity label    |      ['field' => 'field_a',       │
│                                           'value' => 'Entity label']   │
│                                       queries fields named `field`     │
│                                       and `value`, which do not exist  │
│                                                                        │
│ AFTER                                                                  │
│   | title           |                 ->  getHash() yields             │
│   | Entity label    |                    ['title' => 'Entity label']   │
│                                       matches the shape the trait      │
│                                       itself passes in                 │
└────────────────────────────────────────────────────────────────────────┘
```

```
┌────────────────────────────────────────────────────────────────────────┐
│ XmlTrait::assertResponseMatchesDtd() docblock                          │
├────────────────────────────────────────────────────────────────────────┤
│ BEFORE                                                                 │
│   "...share this code path without exposing external-entity loading."  │
│                                                                        │
│ AFTER                                                                  │
│   "...share this code path. A SYSTEM entity declared in the DTD is     │
│   dereferenced during validation (LIBXML_DTDVALID), but its content is │
│   never substituted because LIBXML_NOENT is not passed."               │
└────────────────────────────────────────────────────────────────────────┘
```
