### PR TITLE
[#720] Ended thrown messages with a period and settled the phrasing families.

### DIFF
--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -313,7 +313,7 @@ trait AccessibilityTrait {
     }
 
     if ($messages !== []) {
-      $message = sprintf("Auto accessibility gate failed (threshold=%s, fail_on_incomplete=%s):\n%s", $threshold, $check_incomplete ? 'yes' : 'no', implode("\n", $messages));
+      $message = sprintf("Auto accessibility gate failed (threshold: %s, fail_on_incomplete: %s):\n%s", $threshold, $check_incomplete ? 'yes' : 'no', implode("\n", $messages));
       throw new ExpectationException($message, $this->getSession()->getDriver());
     }
   }
@@ -385,7 +385,7 @@ trait AccessibilityTrait {
 
     $content = @file_get_contents($this->accessibilityGetCdnUrl());
     if ($content === FALSE || $content === '') {
-      throw new \RuntimeException(sprintf('Failed to fetch accessibility engine from %s', $this->accessibilityGetCdnUrl()));
+      throw new \RuntimeException(sprintf('Failed to fetch accessibility engine from %s.', $this->accessibilityGetCdnUrl()));
     }
 
     self::$accessibilityCachedJs = $content;
@@ -515,7 +515,7 @@ trait AccessibilityTrait {
     }
 
     if (isset($results['error'])) {
-      throw new \RuntimeException(sprintf('Accessibility engine failed: %s', $results['error']));
+      throw new \RuntimeException(sprintf('Accessibility engine failed: %s.', $results['error']));
     }
 
     return $results;

--- a/src/CommandTrait.php
+++ b/src/CommandTrait.php
@@ -168,7 +168,7 @@ trait CommandTrait {
     $exit_code = (int) $this->commandExitCode;
 
     if ($exit_code !== 0) {
-      throw new \Exception(sprintf('Expected the command to succeed, but it exited with code %d. Error output: %s', $exit_code, $this->commandStderr));
+      throw new \Exception(sprintf('Expected the command to succeed, but it exited with code %d. Error output: %s.', $exit_code, $this->commandStderr));
     }
   }
 
@@ -224,7 +224,7 @@ trait CommandTrait {
     $this->commandAssertHasRun();
 
     if (!str_contains($this->commandStdout, $text)) {
-      throw new \Exception(sprintf('Expected the command output to contain "%s", but it did not. Actual output: %s', $text, $this->commandStdout));
+      throw new \Exception(sprintf('Expected the command output to contain "%s", but it did not. Actual output: %s.', $text, $this->commandStdout));
     }
   }
 
@@ -243,7 +243,7 @@ trait CommandTrait {
     $this->commandAssertHasRun();
 
     if (str_contains($this->commandStdout, $text)) {
-      throw new \Exception(sprintf('Expected the command output to not contain "%s", but it did. Actual output: %s', $text, $this->commandStdout));
+      throw new \Exception(sprintf('Expected the command output to not contain "%s", but it did. Actual output: %s.', $text, $this->commandStdout));
     }
   }
 
@@ -283,7 +283,7 @@ trait CommandTrait {
     $this->commandAssertHasRun();
 
     if (!str_contains($this->commandStderr, $text)) {
-      throw new \Exception(sprintf('Expected the command error output to contain "%s", but it did not. Actual error output: %s', $text, $this->commandStderr));
+      throw new \Exception(sprintf('Expected the command error output to contain "%s", but it did not. Actual error output: %s.', $text, $this->commandStderr));
     }
   }
 

--- a/src/CookieTrait.php
+++ b/src/CookieTrait.php
@@ -312,7 +312,7 @@ trait CookieTrait {
     }
     else {
       // @codeCoverageIgnoreStart
-      throw new UnsupportedDriverActionException('Cookie retrieval is not supported by %s', $driver);
+      throw new UnsupportedDriverActionException('Cookie retrieval is not supported by %s.', $driver);
       // @codeCoverageIgnoreEnd
     }
 

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -64,7 +64,7 @@ trait BlockTrait {
     }
 
     if (!$block instanceof Block) {
-      throw new \RuntimeException(sprintf('Could not create block with admin label "%s"', $admin_label));
+      throw new \RuntimeException(sprintf('Could not create block with admin label "%s".', $admin_label));
     }
 
     $this->blockConfigure($admin_label, $fields);

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -88,7 +88,7 @@ trait ContentBlockTrait {
     ]);
 
     if (empty($block_ids)) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" content block with the description "%s"', $type, $description));
