### PR TITLE
[#719] Collected JavaScript errors under any JavaScript-capable driver.

### DIFF
--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -12,7 +12,6 @@ use Behat\Hook\AfterScenario;
 use Behat\Hook\AfterStep;
 use Behat\Hook\BeforeScenario;
 use Behat\Hook\BeforeStep;
-use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Exception\ExpectationException;
 
 /**
@@ -145,10 +144,11 @@ trait JavascriptTrait {
       return;
     }
 
-    $driver = $this->getSession()->getDriver();
-
+    // Collection runs through the driver-agnostic Mink script API, so any
+    // JavaScript-capable driver qualifies. Naming one driver class skipped
+    // every other one, including the Chrome driver this package suggests.
     // @codeCoverageIgnoreStart
-    if (!$driver instanceof Selenium2Driver) {
+    if (!$this->helperIsJavascriptSupported()) {
       return;
     }
     // @codeCoverageIgnoreEnd
@@ -185,10 +185,11 @@ trait JavascriptTrait {
       return;
     }
 
-    $driver = $this->getSession()->getDriver();
-
+    // Collection runs through the driver-agnostic Mink script API, so any
+    // JavaScript-capable driver qualifies. Naming one driver class skipped
+    // every other one, including the Chrome driver this package suggests.
     // @codeCoverageIgnoreStart
-    if (!$driver instanceof Selenium2Driver) {
+    if (!$this->helperIsJavascriptSupported()) {
       return;
     }
     // @codeCoverageIgnoreEnd


### PR DESCRIPTION
Closes #719

## Summary

`javascriptBeforeStep()` and `javascriptAfterStep()` both tested the driver with `instanceof Selenium2Driver` and returned silently for anything else. Every other JavaScript-capable driver was therefore skipped, and JavaScript error collection quietly did nothing under them. That includes `dmore/behat-chrome-extension`, which this package suggests in its own `composer.json` and which this repository runs in two CI matrix jobs.

Nothing in the collection path needs Selenium specifically. It injects and reads through `Session::executeScript()` and `Session::evaluateScript()`, which are driver-agnostic Mink APIs. The check now uses `helperIsJavascriptSupported()`, the same capability probe `WaitTrait` and `FieldTrait` already use, so the test matches what the code actually requires.

This is the third of the three fixes from #719 and is landing on its own.

## Changes

- `src/JavascriptTrait.php`: both step hooks probe for JavaScript capability instead of matching one driver class.
- `src/JavascriptTrait.php`: dropped the now-unused `Selenium2Driver` import.

## Impact

This widens where error collection runs. A suite using a non-Selenium JavaScript driver has never had its console errors asserted, and after this change it will. That is the intent of the fix, but it means such a suite can start failing on errors that were always present and never reported. Scenarios that expect errors can opt out with the existing `@js-errors` tag, and the trait can be skipped entirely with `@behat-steps-skip:JavascriptTrait`.

## Verification

`javascript.feature` passes with 10 scenarios and 60 steps, and `javascript_skip.feature` passes with 1 scenario and 4 steps. `ahoy lint` and `ahoy test-unit` pass. `STEPS.md` is unchanged.

Local runs use the Selenium driver, so they exercise the path that already worked. The two `Driver chrome_headless` CI jobs are the real test of this change, since they are the configuration that was previously skipped.

## Before / After

```
┌────────────────────────────────────────────────────────────────────────┐
│ A @javascript scenario that logs a console error                       │
├────────────────────────────────────────────────────────────────────────┤
│                      │ Selenium2 driver  │ Chrome (CDP) driver         │
│ BEFORE               │ collects, asserts │ returns early, no collection│
│                      │ scenario FAILS    │ scenario PASSES silently    │
│                      │                   │                             │
│ AFTER                │ collects, asserts │ collects, asserts           │
│                      │ scenario FAILS    │ scenario FAILS              │
└────────────────────────────────────────────────────────────────────────┘
```

```
┌────────────────────────────────────────────────────────────────────────┐
│ The guard                                                              │
├────────────────────────────────────────────────────────────────────────┤
│ BEFORE  if (!$driver instanceof Selenium2Driver) { return; }           │
│         names one implementation                                       │
│                                                                        │
│ AFTER   if (!$this->helperIsJavascriptSupported()) { return; }         │
│         names the capability the code actually uses                    │
└────────────────────────────────────────────────────────────────────────┘
```
