### PR TITLE
Converged source comments onto the technical register.

### DIFF
--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -766,11 +766,12 @@ trait AccessibilityTrait {
    *
    * Default: strip the configured Mink `base_url` prefix so reports show the
    * page path (`/contact`) rather than the internal host and port
-   * (`http://nginx:8080/contact`), which is noise and makes reports
-   * non-portable. The base URL itself maps to `/` and the query string is
-   * kept. Only the known `base_url` is stripped: a genuinely cross-origin URL
-   * captured during assessment stays absolute, so it remains distinguishable.
-   * Override to keep the absolute URL or to format it differently.
+   * (`http://nginx:8080/contact`). The absolute form is noise and makes
+   * reports non-portable. The base URL itself maps to `/` and the query
+   * string is kept. Only the known `base_url` is stripped: a genuinely
+   * cross-origin URL captured during assessment stays absolute, so it
+   * remains distinguishable. Override to keep the absolute URL or to format
+   * it differently.
    */
   protected function accessibilityFormatUrl(string $url): string {
     $base = rtrim((string) $this->getMinkParameter('base_url'), '/');

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -354,8 +354,7 @@ trait BlockTrait {
       ]);
 
     // Machine names gain a numeric suffix on collision, so ordering the keys
-    // ascending puts the most recently created block last. This matches how
-    // the other traits resolve a duplicate label.
+    // ascending puts the most recently created block last.
     ksort($blocks);
 
     return empty($blocks) ? NULL : end($blocks);

--- a/src/Drupal/ConfigOverrideTrait.php
+++ b/src/Drupal/ConfigOverrideTrait.php
@@ -77,9 +77,10 @@ trait ConfigOverrideTrait {
   /**
    * Collect `@disable-config-override:*` tags for the current scenario.
    *
-   * Always clears any propagated signal from a previous scenario first so
-   * state never bleeds between scenarios - even when this hook is bypassed
-   * via `@behat-steps-skip:configOverrideBeforeScenario`.
+   * The signal propagated by a previous scenario is cleared before the
+   * skip-tag check, so no signal persists across scenarios.
+   * `@behat-steps-skip:configOverrideBeforeScenario` bypasses tag collection,
+   * not the clearing.
    */
   #[BeforeScenario('@api')]
   public function configOverrideBeforeScenario(BeforeScenarioScope $scope): void {

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -270,14 +270,14 @@ trait ContentTrait {
 
     $node = $this->contentLoadNodeByTitle($content_type, $title);
 
-    // The current value carries the 'pid' of the existing alias, which makes
-    // the save update that alias rather than add a second one.
+    // The current value carries the 'pid' of the existing alias, so the save
+    // updates that alias rather than adding a second one.
     $path_value = (array) ($node->get('path')->getValue()[0] ?? []);
     $path_value['alias'] = '/' . ltrim($alias, '/');
 
-    // 0 is 'PathautoState::SKIP', which stops pathauto from regenerating the
-    // alias on save. The property exists only on 'PathautoItem', so setting
-    // it without the module throws.
+    // 0 is 'PathautoState::SKIP', so pathauto does not regenerate the alias
+    // on save. The property exists only on 'PathautoItem', so setting it
+    // without the module throws.
     if (\Drupal::moduleHandler()->moduleExists('pathauto')) {
       $path_value['pathauto'] = 0;
     }
@@ -339,10 +339,12 @@ trait ContentTrait {
    * Expand fixture file paths for file/image fields on nodes.
    *
    * Rewrites bare fixture filenames (e.g. 'document.pdf') on 'file' and
-   * 'image' field types to absolute paths under the Mink 'files_path' so
-   * drupal-driver's FileHandler can read and upload them during node
-   * creation. Without this, scenarios with file fields on nodes have to
-   * pre-create managed files explicitly via FileTrait.
+   * 'image' field types to absolute paths under the Mink 'files_path'.
+   * drupal-driver's FileHandler can then read and upload them during node
+   * creation.
+   *
+   * Without this, scenarios with file fields on nodes have to pre-create
+   * managed files explicitly via FileTrait.
    *
    * Backed by 'HelperTrait::helperExpandEntityFieldsFixtures()'.
    */

--- a/src/Drupal/DraggableviewsTrait.php
+++ b/src/Drupal/DraggableviewsTrait.php
@@ -39,7 +39,7 @@ trait DraggableviewsTrait {
 
       $entity_id = $node->id();
 
-      // Here and below: copied from draggableviews_views_submit().
+      // Here and below: mirrors draggableviews_views_submit().
       $database->delete('draggableviews_structure')
         ->condition('view_name', $view_id)
         ->condition('view_display', $view_display_id)

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -43,7 +43,7 @@ trait EmailTrait {
   protected array $emailHandlerTypes = [];
 
   /**
-   * Enable email debug.
+   * Whether email debug is enabled.
    */
   protected bool $emailDebug = FALSE;
 
@@ -542,7 +542,6 @@ trait EmailTrait {
   #[When('I enable the test email system')]
   public function emailEnableTestSystem(): void {
     foreach ($this->emailHandlerTypes as $type) {
-      // Store the original system to restore after the scenario.
       $original_test_system = self::emailGetMailSystemDefault($type);
       if (!self::emailGetMailSystemOriginal($type)) {
         self::emailSetMailSystemOriginal($type, $original_test_system);
@@ -659,7 +658,7 @@ trait EmailTrait {
   }
 
   /**
-   * Find an email message field containing a value.
+   * Find an email message whose field contains a value.
    *
    * @param string $field
    *   Field to search in.

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -49,10 +49,9 @@ trait FileTrait {
       return;
     }
     // @codeCoverageIgnoreEnd
-    // 6.x Drupal driver bootstraps lazily on first step that needs Drupal,
-    // so the container may not exist yet when this hook fires. Skip the
-    // best-effort directory check until Drupal is up - the dirs will be
-    // created on demand by the file operations that actually need them.
+    // The 6.x Drupal driver bootstraps lazily on the first step that needs
+    // Drupal, so the container may not exist yet when this hook fires. The
+    // file operations that need the directories create them on demand.
     // @codeCoverageIgnoreStart
     if (!\Drupal::hasContainer()) {
       return;

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -28,8 +28,8 @@ trait ElementTrait {
    * interaction failures caused by sticky headers, admin toolbars, or fixed
    * navigation.
    *
-   * Returns FALSE to use the legacy scrollIntoView(true) behavior, which
-   * aligns the element to the top of the viewport.
+   * Returns FALSE to use the scrollIntoView(true) behavior, which aligns
+   * the element to the top of the viewport.
    *
    * Override this method in the context class to change the behavior:
    * @code
@@ -992,9 +992,9 @@ JS;
   /**
    * Assert visible focus indicator state for an element.
    *
-   * An element is considered to have a visible focus indicator when either
-   * its computed outline has a non-`none` style with a width greater than 0,
-   * or its computed box-shadow is not `none`.
+   * An element has a visible focus indicator when its computed outline has
+   * a non-`none` style with a width greater than 0. A computed box-shadow
+   * that is not `none` also counts as a visible indicator.
    *
    * @param string $selector
    *   The CSS selector.

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -66,7 +66,6 @@ trait FieldTrait {
     $this->fieldFormValidationEnabled = TRUE;
     $this->fieldFormValidationRegistry = [];
 
-    // Check for @disable-form-validation tag.
     $this->fieldDisableAllFormValidation = $scope->getScenario()->hasTag('disable-form-validation');
   }
 
@@ -89,13 +88,11 @@ trait FieldTrait {
       return;
     }
 
-    // Handle @disable-form-validation tag - disable all forms on page.
     if ($this->fieldDisableAllFormValidation) {
       $this->fieldDisableFormValidation();
       return;
     }
 
-    // Handle selector-based registry - disable specific forms.
     if (!empty($this->fieldFormValidationRegistry)) {
       foreach ($this->fieldFormValidationRegistry as $selector) {
         $this->fieldDisableFormValidation($selector);
@@ -115,7 +112,6 @@ trait FieldTrait {
       return;
     }
 
-    // Clean up for next scenario.
     $this->fieldFormValidationRegistry = [];
     $this->fieldFormValidationEnabled = FALSE;
     $this->fieldDisableAllFormValidation = FALSE;
@@ -169,7 +165,6 @@ trait FieldTrait {
   public function fieldAssertExists(string $name): NodeElement {
     $page = $this->getSession()->getPage();
     $field = $page->findField($name);
-    // Try to resolve by ID.
     $field = $field ?: $page->findById($name);
 
     if ($field === NULL) {
@@ -191,7 +186,6 @@ trait FieldTrait {
   public function fieldAssertNotExists(string $name): void {
     $page = $this->getSession()->getPage();
     $field = $page->findField($name);
-    // Try to resolve by ID.
     $field = $field ?: $page->findById($name);
 
     if ($field !== NULL) {
@@ -298,24 +292,22 @@ trait FieldTrait {
 
     $page = $this->getSession()->getPage();
 
-    // Locate the field wrapper. Drupal multi-value widgets wrap the field
-    // rows (a table) and the "Add another item" button in an outer
-    // container identified by `data-drupal-selector="edit-<field>-wrapper"`.
-    // The title can live in a nested <label>, <h4>, <legend>, <caption>,
-    // or plain text element. Match the title first, then walk up to the
-    // outermost edit- wrapper so that the Add-more button is included.
+    // Drupal multi-value widgets wrap the field rows (a table) and the
+    // "Add another item" button in an outer container identified by
+    // `data-drupal-selector="edit-<field>-wrapper"`. The title can appear
+    // in a nested <label>, <h4>, <legend>, <caption>, or plain text
+    // element. Match the title first, then walk up to the outermost edit-
+    // wrapper so that the Add-more button is included.
     $literal = $this->fieldXpathLiteral($field);
     $title_xpath = sprintf('//*[not(self::input or self::select or self::textarea) and (normalize-space(text())=%s or normalize-space(.)=%s)]', $literal, $literal);
     $wrapper_xpath = $title_xpath . '/ancestor::*[@data-drupal-selector and contains(@data-drupal-selector, "-wrapper")][1]';
     $wrapper = $page->find('xpath', $wrapper_xpath);
 
-    // Fallback: any edit-* ancestor or field-multiple-table.
     if ($wrapper === NULL) {
       $fallback_xpath = $title_xpath . '/ancestor::*[contains(@class, "field-multiple-table") or (@data-drupal-selector and starts-with(@data-drupal-selector, "edit-"))][1]';
       $wrapper = $page->find('xpath', $fallback_xpath);
     }
 
-    // Fallback: locate the first input by label via Mink, then walk up.
     if ($wrapper === NULL) {
       $first_input = $page->findField($field);
       if ($first_input !== NULL) {
@@ -330,18 +322,15 @@ trait FieldTrait {
       throw new ElementNotFoundException($this->getSession()->getDriver(), 'multi-value field wrapper', 'label', $field);
     }
 
-    // Count existing input rows within the wrapper. Match inputs whose name
-    // contains the common multi-value suffixes ([0][value], [1][value], etc.)
-    // or [0][target_id] for entity reference widgets.
+    // Multi-value rows carry name suffixes such as [0][value] and
+    // [1][value]; entity reference widgets use [0][target_id].
     $existing_inputs = $wrapper->findAll('xpath', './/input[contains(@name, "[value]") or contains(@name, "[target_id]")]');
     $existing_count = count($existing_inputs);
     if ($existing_count === 0) {
-      // As a last resort, fall back to any text-like input within the wrapper.
       $existing_inputs = $wrapper->findAll('xpath', './/input[@type="text"]');
       $existing_count = count($existing_inputs);
     }
 
-    // Ensure we have at least one slot to fill.
     $existing_count = max(1, $existing_count);
 
     $required = count($values);
@@ -356,8 +345,6 @@ trait FieldTrait {
         }
       }
       if ($add_more === NULL) {
-        // XPath fallback: any submit input or button whose name or value
-        // contains "add_more" / "Add another item".
         $add_more = $wrapper->find('xpath', './/input[@type="submit" and (contains(@name, "_add_more") or contains(@value, "Add another"))] | .//button[contains(@name, "_add_more") or contains(normalize-space(.), "Add another")]');
       }
       if ($add_more === NULL) {

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -29,8 +29,8 @@ trait HelperTrait {
   /**
    * Record the line of the scenario's last step.
    *
-   * A hook that must run once per scenario, but must raise its verdict at step
-   * scope for Behat to record it, needs to recognise the last step. Step scopes
+   * A hook that runs once per scenario, yet raises its verdict at step
+   * scope for Behat to record it, must recognise the last step. Step scopes
    * expose no scenario, so the line is resolved here and compared later.
    */
   protected function helperSetLastStepLine(BeforeScenarioScope $scope): void {
@@ -79,13 +79,11 @@ trait HelperTrait {
   protected function helperTransposeVerticalTable(TableNode $table): array {
     $rows = $table->getRows();
 
-    // Validate table has at least 2 columns (field + at least one value column).
     $first_row = $rows[0];
     if (count($first_row) < 2) {
       throw new \RuntimeException('Vertical table must have at least 2 columns (field name and value).');
     }
 
-    // Validate no duplicate field names.
     $field_names = array_column($rows, 0);
     $duplicate_fields = array_filter(array_count_values($field_names), fn(int $count): bool => $count > 1);
 
@@ -93,24 +91,19 @@ trait HelperTrait {
       throw new \RuntimeException(sprintf('Duplicate field names found: %s', implode(', ', array_keys($duplicate_fields))));
     }
 
-    // Validate all field names are non-empty.
     foreach ($field_names as $field_name) {
       if (trim((string) $field_name) === '') {
         throw new \RuntimeException('Field names cannot be empty.');
       }
     }
 
-    // Determine number of entities based on number of columns.
     $num_entities = count($first_row) - 1;
 
-    // Initialize result array for each entity.
     $entities = array_fill(0, $num_entities, []);
 
-    // Transpose the data.
     foreach ($rows as $row) {
       $field_name = array_shift($row);
 
-      // Assign each value to corresponding entity.
       // Gherkin rejects a table whose rows have differing column counts, so
       // row length needs no validation here.
       foreach ($row as $index => $value) {
@@ -140,11 +133,9 @@ trait HelperTrait {
       return new TableNode([]);
     }
     // @codeCoverageIgnoreEnd
-    // Get field names from first entity.
     $field_names = array_keys($entities[0]);
     $rows = [$field_names];
 
-    // Add each entity as a row.
     foreach ($entities as $entity) {
       $rows[] = array_values($entity);
     }
@@ -202,9 +193,9 @@ trait HelperTrait {
   /**
    * Convert an arbitrary string into a filesystem-safe slug.
    *
-   * Lowercases the input, collapses any run of non-alphanumeric characters
-   * to a single hyphen, trims leading and trailing hyphens, and falls back
-   * to `untitled` when the result would otherwise be empty.
+   * Lowercases the input and collapses any run of non-alphanumeric
+   * characters to a single hyphen. Trims leading and trailing hyphens and
+   * falls back to `untitled` when the result would otherwise be empty.
    *
    * @param string $value
    *   The string to slugify.
@@ -230,7 +221,6 @@ trait HelperTrait {
   protected function helperIsJavascriptSupported(): bool {
     try {
       $driver = $this->getSession()->getDriver();
-      // Ensure driver is started before checking JS capability.
       if (!$driver->isStarted()) {
         $driver->start();
       }

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -195,9 +195,7 @@ trait JavascriptTrait {
     try {
       $current_url = $this->getSession()->getCurrentUrl();
 
-      // Only collect errors if URL changed (navigation occurred).
       if ($current_url !== $this->javascriptCurrentUrl) {
-        // Re-inject collector on new page.
         $this->javascriptInjectCollector();
         $this->javascriptCurrentUrl = $current_url;
       }
@@ -333,7 +331,6 @@ JS;
       return;
     }
 
-    // Build detailed error message.
     $error_count = 0;
     $message_parts = ["JavaScript errors detected:\n"];
 

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -193,7 +193,6 @@ trait JavascriptTrait {
     }
     // @codeCoverageIgnoreEnd
     try {
-      // Get current URL.
       $current_url = $this->getSession()->getCurrentUrl();
 
       // Only collect errors if URL changed (navigation occurred).

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -94,9 +94,6 @@ trait KeyboardTrait {
   public function keyboardPressKeyOnElementSingle(string $char, ?string $selector): void {
     $driver = $this->getSession()->getDriver();
 
-    // Keyboard interaction needs a JavaScript-capable driver: Selenium2 uses
-    // the bundled Syn library, chrome-mink uses native DevTools key events.
-    // BrowserKit-based (non-JavaScript) drivers cannot dispatch key events.
     if ($driver instanceof BrowserKitDriver) {
       throw new UnsupportedDriverActionException('Keyboard interaction is only supported by JavaScript drivers (Selenium2 or Chrome).', $driver);
     }
@@ -128,26 +125,21 @@ trait KeyboardTrait {
       'caps' => 'caps',
     ];
 
-    // Convert provided character sequence to special keys.
     if (strlen($char) < 1) {
       throw new \InvalidArgumentException('The keyboard key must not be empty.');
     }
 
-    // Consider provided characters string longer then 1 to be a keyboard key.
     if (strlen($char) > 1) {
       if (!array_key_exists(strtolower($char), $keys)) {
         throw new \RuntimeException(sprintf('Unsupported key "%s" provided', $char));
       }
 
-      // Special case for tab key triggered in window without target element
-      // focused: Syn (JS library that provides synthetic events) can tab only
-      // from another element that can receive focus, so we inject such
-      // element as a very first element after opening <body> tag. This
-      // element is visually hidden, but compatible with screen readers. Then
-      // we trigger key on this element to make sure that an element that
-      // supposed to get the very first focus from tab index actually gets it.
-      // Note that injecting element and triggering key press on it does not
-      // make it focused itself.
+      // Syn, the JS library that provides synthetic events, can tab only
+      // from an element that can receive focus. A tab press with no
+      // selector therefore targets a visually hidden, screen-reader
+      // compatible anchor injected as the first element inside <body>.
+      // Triggering the key on the anchor moves focus to the first element
+      // in the tab order without focusing the anchor itself.
       if ($selector === NULL && $char === 'tab') {
         $selector = '#injected-focusable';
 
@@ -164,9 +156,9 @@ trait KeyboardTrait {
       $char = $keys[strtolower($char)];
     }
 
-    // When no selector is provided, use the currently focused element.
-    // This allows chaining key presses: first call with selector to focus and
-    // type, then subsequent calls without selector to continue typing.
+    // With no selector the key is sent to the currently focused element.
+    // A call with a selector focuses and types; later calls without one
+    // continue typing in the same element.
     if ($selector === NULL) {
       $script = <<<'JS'
         (function() {

--- a/src/LinkTrait.php
+++ b/src/LinkTrait.php
@@ -66,7 +66,6 @@ trait LinkTrait {
     }
 
     $pattern = '/' . preg_quote($href, '/') . '/';
-    // Support for simplified wildcard using '*'.
     $pattern = str_contains($href, '*') ? str_replace('\*', '.*', $pattern) : $pattern;
     if (!preg_match($pattern, (string) $link_element->getAttribute('href'))) {
       throw new ExpectationException(sprintf('The link href "%s" does not match the specified href "%s"', $link_element->getAttribute('href'), $href), $this->getSession()->getDriver());
@@ -119,7 +118,6 @@ trait LinkTrait {
     }
 
     $pattern = '/' . preg_quote($href, '/') . '/';
-    // Support for simplified wildcard using '*'.
     $pattern = str_contains($href, '*') ? str_replace('\*', '.*', $pattern) : $pattern;
     if (preg_match($pattern, (string) $link_element->getAttribute('href'))) {
       throw new ExpectationException(sprintf('The link href "%s" matches the specified href "%s" but should not', $link_element->getAttribute('href'), $href), $this->getSession()->getDriver());


### PR DESCRIPTION
## Summary

This PR applies a source-comment register pass over all 51 traits in `src/`. It deletes comments that restate the code or narrate a past change, and rewords the survivors into declarative single-clause statements. No code changed.

## Changes

- Inline comments inside method bodies were subject to deletion.
- Docblocks on methods that carry no step attribute, and property docblocks, were reworded but never deleted, because the Drupal phpcs standard requires a docblock on every method and property.
- Trait docblocks, step-method docblocks, `@code` blocks and all `@param`/`@return`/`@throws` lines were left untouched, because `docs.php` renders them into `STEPS.md`, and editing them would turn a comment pass into a rewrite of published documentation. `ahoy lint-docs` confirms `STEPS.md` is unchanged.
- Comments inside the `<<<JS` heredoc in `JavascriptTrait` were left alone: they are part of an injected browser payload rather than PHP source, so editing them would alter a string literal for no functional gain.
- One comment in `BlockTrait` lost a sentence asserting how sibling traits break a duplicate-label tie. That claim describes behaviour in other files that can change without this one being touched, so it would go stale unnoticed. The reason the keys are sorted ascending is retained.

## Coverage

- The pass ran as ten parallel reviewers, one per slice of the source tree. Seven completed. Three were interrupted, and their files had their inline comments reviewed individually instead. Those three slices did not get an exhaustive re-review of their non-step docblocks.

## Claims found but not fixed

- A register pass reports claims rather than correcting them, because burying a documentation correction in a wording diff hides it from review.
- Twelve wrong docblock claims were found and are fixed separately in #732, which is already merged.
- `DateTrait` documents its relative-date fallback as rounding to the current hour, while `date('Y-m-d H:i:00', ...)` rounds to the current minute. Reported as #734, unchanged here.

## Before / After

```
┌─ src/FieldTrait.php ── before ─────────────────────────────
│
│   $field = $page->findField($name);
│   // Try to resolve by ID.
│   $field = $field ?: $page->findById($name);
│
├─ src/FieldTrait.php ── after ──────────────────────────────
│
│   $field = $page->findField($name);
│   $field = $field ?: $page->findById($name);
│
└─────────────────────────────────────────────────────────────
```