+      throw new \RuntimeException(sprintf('Unable to find "%s" content block with the description "%s".', $type, $description));
     }
 
     ksort($block_ids);

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -132,7 +132,7 @@ trait EmailTrait {
       }
     }
 
-    throw new ExpectationException(sprintf('Unable to find email that should be sent to "%s" retrieved from test message collector.', $address), $this->getSession()->getDriver());
+    throw new ExpectationException(sprintf('Unable to find email that should be sent to "%s" retrieved from test email collector.', $address), $this->getSession()->getDriver());
   }
 
   /**
@@ -352,7 +352,7 @@ trait EmailTrait {
   public function emailAssertMessageFieldNotContains(string $field, PyStringNode $string, bool $exact = FALSE): void {
     // @codeCoverageIgnoreStart
     if (!in_array($field, ['subject', 'body', 'to', 'from', 'cc', 'bcc'], TRUE)) {
-      throw new \RuntimeException(sprintf('Invalid message field %s was specified for assertion', $field));
+      throw new \RuntimeException(sprintf('Invalid email field %s was specified for assertion.', $field));
     }
     // @codeCoverageIgnoreEnd
     $string = (string) $string;
@@ -408,17 +408,17 @@ trait EmailTrait {
       $body = $message['body'];
     }
     else {
-      throw new \RuntimeException('No body found in email');
+      throw new \RuntimeException('No body found in email.');
     }
     // @codeCoverageIgnoreEnd
     $links = self::emailExtractLinks($body);
 
     if (empty($links)) {
-      throw new ExpectationException(sprintf('No links were found in the email with subject "%s"', $subject), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('No links were found in the email with subject "%s".', $subject), $this->getSession()->getDriver());
     }
 
     if (count($links) < $link_number) {
-      throw new ExpectationException(sprintf('The link with number %s was not found among %s links', $link_number, count($links)), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The link with number %s was not found among %s links.', $link_number, count($links)), $this->getSession()->getDriver());
     }
 
     $link = $links[$link_number - 1];
@@ -456,17 +456,17 @@ trait EmailTrait {
       $body = $message['body'];
     }
     else {
-      throw new \RuntimeException('No body found in email');
+      throw new \RuntimeException('No body found in email.');
     }
     // @codeCoverageIgnoreEnd
     $links = self::emailExtractLinks($body);
 
     if (empty($links)) {
-      throw new ExpectationException(sprintf('No links were found in the email with subject containing "%s"', $subject), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('No links were found in the email with subject containing "%s".', $subject), $this->getSession()->getDriver());
     }
 
     if (count($links) < $link_number) {
-      throw new ExpectationException(sprintf('The link with number %s was not found among %s links', $link_number, count($links)), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The link with number %s was not found among %s links.', $link_number, count($links)), $this->getSession()->getDriver());
     }
 
     $link = $links[$link_number - 1];
@@ -497,7 +497,7 @@ trait EmailTrait {
       }
     }
 
-    throw new ExpectationException(sprintf('No attachments were found in the email with subject %s', $subject), $this->getSession()->getDriver());
+    throw new ExpectationException(sprintf('No attachments were found in the email with subject %s.', $subject), $this->getSession()->getDriver());
   }
 
   /**
@@ -529,7 +529,7 @@ trait EmailTrait {
       }
     }
 
-    throw new ExpectationException(sprintf('No attachments were found in the email with subject containing "%s"', $subject), $this->getSession()->getDriver());
+    throw new ExpectationException(sprintf('No attachments were found in the email with subject containing "%s".', $subject), $this->getSession()->getDriver());
   }
 
   /**
@@ -673,7 +673,7 @@ trait EmailTrait {
   protected function emailFindMessage(string $field, PyStringNode $string, bool $exact = FALSE): ?array {
     // @codeCoverageIgnoreStart
     if (!in_array($field, ['subject', 'body', 'to', 'from', 'cc', 'bcc'], TRUE)) {
-      throw new \RuntimeException(sprintf('Invalid email field %s was specified for assertion', $field));
+      throw new \RuntimeException(sprintf('Invalid email field %s was specified for assertion.', $field));
     }
     // @codeCoverageIgnoreEnd
     $string = (string) $string;

--- a/src/Drupal/ModuleTrait.php
+++ b/src/Drupal/ModuleTrait.php
@@ -256,7 +256,7 @@ trait ModuleTrait {
       drupal_flush_all_caches();
     }
     catch (\Exception $e) {
-      throw new \RuntimeException(sprintf('Failed to enable module "%s": %s', $module, $e->getMessage()), $e->getCode(), $e);
+      throw new \RuntimeException(sprintf('Failed to enable module "%s": %s.', $module, $e->getMessage()), $e->getCode(), $e);
     }
     // @codeCoverageIgnoreEnd
   }
@@ -279,7 +279,7 @@ trait ModuleTrait {
       drupal_flush_all_caches();
     }
     catch (\Exception $e) {
-      throw new \RuntimeException(sprintf('Failed to disable module "%s": %s', $module, $e->getMessage()), $e->getCode(), $e);
+      throw new \RuntimeException(sprintf('Failed to disable module "%s": %s.', $module, $e->getMessage()), $e->getCode(), $e);
     }
     // @codeCoverageIgnoreEnd
   }

--- a/src/Drupal/ParagraphsTrait.php
+++ b/src/Drupal/ParagraphsTrait.php
@@ -42,7 +42,7 @@ trait ParagraphsTrait {
     $parent_entity = $this->paragraphsFindEntity($parent_entity_type, $parent_bundle, $parent_lookup_field, $parent_lookup_value);
 
     if (!$parent_entity) {
-      throw new \RuntimeException(sprintf('The parent entity of type "%s" and bundle "%s" with the field "%s" and the value "%s" was not found', $parent_entity_type, $parent_bundle, $parent_lookup_field, $parent_lookup_value));
+      throw new \RuntimeException(sprintf('The parent entity of type "%s" and bundle "%s" with the field "%s" and the value "%s" was not found.', $parent_entity_type, $parent_bundle, $parent_lookup_field, $parent_lookup_value));
     }
 
     $stub = new EntityStub('paragraph', $paragraph_type, $fields->getRowsHash());

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -537,7 +537,7 @@ trait UserTrait {
   public function userCreateRoles(TableNode $table): void {
     foreach ($table->getHash() as $hash) {
       if (!isset($hash['name'])) {
-        throw new \RuntimeException('Missing required column "name"');
+        throw new \RuntimeException('Missing required column "name".');
       }
 
       $permissions = $hash['permissions'] ?: '';

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -88,7 +88,7 @@ trait HelperTrait {
     $duplicate_fields = array_filter(array_count_values($field_names), fn(int $count): bool => $count > 1);
 
     if (!empty($duplicate_fields)) {
-      throw new \RuntimeException(sprintf('Duplicate field names found: %s', implode(', ', array_keys($duplicate_fields))));
+      throw new \RuntimeException(sprintf('Duplicate field names found: %s.', implode(', ', array_keys($duplicate_fields))));
     }
 
     foreach ($field_names as $field_name) {

--- a/src/JsonTrait.php
+++ b/src/JsonTrait.php
@@ -470,7 +470,7 @@ trait JsonTrait {
     $data = json_decode($content, TRUE);
 
     if (json_last_error() !== JSON_ERROR_NONE) {
-      throw new \RuntimeException(sprintf('Failed to decode JSON: %s', json_last_error_msg()));
+      throw new \RuntimeException(sprintf('Failed to decode JSON: %s.', json_last_error_msg()));
     }
 
     if (!is_array($data)) {
@@ -496,7 +496,7 @@ trait JsonTrait {
     $data = json_decode($content);
 
     if (json_last_error() !== JSON_ERROR_NONE) {
-      throw new ExpectationException(sprintf('The response is not valid JSON: %s', json_last_error_msg()), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The response is not valid JSON: %s.', json_last_error_msg()), $this->getSession()->getDriver());
     }
 
     return $data;
@@ -518,7 +518,7 @@ trait JsonTrait {
       $result = (new JSONPath($this->jsonData))->find($path);
     }
     catch (\Exception $exception) {
-      throw new ExpectationException(sprintf('The JSON path "%s" is invalid: %s', $path, $exception->getMessage()), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The JSON path "%s" is invalid: %s.', $path, $exception->getMessage()), $this->getSession()->getDriver());
     }
 
     $data = $result->getData();
@@ -606,7 +606,7 @@ trait JsonTrait {
 
     $schema = json_decode($schema_json);
     if (json_last_error() !== JSON_ERROR_NONE) {
-      throw new ExpectationException(sprintf('The provided JSON schema is not valid JSON: %s', json_last_error_msg()), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The provided JSON schema is not valid JSON: %s.', json_last_error_msg()), $this->getSession()->getDriver());
     }
 
     $validator = new Validator();
@@ -617,7 +617,7 @@ trait JsonTrait {
       foreach ($validator->getErrors() as $error) {
         $messages[] = sprintf('[%s] %s', $error['property'], $error['message']);
       }
-      throw new ExpectationException(sprintf('The response does not match the JSON schema: %s', implode('; ', $messages)), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The response does not match the JSON schema: %s.', implode('; ', $messages)), $this->getSession()->getDriver());
     }
   }
 

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -131,7 +131,7 @@ trait KeyboardTrait {
 
     if (strlen($char) > 1) {
       if (!array_key_exists(strtolower($char), $keys)) {
-        throw new \RuntimeException(sprintf('Unsupported key "%s" provided', $char));
+        throw new \RuntimeException(sprintf('Unsupported key "%s" provided.', $char));
       }
 
       // Syn, the JS library that provides synthetic events, can tab only

--- a/src/LinkTrait.php
+++ b/src/LinkTrait.php
@@ -68,7 +68,7 @@ trait LinkTrait {
     $pattern = '/' . preg_quote($href, '/') . '/';
     $pattern = str_contains($href, '*') ? str_replace('\*', '.*', $pattern) : $pattern;
     if (!preg_match($pattern, (string) $link_element->getAttribute('href'))) {
-      throw new ExpectationException(sprintf('The link href "%s" does not match the specified href "%s"', $link_element->getAttribute('href'), $href), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The link href "%s" does not match the specified href "%s".', $link_element->getAttribute('href'), $href), $this->getSession()->getDriver());
     }
   }
 
@@ -120,7 +120,7 @@ trait LinkTrait {
     $pattern = '/' . preg_quote($href, '/') . '/';
     $pattern = str_contains($href, '*') ? str_replace('\*', '.*', $pattern) : $pattern;
     if (preg_match($pattern, (string) $link_element->getAttribute('href'))) {
-      throw new ExpectationException(sprintf('The link href "%s" matches the specified href "%s" but should not', $link_element->getAttribute('href'), $href), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The link href "%s" matches the specified href "%s" but should not.', $link_element->getAttribute('href'), $href), $this->getSession()->getDriver());
     }
   }
 

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -118,7 +118,7 @@ trait MetatagTrait {
     $content = (string) $meta_tag->getAttribute('content');
 
     if ($content !== strip_tags($content)) {
-      throw new \Exception(sprintf('The "%s" meta tag contains HTML tags: %s', $meta_name, $content));
+      throw new \Exception(sprintf('The "%s" meta tag contains HTML tags: %s.', $meta_name, $content));
     }
   }
 

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -35,21 +35,21 @@ trait PathTrait {
 
     // @codeCoverageIgnoreStart
     if (empty($current_path)) {
-      throw new ExpectationException('Current path is empty', $this->getSession()->getDriver());
+      throw new ExpectationException('Current path is empty.', $this->getSession()->getDriver());
     }
     // @codeCoverageIgnoreEnd
     $current_path = parse_url((string) $current_path, PHP_URL_PATH);
 
     // @codeCoverageIgnoreStart
     if ($current_path === FALSE) {
-      throw new ExpectationException('Current path is not a valid URL', $this->getSession()->getDriver());
+      throw new ExpectationException('Current path is not a valid URL.', $this->getSession()->getDriver());
     }
     // @codeCoverageIgnoreEnd
     $normalized_current_path = ($current_path === '' || $current_path === '/') ? '<front>' : $current_path;
     $normalized_path = ($path === '/' || $path === '<front>') ? '<front>' : $path;
 
     if (ltrim((string) $normalized_current_path, '/') !== ltrim($normalized_path, '/')) {
-      throw new ExpectationException(sprintf('Current path is "%s", but expected is "%s"', $current_path, $path), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('Current path is "%s", but expected is "%s".', $current_path, $path), $this->getSession()->getDriver());
     }
   }
 
@@ -70,21 +70,21 @@ trait PathTrait {
 
     // @codeCoverageIgnoreStart
     if (empty($current_path)) {
-      throw new ExpectationException('Current path is empty', $this->getSession()->getDriver());
+      throw new ExpectationException('Current path is empty.', $this->getSession()->getDriver());
     }
     // @codeCoverageIgnoreEnd
     $current_path = parse_url((string) $current_path, PHP_URL_PATH);
 
     // @codeCoverageIgnoreStart
     if ($current_path === FALSE) {
-      throw new ExpectationException('Current path is not a valid URL', $this->getSession()->getDriver());
+      throw new ExpectationException('Current path is not a valid URL.', $this->getSession()->getDriver());
     }
     // @codeCoverageIgnoreEnd
     $normalized_current_path = ($current_path === '' || $current_path === '/') ? '<front>' : $current_path;
     $normalized_path = ($path === '/' || $path === '<front>') ? '<front>' : $path;
 
     if (ltrim((string) $normalized_current_path, '/') === ltrim($normalized_path, '/')) {
-      throw new ExpectationException(sprintf('Current path should not be "%s"', $path), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('Current path should not be "%s".', $path), $this->getSession()->getDriver());
     }
 
     return TRUE;
@@ -104,7 +104,7 @@ trait PathTrait {
     $query = $this->pathGetCurrentUrlQuery();
 
     if (empty($query[$param])) {
-      throw new ExpectationException(sprintf('The param "%s" is not in the URL', $param), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The parameter "%s" is not in the URL.', $param), $this->getSession()->getDriver());
     }
   }
 
@@ -126,7 +126,7 @@ trait PathTrait {
     $actual_value = $query[$param] ?? '';
 
     if ($actual_value !== $value) {
-      throw new ExpectationException(sprintf('The param "%s" is in the URL but with the wrong value "%s"', $param, is_array($actual_value) ? json_encode($actual_value) : $actual_value), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The parameter "%s" is in the URL but with the wrong value "%s".', $param, is_array($actual_value) ? json_encode($actual_value) : $actual_value), $this->getSession()->getDriver());
     }
   }
 
@@ -144,7 +144,7 @@ trait PathTrait {
     $query = $this->pathGetCurrentUrlQuery();
 
     if (!empty($query[$param])) {
-      throw new ExpectationException(sprintf('The param "%s" is in the URL but should not be', $param), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The parameter "%s" is in the URL but should not be.', $param), $this->getSession()->getDriver());
     }
   }
 
@@ -166,7 +166,7 @@ trait PathTrait {
     }
 
     if ($query[$param] === $value) {
-      throw new ExpectationException(sprintf('The param "%s" with value "%s" is in the URL but should not be', $param, $value), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The parameter "%s" with value "%s" is in the URL but should not be.', $param, $value), $this->getSession()->getDriver());
     }
   }
 

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -142,13 +142,13 @@ trait ResponsiveTrait {
     }
 
     if (count($breakpoint_tags) > 1) {
-      throw new \RuntimeException(sprintf('Only one @breakpoint tag is allowed per scenario. Found: @%s', implode(', @', $breakpoint_tags)));
+      throw new \RuntimeException(sprintf('Only one @breakpoint tag is allowed per scenario. Found: @%s.', implode(', @', $breakpoint_tags)));
     }
 
     $tag = $breakpoint_tags[0];
 
     if (!in_array('javascript', $tags)) {
-      throw new \RuntimeException(sprintf('@%s tag requires @javascript tag to resize viewport', $tag));
+      throw new \RuntimeException(sprintf('@%s tag requires @javascript tag to resize viewport.', $tag));
     }
 
     $breakpoint_name = substr($tag, strlen('breakpoint:'));

--- a/src/WaitTrait.php
+++ b/src/WaitTrait.php
@@ -42,7 +42,7 @@ trait WaitTrait {
 
     if (!$this->helperIsJavascriptSupported()) {
       $driver = $this->getSession()->getDriver();
-      throw new \RuntimeException(sprintf('Method can be used only with JS-capable driver. Driver %s is not JS-capable driver', $driver::class));
+      throw new \RuntimeException(sprintf('Method can be used only with JS-capable driver. Driver %s is not JS-capable driver.', $driver::class));
     }
 
     $script = <<<JS

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -513,7 +513,7 @@ trait XmlTrait {
     $namespaces = $this->xmlExtractNamespaces();
 
     if (!in_array($namespace, $namespaces, TRUE)) {
-      throw new ExpectationException(sprintf('The XML does not use the namespace "%s". Available namespaces: %s', $namespace, implode(', ', $namespaces)), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The XML does not use the namespace "%s". Available namespaces: %s.', $namespace, implode(', ', $namespaces)), $this->getSession()->getDriver());
     }
   }
 
@@ -697,7 +697,7 @@ trait XmlTrait {
 
     if (!$loaded) {
       $errors = libxml_get_errors();
-      throw new \RuntimeException(sprintf('Failed to load XML. Errors: %s', $this->xmlFormatErrors($errors)));
+      throw new \RuntimeException(sprintf('Failed to load XML. Errors: %s.', $this->xmlFormatErrors($errors)));
     }
 
     $this->xmlXpath = new \DOMXPath($this->xmlDocument);
@@ -830,7 +830,7 @@ trait XmlTrait {
     libxml_clear_errors();
 
     if (!$valid) {
-      throw new ExpectationException(sprintf('The response does not match the XSD schema: %s', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The response does not match the XSD schema: %s.', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());
     }
   }
 
@@ -849,7 +849,7 @@ trait XmlTrait {
     libxml_clear_errors();
 
     if (!$valid) {
-      throw new ExpectationException(sprintf('The response does not match the RelaxNG schema: %s', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The response does not match the RelaxNG schema: %s.', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());
     }
   }
 
@@ -897,7 +897,7 @@ trait XmlTrait {
     libxml_clear_errors();
 
     if (!$loaded || $errors !== []) {
-      throw new ExpectationException(sprintf('The response does not match the DTD: %s', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The response does not match the DTD: %s.', $this->xmlFormatErrors($errors)), $this->getSession()->getDriver());
     }
   }
 

--- a/tests/behat/features/accessibility.feature
+++ b/tests/behat/features/accessibility.feature
@@ -80,7 +80,7 @@ Feature: Check that AccessibilityTrait works
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      threshold=critical
+      threshold: critical
       """
     And the output should contain:
       """

--- a/tests/behat/features/behatcli.feature
+++ b/tests/behat/features/behatcli.feature
@@ -88,7 +88,7 @@ Feature: Behat CLI context
         Scenario: Anonymous user visits homepage # features/drupal_bootstrap.feature:3
           Given I go to the homepage             # Drupal\DrupalExtension\Context\MinkContext::iAmOnHomepage()
           And the path should be "/nonexisting"  # FeatureContext::pathAssertCurrent()
-            Current path is "/", but expected is "/nonexisting" (Behat\Mink\Exception\ExpectationException)
+            Current path is "/", but expected is "/nonexisting". (Behat\Mink\Exception\ExpectationException)
 
       --- Failed scenarios:
 

--- a/tests/behat/features/drupal_email.feature
+++ b/tests/behat/features/drupal_email.feature
@@ -360,7 +360,7 @@ Feature: Check that EmailTrait works
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      Unable to find email that should be sent to "test@example.com" retrieved from test message collector.
+      Unable to find email that should be sent to "test@example.com" retrieved from test email collector.
       """
 
   @trait:Drupal\EmailTrait

--- a/tests/behat/features/path.feature
+++ b/tests/behat/features/path.feature
@@ -150,7 +150,7 @@ Feature: Check that PathTrait works
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      The param "filter" is not in the URL
+      The parameter "filter" is not in the URL
       """
 
   @trait:PathTrait
@@ -165,7 +165,7 @@ Feature: Check that PathTrait works
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      The param "status" is in the URL but with the wrong value "1"
+      The parameter "status" is in the URL but with the wrong value "1"
       """
 
   @trait:PathTrait
@@ -180,7 +180,7 @@ Feature: Check that PathTrait works
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      The param "status" with value "1" is in the URL but should not be
+      The parameter "status" with value "1" is in the URL but should not be
       """
 
   @trait:PathTrait
@@ -195,7 +195,7 @@ Feature: Check that PathTrait works
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      The param "status" is in the URL but should not be
+      The parameter "status" is in the URL but should not be
       """
 
   @api


### PR DESCRIPTION
Closes #720

## Summary

About 400 thrown messages exist in `src/`. Fifty-one of them omitted the trailing period, and not randomly: six traits consistently dropped it when the message ended in an interpolated value. That was a real sub-convention rather than drift, but it was never written down, so the codebase carried two rules and neither was stated.

This adopts the single rule: a thrown message ends with a period. It also settles the phrasing families #720 lists, since those are the same class of inconsistency.

## Why the test coupling turned out to be safe

#720 warned that in-repo scenarios assert failure text verbatim and would need to change in the same commit. Checking how that assertion actually works: `BehatCliContext::itShouldPassOrFailWith()` uses `str_contains($output, $expected)`, a substring match, and PHPUnit's `expectExceptionMessage()` is substring too.

Appending a period leaves the old message as a strict prefix of the new one, so every existing assertion still matches and none needed touching. Only the phrasing changes below are not prefix-preserving, and those tests were updated.

## Changes

- 51 messages across 19 traits now end with a period.
- `Drupal\EmailTrait`: the collector is called `test email collector` everywhere; one message called it `test message collector`.
- `Drupal\EmailTrait`: both field-whitelist guards say `Invalid email field`; one said `Invalid message field`.
- `PathTrait`: messages say `parameter`, matching the registered step text, rather than `param`.
- `AccessibilityTrait`: the auto gate header uses `threshold: %s, fail_on_incomplete: %s`, matching the other gate header, rather than `threshold=%s, fail_on_incomplete=%s`.
- `tests/behat/features/path.feature`, `drupal_email.feature` and `accessibility.feature` updated for those four phrasing changes.

## Two deliberate exceptions

**Messages ending in a multi-line dump keep their previous form.** `Drupal\WatchdogTrait` ends with `PHP_EOL . implode(PHP_EOL . PHP_EOL, $errors)` and `Drupal\EmailTrait::emailAssertNoMessagesSent()` ends with `PHP_EOL . print_r($messages, TRUE)`. In both the final interpolation is a multi-line block by construction, so a trailing period lands on its own line after the dump rather than closing a sentence. Applying the rule there makes the output worse, not more consistent.

**JavaScript `throw new Error(...)` inside injected scripts is untouched.** Five of those exist in `FieldTrait`, `ElementTrait` and `DropzoneTrait`. They are a different language inside a string payload, not PHP exception messages, and are outside what #720 describes.

## Verification

Every suite covering a changed message passes: path 27 scenarios, command 16, link 19, keyboard 10, json 52, element 95, email 55, accessibility 9. That is 283 scenarios and over 1000 steps. `ahoy lint`, `ahoy test-unit` and `ahoy lint-docs` all pass, and `STEPS.md` is unchanged since no step text or docblock moved.

## Before / After

```
┌────────────────────────────────────────────────────────────────────────┐
│ The two competing rules, and why the tests did not break               │
├────────────────────────────────────────────────────────────────────────┤
│ BEFORE                                                                 │
│   'The response is valid XML, but it should not be.'      <- period    │
│   'The param "%s" is not in the URL'                      <- none      │
│                                                                        │
│ AFTER                                                                  │
│   'The response is valid XML, but it should not be.'                   │
│   'The parameter "%s" is not in the URL.'                              │
│                                                                        │
│ Assertion match is str_contains(), and the old text is a prefix of     │
│ the new text, so a period alone never breaks an assertion. The         │
│ param -> parameter rename is not a prefix, so its tests were updated.  │
└────────────────────────────────────────────────────────────────────────┘
```

```
┌────────────────────────────────────────────────────────────────────────┐
│ Where the rule is not applied                                          │
├────────────────────────────────────────────────────────────────────────┤
│   'PHP errors were logged to watchdog %s: %s'                          │
│                                       └─ PHP_EOL . implode(...)        │
│                                                                        │
│   ...logged to watchdog during scenario "x" (line 12):                 │
│                                                                        │
│   [dumped error one]                                                   │
│                                                                        │
│   [dumped error two]                                                   │
│   .            <- where the period would land                          │
└────────────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Standardize 51 PHP exception messages across 19 traits with terminal periods.
- Align related wording, including email collector names, `parameter` terminology, invalid email fields, and accessibility gate formatting.
- Update affected Behat expectations and one harness assertion.
- Leave multiline dumps and injected JavaScript `Error` messages unchanged.
- Verify 283 scenarios and more than 1,000 steps, including lint, unit tests, and documentation linting.

## Critical

- No step-definition violations identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->