### PR TITLE
[#719] Failed the negative link assertion when its container is missing.

### DIFF
--- a/src/LinkTrait.php
+++ b/src/LinkTrait.php
@@ -104,8 +104,12 @@ trait LinkTrait {
 
     if ($selector) {
       $element = $page->find('css', $selector);
+
+      // A missing container is an unusable assertion rather than a passing
+      // one, so it fails here as it does in the positive assertion. Returning
+      // instead would let a typo in the selector pass unconditionally.
       if (!$element) {
-        return;
+        throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
       }
     }
     else {

--- a/tests/behat/features/link.feature
+++ b/tests/behat/features/link.feature
@@ -23,7 +23,7 @@ Feature: Check that LinkTrait works
   Scenario: Assert link with href with selector does not exist
     When I visit "/sites/default/files/links.html"
     Then the link "RandomLinkText" with the href "https://www.randomhref.org" within the element "#navigation" should not exist
-    And the link "Absolute Link One" with the href "https://www.example.com" within the element "#random-selector" should not exist
+    And the link "Absolute Link One" with the href "https://www.randomhref.org" within the element "#navigation" should not exist
 
   Scenario: Assert link with wildcard in href without selector does not exist
     When I visit "/sites/default/files/links.html"
@@ -108,6 +108,20 @@ Feature: Check that LinkTrait works
     Then it should fail with an error:
       """
       Link with text "NonexistentLinkText" not found.
+      """
+
+  @trait:LinkTrait
+  Scenario: Assert that negative link assertion fails when selector does not exist
+    Given some behat configuration
+    And scenario steps:
+      """
+      When I visit "/sites/default/files/links.html"
+      Then the link "Absolute Link One" with the href "https://www.example.com" within the element "#nonexistent-selector" should not exist
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      Element matching css "#nonexistent-selector" not found.
       """
 
   @trait:LinkTrait


### PR DESCRIPTION
Closes #719

## Summary

`the link :link with the href :href within the element :selector should not exist` returned early when the container selector matched nothing, which made the assertion pass. A typo in the container selector therefore produced a test that could not fail, regardless of what the page contained.

Its positive twin `linkAssertTextWithHrefWithinElementExists()` already throws `ElementNotFoundException` for exactly that condition, so the two halves of the same pair disagreed about whether a missing container is an error or a pass.

The step now throws for a missing container. The separate early return for a missing link is kept, because that one is the assertion genuinely succeeding: no link means the link does not exist.

This is one of three fixes from #719 and is landing on its own.

## Changes

- `src/LinkTrait.php`: `linkAssertTextWithHrefWithinElementNotExists()` throws `ElementNotFoundException` when the container selector matches nothing, matching the positive assertion.
- `tests/behat/features/link.feature`: the existing scenario asserted against `#random-selector`, a container that does not exist, so it was encoding the old behaviour and would now fail. It now uses the real `#navigation` container with a non-matching href, which tests what it was meant to test.
- `tests/behat/features/link.feature`: a new `@trait:LinkTrait` scenario pins the new failure.

## Verification

The new scenario was confirmed to fail without the source change and pass with it. With the fix reverted, `link.feature` reports 19 of 20 scenarios passing, and the failure is the nested Behat run passing when it was expected to fail. With the fix applied, all 20 scenarios and 69 steps pass.

`ahoy lint`, `ahoy test-unit` and `ahoy lint-docs` all pass. `STEPS.md` is unchanged, since the step text and its docblock are untouched.

## Before / After

```
┌──────────────────────────────────────────────────────────────────────┐
│ "...within the element '#typo' should not exist" on a page that      │
│ does contain the link                                                │
├──────────────────────────────────────────────────────────────────────┤
│ BEFORE                                                               │
│   find('css', '#typo')  ->  NULL                                     │
│   return                ->  step PASSES                              │
│                             the link was never examined              │
│                                                                      │
│ AFTER                                                                │
│   find('css', '#typo')  ->  NULL                                     │
│   throw                 ->  step FAILS                               │
│                             Element matching css "#typo" not found.  │
└──────────────────────────────────────────────────────────────────────┘
```

```
┌──────────────────────────────────────────────────────────────────────┐
│ The pair, before and after                                           │
├──────────────────────────────────────────────────────────────────────┤
│                        │ container missing │ link missing            │
│ BEFORE  should exist   │ throws            │ throws                  │
│         should not     │ PASSES            │ passes (correct)        │
│                        │                   │                         │
│ AFTER   should exist   │ throws            │ throws                  │
│         should not     │ throws            │ passes (correct)        │
└──────────────────────────────────────────────────────────────────────┘
```
