### PR TITLE
[#723] Rejected error responses when downloading and unified the impact ordering.

### DIFF
--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -470,6 +470,19 @@ trait AccessibilityTrait {
    *   Impact identifiers ordered from most severe to least.
    */
   protected function accessibilityGetImpacts(): array {
+    return static::accessibilityGetDefaultImpacts();
+  }
+
+  /**
+   * Return the impact levels in descending severity order, statically.
+   *
+   * The static rollup cannot reach the instance getter, so both read this one
+   * ordering rather than each carrying its own copy.
+   *
+   * @return array<int, string>
+   *   Impact identifiers ordered from most severe to least.
+   */
+  protected static function accessibilityGetDefaultImpacts(): array {
     return [
       self::IMPACT_CRITICAL,
       self::IMPACT_SERIOUS,
@@ -1132,14 +1145,10 @@ HTML;
    *   Severity-sorted rules and per-impact totals.
    */
   protected static function accessibilityAggregateRollup(array $pages): array {
-    $rank = [self::IMPACT_CRITICAL => 0, self::IMPACT_SERIOUS => 1, self::IMPACT_MODERATE => 2, self::IMPACT_MINOR => 3];
+    $impacts = static::accessibilityGetDefaultImpacts();
+    $rank = array_flip($impacts);
     $rules = [];
-    $totals = [
-      self::IMPACT_CRITICAL => 0,
-      self::IMPACT_SERIOUS => 0,
-      self::IMPACT_MODERATE => 0,
-      self::IMPACT_MINOR => 0,
-    ];
+    $totals = array_fill_keys($impacts, 0);
 
     foreach ($pages as $url => $page) {
       foreach ($page['violations'] ?? [] as $violation) {

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -13,6 +13,7 @@ use Behat\Hook\BeforeScenario;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Step\Then;
 use Behat\Step\When;
 use Symfony\Component\Filesystem\Filesystem;
@@ -103,14 +104,22 @@ trait FileDownloadTrait {
       }
     }
 
-    // BrowserKit-based drivers like GoutteDriver.
-    else {
+    // BrowserKit-based drivers like GoutteDriver. Values are passed through as
+    // the driver reports them, because they are going back out in a Cookie
+    // header and belong in their wire form. CookieTrait decodes the same
+    // values instead, since it presents them for assertion.
+    elseif (method_exists($driver, 'getClient')) {
       /** @var \Behat\Mink\Driver\BrowserKitDriver $driver */
       // @phpstan-ignore-next-line
       $cookies = $driver->getClient()->getCookieJar()->allValues($driver->getCurrentUrl());
       foreach ($cookies as $cookie_name => $cookie_value) {
         $cookie_list[] = $cookie_name . '=' . $cookie_value;
       }
+    }
+    else {
+      // @codeCoverageIgnoreStart
+      throw new UnsupportedDriverActionException('Cookie retrieval is not supported by %s.', $driver);
+      // @codeCoverageIgnoreEnd
     }
 
     $this->fileDownloadDownloadedFileInfo = $this->fileDownloadProcess($url, [
@@ -399,12 +408,19 @@ trait FileDownloadTrait {
     curl_setopt_array($handle, $options);
 
     $content = curl_exec($handle);
+    $status = curl_getinfo($handle, CURLINFO_HTTP_CODE);
     curl_close($handle);
 
     if (!$content) {
       // @codeCoverageIgnoreStart
       throw new \RuntimeException(sprintf('Unable to save temp file from URL %s.', $url));
       // @codeCoverageIgnoreEnd
+    }
+
+    // An error page has a body like any other response, so without this the
+    // response to a 404 would be saved and asserted on as the downloaded file.
+    if ($status >= 400) {
+      throw new \RuntimeException(sprintf('The URL %s returned HTTP status %d.', $url, $status));
     }
 
     $headers = $this->fileDownloadParseHeaders($response_headers);

--- a/tests/behat/features/file_download.feature
+++ b/tests/behat/features/file_download.feature
@@ -19,11 +19,11 @@ Feature: Check that FileDownloadTrait works
 
   @api @download
   Scenario: Assert "When I download the file from the URL :url"
-    When I download the file from the URL "/text.txt"
+    When I download the file from the URL "/sites/default/files/text.txt"
 
   @api @javascript @download
   Scenario: Assert in browser "When I download the file from the URL :url"
-    When I download the file from the URL "/text.txt"
+    When I download the file from the URL "/sites/default/files/text.txt"
 
   @api @download
   Scenario: Assert "When I download the file from the link :link"
@@ -44,7 +44,7 @@ Feature: Check that FileDownloadTrait works
     And scenario steps tagged with "@download":
       """
       When I visit "/"
-      And I download the file from the URL "/text.txt"
+      And I download the file from the URL "/sites/default/files/text.txt"
       Then the downloaded file should contain:
         '''
         /nonexistent.*pattern/
@@ -71,7 +71,7 @@ Feature: Check that FileDownloadTrait works
 
   @api @download
   Scenario: Assert the downloaded file name contains a specific string
-    When I download the file from the URL "/text.txt"
+    When I download the file from the URL "/sites/default/files/text.txt"
     Then the downloaded file name should contain "text"
 
   @api @trait:FileDownloadTrait
@@ -80,7 +80,7 @@ Feature: Check that FileDownloadTrait works
     And scenario steps tagged with "@download":
       """
       When I visit "/"
-      And I download the file from the URL "/text.txt"
+      And I download the file from the URL "/sites/default/files/text.txt"
       Then the downloaded file name should contain "nonexistent"
       """
     When I run "behat --no-colors"
@@ -145,7 +145,7 @@ Feature: Check that FileDownloadTrait works
     And scenario steps tagged with "@download":
       """
       When I visit "/"
-      And I download the file from the URL "/text.txt"
+      And I download the file from the URL "/sites/default/files/text.txt"
       Then the downloaded file name should be "wrong_name.txt"
       """
     When I run "behat --no-colors"
@@ -160,7 +160,7 @@ Feature: Check that FileDownloadTrait works
     And scenario steps tagged with "@download":
       """
       When I visit "/"
-      And I download the file from the URL "/text.txt"
+      And I download the file from the URL "/sites/default/files/text.txt"
       Then the downloaded file should contain:
         '''
         nonexistent content string
@@ -281,7 +281,7 @@ Feature: Check that FileDownloadTrait works
     And scenario steps tagged with "@download":
       """
       Given I am logged in as a user with the "administrator" role
-      When I download the file from the URL "/archive_invalid.zip"
+      When I download the file from the URL "/sites/default/files/archive_invalid.zip"
       Then the downloaded file should be a zip archive containing the following files named:
         | test.txt |
       """
@@ -312,7 +312,7 @@ Feature: Check that FileDownloadTrait works
     And scenario steps tagged with "@download":
       """
       When I visit "/"
-      And I download the file from the URL "/text.txt"
+      And I download the file from the URL "/sites/default/files/text.txt"
       Then the downloaded file should be a zip archive containing the following files named:
         | test.txt |
       """
@@ -320,4 +320,18 @@ Feature: Check that FileDownloadTrait works
     Then it should fail with an error:
       """
       Downloaded file does not have correct headers set for ZIP.
+      """
+
+  @api @trait:FileDownloadTrait
+  Scenario: Assert that downloading a URL returning an error status fails
+    Given some behat configuration
+    And scenario steps tagged with "@download":
+      """
+      When I visit "/"
+      And I download the file from the URL "/sites/default/files/nonexistent-download-target.txt"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      returned HTTP status 404
       """


### PR DESCRIPTION
Closes #723

## Summary

#723 groups the duplication three ways and names group 2, the copies that have drifted behaviorally, as the priority. This addresses that group. Groups 1 and 3 are refactors with no behaviour question attached, and #723 itself recommends doing them trait by trait rather than as one sweep, so they are noted at the end rather than folded in here.

## The download status check, and what it uncovered

`FileDownloadTrait::fileDownloadProcess()` and `MetatagTrait::metatagFetchUrl()` are two cURL implementations of the same job that had drifted. The metatag one reads `CURLINFO_HTTP_CODE` and rejects a status at or above 400. The download one checked only that the body was truthy, and an error page has a body like any other response, so a 404 was saved and asserted on as the downloaded file.

Adding the check made ten of the twenty-four scenarios in `file_download.feature` fail immediately, which is the finding rather than a problem with the fix. Every URL-based scenario downloaded a bare path such as `/text.txt`. Managed files are written to `public://<name>` and served from `/sites/default/files/<name>`, so `/text.txt` is not a file route at all and Drupal answered `403`. `/archive_invalid.zip` answered `404`.

Those scenarios passed only because nothing checked the status, and because the URL-based ones assert on the file name, which is derived from the URL path, rather than on the content. The link-based scenarios, which resolve a real href, all passed and still do. Their URLs are corrected here so they download the file they claim to.

## Changes

- `src/FileDownloadTrait.php`: `fileDownloadProcess()` rejects a response with a status at or above 400, matching `MetatagTrait::metatagFetchUrl()`.
- `src/FileDownloadTrait.php`: the BrowserKit branch of the cookie cascade is now guarded with `method_exists($driver, 'getClient')` and an unknown driver throws `UnsupportedDriverActionException`, matching `CookieTrait::cookieGetAll()`. Previously the branch was a bare `else` that assumed BrowserKit and would fatal on any other driver.
- `src/AccessibilityTrait.php`: the ordered impact list and the hardcoded rank map are replaced by one static list. `accessibilityGetImpacts()` returns it, and the static rollup derives both its rank map and its totals keys from it with `array_flip()` and `array_fill_keys()`. The static method could not call the instance getter, which is why the copy existed; it now reads the same list through late static binding, so an override is still honoured.
- `tests/behat/features/file_download.feature`: ten download URLs corrected to `/sites/default/files/...`, and a new `@trait:FileDownloadTrait` scenario pins the error-status rejection.

## One difference deliberately kept

`CookieTrait::cookieGetAll()` calls `rawurldecode()` on cookie values and `FileDownloadTrait::fileDownloadFrom()` does not. #723 lists this as drift, but the two are correct as they stand and unifying them would break one. `CookieTrait` presents values for assertion, where a user comparing against `hello world` wants the decoded form. `FileDownloadTrait` puts the values straight back into a `Cookie` header, where the wire form is what belongs on the wire. The reason is now recorded in the code.

## Verification

The new scenario was confirmed to fail without the source change and pass with it. With the fix reverted, exactly one of the twenty-four scenarios fails, and it is the new one. With the fix applied, all twenty-four scenarios and 162 steps pass.

Other affected suites pass: accessibility 9 scenarios, cookie 40, metatag 38. `ahoy lint`, `ahoy test-unit` and `ahoy lint-docs` all pass, and `STEPS.md` is unchanged.

## Not included

Group 1 (verbatim duplicates such as the file-reading helpers shared by `XmlTrait` and `JsonTrait`, and the entity-ids query repeated across five traits) and group 3 (roughly 35 in-file twin bodies) are mechanical refactors. They need a shared composition seam that not every affected trait currently uses, which is a design decision rather than a cleanup, and #723 recommends approaching them trait by trait.

## Before / After

```
┌────────────────────────────────────────────────────────────────────────┐
│ "I download the file from the URL" against a path that 404s            │
├────────────────────────────────────────────────────────────────────────┤
│ BEFORE                                                                 │
│   curl_exec()   ->  body of the Drupal error page                      │
│   if (!$content) ->  false, body is truthy                             │
│   saved as the downloaded file, assertions run against the error page  │
│                                                                        │
│ AFTER                                                                  │
│   curl_exec()   ->  body of the Drupal error page                      │
│   status 404    ->  throws, naming the URL and the status              │
└────────────────────────────────────────────────────────────────────────┘
```

```
┌────────────────────────────────────────────────────────────────────────┐
│ AccessibilityTrait severity ordering                                   │
├────────────────────────────────────────────────────────────────────────┤
│ BEFORE  accessibilityGetImpacts()      [CRITICAL, SERIOUS, ...]        │
│         accessibilityAggregateRollup() [CRITICAL => 0, SERIOUS => 1,   │
│                                         ...] plus a third copy for     │
│                                         the totals keys                │
│                                                                        │
│ AFTER   accessibilityGetDefaultImpacts()  one ordered list             │
│           |- getImpacts()      returns it                              │
│           |- rollup rank       array_flip()                            │
│           `- rollup totals     array_fill_keys()                       │
└────────────────────────────────────────────────────────────────────────┘
```
