### PR TITLE
Guarded contrib-module dependencies and refused external entities during DTD validation.

### DIFF
--- a/src/Drupal/DraggableviewsTrait.php
+++ b/src/Drupal/DraggableviewsTrait.php
@@ -16,6 +16,8 @@ use Drupal\node\NodeInterface;
  */
 trait DraggableviewsTrait {
 
+  use HelperTrait;
+
   /**
    * Save order of the Draggable Order items.
    *
@@ -28,7 +30,7 @@ trait DraggableviewsTrait {
    */
   #[When('I save the draggable views items of the view :view_id and the display :view_display_id for the :bundle content in the following order:')]
   public function draggableViewsSaveBundleOrder(string $view_id, string $view_display_id, string $bundle, TableNode $order_table): void {
-    $this->draggableViewsAssertModuleEnabled();
+    $this->helperAssertModuleEnabled('draggableviews', 'drupal/draggableviews');
 
     $database = Database::getConnection();
 
@@ -63,17 +65,6 @@ trait DraggableviewsTrait {
     // change.
     $list_cache_tags = \Drupal::entityTypeManager()->getDefinition('node')->getListCacheTags();
     Cache::invalidateTags($list_cache_tags);
-  }
-
-  /**
-   * Assert that the module backing these steps is enabled.
-   */
-  protected function draggableViewsAssertModuleEnabled(): void {
-    // @codeCoverageIgnoreStart
-    if (!\Drupal::moduleHandler()->moduleExists('draggableviews')) {
-      throw new \RuntimeException('The "draggableviews" module is not enabled. Add "drupal/draggableviews" to the consumer project\'s composer.json and enable the module as part of the site setup.');
-    }
-    // @codeCoverageIgnoreEnd
   }
 
   /**

--- a/src/Drupal/DraggableviewsTrait.php
+++ b/src/Drupal/DraggableviewsTrait.php
@@ -28,6 +28,8 @@ trait DraggableviewsTrait {
    */
   #[When('I save the draggable views items of the view :view_id and the display :view_display_id for the :bundle content in the following order:')]
   public function draggableViewsSaveBundleOrder(string $view_id, string $view_display_id, string $bundle, TableNode $order_table): void {
+    $this->draggableViewsAssertModuleEnabled();
+
     $database = Database::getConnection();
 
     foreach ($order_table->getColumn(0) as $weight => $title) {
@@ -61,6 +63,17 @@ trait DraggableviewsTrait {
     // change.
     $list_cache_tags = \Drupal::entityTypeManager()->getDefinition('node')->getListCacheTags();
     Cache::invalidateTags($list_cache_tags);
+  }
+
+  /**
+   * Assert that the module backing these steps is enabled.
+   */
+  protected function draggableViewsAssertModuleEnabled(): void {
+    // @codeCoverageIgnoreStart
+    if (!\Drupal::moduleHandler()->moduleExists('draggableviews')) {
+      throw new \RuntimeException('The "draggableviews" module is not enabled. Add "drupal/draggableviews" to the consumer project\'s composer.json and enable the module as part of the site setup.');
+    }
+    // @codeCoverageIgnoreEnd
   }
 
   /**

--- a/src/Drupal/HelperTrait.php
+++ b/src/Drupal/HelperTrait.php
@@ -350,4 +350,34 @@ trait HelperTrait {
     return FALSE;
   }
 
+  /**
+   * Assert that a module backing a set of steps is enabled.
+   *
+   * Without this check a step reaches a contrib module's API regardless, and
+   * the failure arrives as a fatal on an unresolvable class or a raw database
+   * error rather than a message naming the module.
+   *
+   * @param string $module
+   *   The module machine name.
+   * @param string $package
+   *   Optional Composer package to name in the message. Pass an empty string
+   *   for a module that ships with Drupal core.
+   *
+   * @throws \RuntimeException
+   *   When the module is not enabled.
+   */
+  protected function helperAssertModuleEnabled(string $module, string $package = ''): void {
+    // @codeCoverageIgnoreStart
+    if (\Drupal::moduleHandler()->moduleExists($module)) {
+      return;
+    }
+
+    $remedy = $package === ''
+      ? 'Enable it as part of the site setup; it ships with Drupal core.'
+      : sprintf('Add "%s" to the consumer project\'s composer.json and enable the module as part of the site setup.', $package);
+
+    throw new \RuntimeException(sprintf('The "%s" module is not enabled. %s', $module, $remedy));
+    // @codeCoverageIgnoreEnd
+  }
+
 }

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -87,6 +87,8 @@ trait MenuTrait {
    */
   #[Given('the following menu links do not exist in the menu :menu_name:')]
   public function menuLinksDelete(string $menu_name, TableNode $table): void {
+    $this->menuAssertLinkModuleEnabled();
+
     foreach ($table->getColumn(0) as $title) {
       $menu_link = $this->loadMenuLinkByTitle($title, $menu_name);
       if ($menu_link instanceof MenuLinkContent) {
@@ -107,6 +109,8 @@ trait MenuTrait {
    */
   #[Given('the following menu links exist in the menu :menu_name:')]
   public function menuLinksCreate(string $menu_name, TableNode $table): void {
+    $this->menuAssertLinkModuleEnabled();
+
     $menu = $this->loadMenuByLabel($menu_name);
 
     // @codeCoverageIgnoreStart
@@ -142,7 +146,18 @@ trait MenuTrait {
   }
 
   /**
-   * Get a menu by label.
+   * Assert that the module backing the menu link steps is enabled.
+   */
+  protected function menuAssertLinkModuleEnabled(): void {
+    // @codeCoverageIgnoreStart
+    if (!\Drupal::moduleHandler()->moduleExists('menu_link_content')) {
+      throw new \RuntimeException('The "menu_link_content" module is not enabled. Enable it as part of the site setup; it ships with Drupal core.');
+    }
+    // @codeCoverageIgnoreEnd
+  }
+
+  /**
+   * Load a menu by its label.
    *
    * @param string $label
    *   The label of the menu.

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -87,7 +87,7 @@ trait MenuTrait {
    */
   #[Given('the following menu links do not exist in the menu :menu_name:')]
   public function menuLinksDelete(string $menu_name, TableNode $table): void {
-    $this->menuAssertLinkModuleEnabled();
+    $this->helperAssertModuleEnabled('menu_link_content');
 
     foreach ($table->getColumn(0) as $title) {
       $menu_link = $this->loadMenuLinkByTitle($title, $menu_name);
@@ -109,7 +109,7 @@ trait MenuTrait {
    */
   #[Given('the following menu links exist in the menu :menu_name:')]
   public function menuLinksCreate(string $menu_name, TableNode $table): void {
-    $this->menuAssertLinkModuleEnabled();
+    $this->helperAssertModuleEnabled('menu_link_content');
 
     $menu = $this->loadMenuByLabel($menu_name);
 
@@ -143,17 +143,6 @@ trait MenuTrait {
       $menu_link->save();
       $this->entityRegister($menu_link);
     }
-  }
-
-  /**
-   * Assert that the module backing the menu link steps is enabled.
-   */
-  protected function menuAssertLinkModuleEnabled(): void {
-    // @codeCoverageIgnoreStart
-    if (!\Drupal::moduleHandler()->moduleExists('menu_link_content')) {
-      throw new \RuntimeException('The "menu_link_content" module is not enabled. Enable it as part of the site setup; it ships with Drupal core.');
-    }
-    // @codeCoverageIgnoreEnd
   }
 
   /**

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -60,7 +60,7 @@ trait RedirectTrait {
    */
   #[Given('the following redirects exist:')]
   public function redirectCreate(TableNode $table): void {
-    $this->redirectAssertModuleEnabled();
+    $this->helperAssertModuleEnabled('redirect', 'drupal/redirect');
 
     foreach ($table->getHash() as $row) {
       $from = isset($row['from']) ? trim($row['from']) : '';
@@ -99,7 +99,7 @@ trait RedirectTrait {
    */
   #[Given('the following redirects do not exist:')]
   public function redirectDelete(TableNode $table): void {
-    $this->redirectAssertModuleEnabled();
+    $this->helperAssertModuleEnabled('redirect', 'drupal/redirect');
 
     $storage = \Drupal::entityTypeManager()->getStorage('redirect');
 
@@ -147,7 +147,7 @@ trait RedirectTrait {
    */
   #[Then('the following redirects should exist:')]
   public function redirectAssertExist(TableNode $table): void {
-    $this->redirectAssertModuleEnabled();
+    $this->helperAssertModuleEnabled('redirect', 'drupal/redirect');
 
     $storage = \Drupal::entityTypeManager()->getStorage('redirect');
     $missing = [];
@@ -198,7 +198,7 @@ trait RedirectTrait {
    */
   #[Then('the following redirects should not exist:')]
   public function redirectAssertNotExist(TableNode $table): void {
-    $this->redirectAssertModuleEnabled();
+    $this->helperAssertModuleEnabled('redirect', 'drupal/redirect');
 
     $storage = \Drupal::entityTypeManager()->getStorage('redirect');
     $present = [];
@@ -219,17 +219,6 @@ trait RedirectTrait {
     if ($present !== []) {
       throw new \Exception(sprintf('The following redirects should not exist but were found: %s.', implode(', ', $present)));
     }
-  }
-
-  /**
-   * Throw when the `redirect` module is not enabled.
-   */
-  protected function redirectAssertModuleEnabled(): void {
-    // @codeCoverageIgnoreStart
-    if (!\Drupal::moduleHandler()->moduleExists('redirect')) {
-      throw new \RuntimeException('The "redirect" module is not enabled. Add "drupal/redirect" to the consumer project\'s composer.json and enable the module as part of the site setup.');
-    }
-    // @codeCoverageIgnoreEnd
   }
 
   /**

--- a/src/Drupal/SearchApiTrait.php
+++ b/src/Drupal/SearchApiTrait.php
@@ -26,6 +26,8 @@ trait SearchApiTrait {
    */
   #[When('I add the :content_type content with the title :title to the search index')]
   public function searchApiIndexContent(string $type, string $title): void {
+    $this->searchApiAssertModuleEnabled();
+
     $nids = $this->contentLoadMultiple($type, [
       'title' => $title,
     ]);
@@ -82,9 +84,7 @@ trait SearchApiTrait {
    */
   #[When('I run the Search API cron')]
   public function searchApiRunCron(): void {
-    if (!\Drupal::moduleHandler()->moduleExists('search_api')) {
-      throw new \RuntimeException('The "search_api" module is not enabled.');
-    }
+    $this->searchApiAssertModuleEnabled();
 
     \Drupal::moduleHandler()->invoke('search_api', 'cron');
   }
@@ -102,11 +102,9 @@ trait SearchApiTrait {
    */
   #[When('I run the Search API Solr cron')]
   public function searchApiRunSolrCron(): void {
-    $module_handler = \Drupal::moduleHandler();
+    $this->searchApiAssertModuleEnabled();
 
-    if (!$module_handler->moduleExists('search_api')) {
-      throw new \RuntimeException('The "search_api" module is not enabled.');
-    }
+    $module_handler = \Drupal::moduleHandler();
 
     // @codeCoverageIgnoreStart
     if (!$module_handler->moduleExists('search_api_solr')) {
@@ -114,6 +112,17 @@ trait SearchApiTrait {
     }
 
     $module_handler->invoke('search_api_solr', 'cron');
+    // @codeCoverageIgnoreEnd
+  }
+
+  /**
+   * Assert that the module backing these steps is enabled.
+   */
+  protected function searchApiAssertModuleEnabled(): void {
+    // @codeCoverageIgnoreStart
+    if (!\Drupal::moduleHandler()->moduleExists('search_api')) {
+      throw new \RuntimeException('The "search_api" module is not enabled. Add "drupal/search_api" to the consumer project\'s composer.json and enable the module as part of the site setup.');
+    }
     // @codeCoverageIgnoreEnd
   }
 

--- a/src/Drupal/SearchApiTrait.php
+++ b/src/Drupal/SearchApiTrait.php
@@ -26,7 +26,7 @@ trait SearchApiTrait {
    */
   #[When('I add the :content_type content with the title :title to the search index')]
   public function searchApiIndexContent(string $type, string $title): void {
-    $this->searchApiAssertModuleEnabled();
+    $this->helperAssertModuleEnabled('search_api', 'drupal/search_api');
 
     $nids = $this->contentLoadMultiple($type, [
       'title' => $title,
@@ -84,7 +84,7 @@ trait SearchApiTrait {
    */
   #[When('I run the Search API cron')]
   public function searchApiRunCron(): void {
-    $this->searchApiAssertModuleEnabled();
+    $this->helperAssertModuleEnabled('search_api', 'drupal/search_api');
 
     \Drupal::moduleHandler()->invoke('search_api', 'cron');
   }
@@ -102,7 +102,7 @@ trait SearchApiTrait {
    */
   #[When('I run the Search API Solr cron')]
   public function searchApiRunSolrCron(): void {
-    $this->searchApiAssertModuleEnabled();
+    $this->helperAssertModuleEnabled('search_api', 'drupal/search_api');
 
     $module_handler = \Drupal::moduleHandler();
 
@@ -112,17 +112,6 @@ trait SearchApiTrait {
     }
 
     $module_handler->invoke('search_api_solr', 'cron');
-    // @codeCoverageIgnoreEnd
-  }
-
-  /**
-   * Assert that the module backing these steps is enabled.
-   */
-  protected function searchApiAssertModuleEnabled(): void {
-    // @codeCoverageIgnoreStart
-    if (!\Drupal::moduleHandler()->moduleExists('search_api')) {
-      throw new \RuntimeException('The "search_api" module is not enabled. Add "drupal/search_api" to the consumer project\'s composer.json and enable the module as part of the site setup.');
-    }
     // @codeCoverageIgnoreEnd
   }
 

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -153,6 +153,9 @@ trait WatchdogTrait {
       return;
     }
 
+    // The step hook throws for a missing table because it runs while the
+    // verdict is still open. This hook runs after it, where throwing would
+    // replace a real scenario failure with a configuration error.
     if (!Database::getConnection()->schema()->tableExists('watchdog')) {
       return;
     }

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -860,9 +860,9 @@ trait XmlTrait {
    * with validation enabled, so a DTD from a file and an inline DTD share this
    * code path.
    *
-   * Validation runs with `LIBXML_DTDVALID` and without `LIBXML_NOENT`, so a
-   * `SYSTEM` entity declared in the DTD is dereferenced during validation but
-   * its content is never substituted into the document.
+   * Validation refuses every external reference, so a `SYSTEM` entity declared
+   * in the DTD reaches neither a local path nor the network. Validation fails
+   * with a resolver error if a DTD references one.
    *
    * DTDs are namespace-unaware, so a namespaced response is validated verbatim
    * and its `xmlns` attributes must be declared in the DTD. This matches
@@ -892,9 +892,22 @@ trait XmlTrait {
 
     $document = new \DOMDocument();
     libxml_clear_errors();
-    $loaded = @$document->loadXML($combined, LIBXML_DTDVALID);
-    $errors = libxml_get_errors();
-    libxml_clear_errors();
+
+    // A SYSTEM entity declared in the DTD is dereferenced while validating.
+    // The resolver refuses every external reference, so validation can neither
+    // read a local path nor reach the network. LIBXML_NONET is passed as well,
+    // but on its own it blocks only the network half.
+    $previous_loader = function_exists('libxml_get_external_entity_loader') ? libxml_get_external_entity_loader() : NULL;
+    libxml_set_external_entity_loader(static fn(): null => NULL);
+
+    try {
+      $loaded = @$document->loadXML($combined, LIBXML_DTDVALID | LIBXML_NONET);
+      $errors = libxml_get_errors();
+    }
+    finally {
+      libxml_set_external_entity_loader($previous_loader);
+      libxml_clear_errors();
+    }
 
     if (!$loaded || $errors !== []) {
       throw new ExpectationException(sprintf('The response does not match the DTD: %s', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());


### PR DESCRIPTION
Closes #718
Closes #721

## Summary

Two unrelated 3.14 items batched to share one CI run.

## #721 External entity resolution during DTD validation

The docblock claimed validation ran "without exposing external-entity loading". It did not. Measured on PHP 8.3.30 with libxml 2.13.9, reproducing the exact load the method performs:

- A DTD that only **declares** a `SYSTEM` entity causes no dereferencing at all. libxml resolves an entity when it is referenced, not when it is declared.
- A **referenced** `SYSTEM` entity is dereferenced. Pointing it at a nonexistent path reports `failed to load "...": No such file or directory`, and pointing it at a readable file loads with no errors at all, so the read succeeded silently.
- `LIBXML_NONET` closes only half of it. With the flag, a network target is refused with `Attempt to load network entity` and no request is made, but a **local path is still read**, byte for byte identically to without the flag.

So the cheap option does not answer the issue. Validation now installs a resolver that returns NULL for every external reference, which refuses both vectors: `Failed to load external entity because the resolver function returned null` for a local file and for a network URL alike. `LIBXML_NONET` is kept alongside it so the network refusal is explicit in the load options rather than implied by the resolver.

The previous loader is restored afterwards. `libxml_get_external_entity_loader()` only exists on PHP 8.4, so on 8.2 and 8.3 the loader is reset to the default instead of to a consumer's custom loader.

**This changes which DTDs validate successfully.** A DTD that declares and references a resolvable `SYSTEM` entity previously validated clean and now fails with a resolver error. Nothing is lost functionally, because `LIBXML_NOENT` is not passed, so the entity content was never substituted into the document and referencing one achieved nothing observable.

## #718 Contrib-module guards

Three traits used a contrib module's API with no guard, so a missing module produced a PHP fatal or a raw database error instead of a message naming the module:

- `Drupal\MenuTrait` called `MenuLinkContent` with `menu_link_content` possibly absent, which fatals on an unresolvable class and Behat reports as a crash rather than a failed step.
- `Drupal\DraggableviewsTrait` wrote directly to the `draggableviews_structure` table.
- `Drupal\SearchApiTrait` called the global `search_api_entity_insert()` unguarded, while the cron steps in the same trait were already guarded. That trait was inconsistent with itself.

All of them now call one `helperAssertModuleEnabled()` in `Drupal\HelperTrait`, at the top of each step. It takes the module machine name and an optional Composer package, so the wording for a core module and for a contrib module lives in one place rather than being restated per trait. `Drupal\RedirectTrait` already had this guard shape as its own method; that copy is gone too, along with `SearchApiTrait`'s two inline checks.

Giving each trait its own guard method would have reintroduced the duplication the change exists to remove, which is why it is a single shared helper.

`Drupal\DraggableviewsTrait` composes `Drupal\HelperTrait` for the first time to reach it. The other three already had it, `SearchApiTrait` transitively through `ContentTrait`.

### The WatchdogTrait question

#718 asked for the throw-versus-return disagreement between the two `WatchdogTrait` hooks to be settled explicitly rather than left inconsistent. It is settled as a deliberate difference, with the reason now recorded in the code.

The `AfterStep` hook throws for a missing `watchdog` table because it runs while the scenario verdict is still open, and a silent return there means error checking never happened. The `AfterScenario` hook returns, because it runs after the verdict has been composed and throwing would replace a real scenario failure with a configuration error. Forcing them to agree would make one of those two behaviours wrong.

## Verification

Every touched trait's BDD suite passes: xml 87 scenarios, menu 3, search api 6, draggableviews 2, watchdog 13. `ahoy lint`, `ahoy test-unit` and `ahoy lint-docs` all pass. `STEPS.md` is unchanged.

## Before / After

```
┌────────────────────────────────────────────────────────────────────────┐
│ DTD declaring and referencing <!ENTITY probe SYSTEM "...">             │
├────────────────────────────────────────────────────────────────────────┤
│                          │ local file        │ network URL             │
│ BEFORE  DTDVALID         │ read, no error    │ request attempted       │
│ option1 +NONET           │ read, no error    │ refused                 │
│ AFTER   +NONET +resolver │ refused           │ refused                 │
└────────────────────────────────────────────────────────────────────────┘
```

```
┌────────────────────────────────────────────────────────────────────────┐
│ A step whose contrib module is not installed                           │
├────────────────────────────────────────────────────────────────────────┤
│ BEFORE                                                                 │
│   MenuTrait          ->  PHP fatal, unresolvable class, reported as    │
│                          a crash rather than a failed step             │
│   DraggableviewsTrait->  raw database exception, missing table         │
│   SearchApiTrait     ->  undefined function                            │
│                                                                        │
│ AFTER                                                                  │
│   all four           ->  helperAssertModuleEnabled($module, $package)   │
│                          one implementation, one message shape         │
└────────────────────────────────────────────────────────────────────────┘
```
