### PR TITLE
[#719] Failed rather than reported an empty mailbox when the collector is unreadable.

### DIFF
--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -631,10 +631,18 @@ trait EmailTrait {
     // may corrupt the system under test.
     $query = Database::getConnection()->query("SELECT name, value FROM {key_value} WHERE name = 'system.test_mail_collector'");
 
-    $messages = [];
-    if ($query instanceof StatementInterface) {
-      $messages = array_map(unserialize(...), $query->fetchAllKeyed());
+    // A failed read is not the same as an empty mailbox. Connection::query()
+    // returns NULL when execution failed and the exception handler suppressed
+    // it, and treating that as zero messages would make every "no emails"
+    // assertion pass without the collector ever being consulted.
+    // @codeCoverageIgnoreStart
+    if (!$query instanceof StatementInterface) {
+      throw new \RuntimeException('The test email collector could not be read from the key_value store.');
     }
+    // @codeCoverageIgnoreEnd
+    $messages = array_map(unserialize(...), $query->fetchAllKeyed());
+
+    // An absent key means the collector is readable and holds nothing yet.
     $messages = $messages['system.test_mail_collector'] ?? [];
 
     $fields = ['subject', 'body', 'to', 'from', 'cc', 'bcc'];


### PR DESCRIPTION
Closes #719

## Summary

`emailGetCollectedMessages()` guarded its query result with `instanceof StatementInterface` and fell through to an empty array when the guard failed. An unreadable collector was therefore indistinguishable from an empty one, and every `no emails should have been sent` assertion passed without the collector ever being consulted.

That path is reachable rather than theoretical. `Drupal\Core\Database\Connection::query()` ends with `return $result ? $statement : NULL;`, so it returns NULL whenever `execute()` failed and the configured exception handler suppressed the exception instead of rethrowing.

The method now throws when the result is not a statement. The separate empty case is preserved: an absent `system.test_mail_collector` key still yields an empty list, because that is a readable collector that holds nothing yet.

This is the second of the three fixes from #719 and is landing on its own.

## Changes

- `src/Drupal/EmailTrait.php`: `emailGetCollectedMessages()` throws `\RuntimeException` when the query does not return a `StatementInterface`, instead of silently producing an empty message list.

## Verification

`drupal_email.feature` passes in full: 55 scenarios, 214 steps. `ahoy lint` and `ahoy test-unit` pass. `STEPS.md` is unchanged, since no step docblock was touched.

The new guard is annotated with `@codeCoverageIgnore`, matching how the codebase treats defensive branches that cannot be reached from a test. Forcing `Connection::query()` to return NULL requires replacing the database exception handler, which is outside what a Behat scenario can arrange. The consistency of those annotations across the codebase is the subject of #725 and is deliberately not touched here.

## Before / After

```
┌───────────────────────────────────────────────────────────────────────┐
│ "no emails should have been sent" when the collector read fails       │
├───────────────────────────────────────────────────────────────────────┤
│ BEFORE                                                                │
│   query()          ->  NULL   (execute failed, exception suppressed)  │
│   instanceof       ->  false                                          │
│   $messages        ->  []                                             │
│   assertion        ->  PASSES                                         │
│                                                                       │
│ AFTER                                                                 │
│   query()          ->  NULL                                           │
│   instanceof       ->  false                                          │
│   throw            ->  FAILS, naming the unreadable collector          │
└───────────────────────────────────────────────────────────────────────┘
```

```
┌───────────────────────────────────────────────────────────────────────┐
│ The two cases the code used to conflate                               │
├───────────────────────────────────────────────────────────────────────┤
│                             │ BEFORE          │ AFTER                 │
│ collector unreadable        │ [] (passes)     │ throws                │
│ collector readable, no key  │ [] (passes)     │ [] (passes)           │
└───────────────────────────────────────────────────────────────────────┘
```
