### PR TITLE
[#724] Ordered every trait's members into one documented layout.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,20 @@ A documented override point that supplies a value is `<trait>Get<Noun>()`, boole
 
 `Normalize`, not `Normalise`, in method names and in prose.
 
+## Member ordering within a trait
+
+Traits lay their members out in this order:
+
+1. Trait composition (`use`), then constants, then properties.
+2. Hooks (`#[BeforeScenario]`, `#[AfterStep]` and the like).
+3. `Given` steps, then `When` steps, then `Then` steps.
+4. Other public methods.
+5. Protected helpers.
+
+Within each of those groups, keep the members in whatever order reads best - the rule settles the groups, not what happens inside one. `tests/phpunit/src/MemberOrderTest.php` enforces it.
+
+Reordering an existing trait into this layout leaves [STEPS.md](STEPS.md) untouched. `docs.php` already groups steps by `Given`, `When` and `Then` and keeps source order inside each group, so this layout only applies a sort the generated documentation applies anyway.
+
 ## Unsettled style questions
 
 Four style questions have no dominant form in this codebase. Both sides of each are correct and behavior-identical where they appear, and converging any of them would churn 25 to 75 sites for no functional gain. Match the surrounding file and do not convert existing code from one form to the other as a drive-by change.

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -296,36 +296,6 @@ trait AccessibilityTrait {
   }
 
   /**
-   * Fail the scenario when collected results breach the automatic gate.
-   *
-   * @throws \Behat\Mink\Exception\ExpectationException
-   *   If a violation at or above the threshold was collected.
-   */
-  protected function accessibilityEnforceGate(): void {
-    $threshold = $this->accessibilityEffectiveThreshold();
-    $check_incomplete = $this->accessibilityEffectiveFailOnIncomplete();
-    $messages = [];
-
-    foreach ($this->accessibilityResults as $r) {
-      $display_url = $this->accessibilityFormatUrl((string) $r['url']);
-
-      foreach ($this->accessibilityFilterViolations($r['result']['violations'] ?? [], $threshold) as $v) {
-        $messages[] = sprintf('  violation [%s] %s on %s', $v['impact'] ?? 'unknown', $v['id'] ?? '', $display_url);
-      }
-      if ($check_incomplete) {
-        foreach ($r['result']['incomplete'] ?? [] as $i) {
-          $messages[] = sprintf('  incomplete [%s] %s on %s', $i['impact'] ?? 'unknown', $i['id'] ?? '', $display_url);
-        }
-      }
-    }
-
-    if ($messages !== []) {
-      $message = sprintf("Auto accessibility gate failed (threshold: %s, fail_on_incomplete: %s):\n%s", $threshold, $check_incomplete ? 'yes' : 'no', implode("\n", $messages));
-      throw new ExpectationException($message, $this->getSession()->getDriver());
-    }
-  }
-
-  /**
    * Render the single cross-page report after the whole suite has run.
    */
   #[AfterSuite]
@@ -377,6 +347,36 @@ trait AccessibilityTrait {
       ),
       $this->getSession()->getDriver()
     );
+  }
+
+  /**
+   * Fail the scenario when collected results breach the automatic gate.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   If a violation at or above the threshold was collected.
+   */
+  protected function accessibilityEnforceGate(): void {
+    $threshold = $this->accessibilityEffectiveThreshold();
+    $check_incomplete = $this->accessibilityEffectiveFailOnIncomplete();
+    $messages = [];
+
+    foreach ($this->accessibilityResults as $r) {
+      $display_url = $this->accessibilityFormatUrl((string) $r['url']);
+
+      foreach ($this->accessibilityFilterViolations($r['result']['violations'] ?? [], $threshold) as $v) {
+        $messages[] = sprintf('  violation [%s] %s on %s', $v['impact'] ?? 'unknown', $v['id'] ?? '', $display_url);
+      }
+      if ($check_incomplete) {
+        foreach ($r['result']['incomplete'] ?? [] as $i) {
+          $messages[] = sprintf('  incomplete [%s] %s on %s', $i['impact'] ?? 'unknown', $i['id'] ?? '', $display_url);
+        }
+      }
+    }
+
+    if ($messages !== []) {
+      $message = sprintf("Auto accessibility gate failed (threshold: %s, fail_on_incomplete: %s):\n%s", $threshold, $check_incomplete ? 'yes' : 'no', implode("\n", $messages));
+      throw new ExpectationException($message, $this->getSession()->getDriver());
+    }
   }
 
   /**

--- a/src/DateTrait.php
+++ b/src/DateTrait.php
@@ -64,13 +64,6 @@ trait DateTrait {
   }
 
   /**
-   * Assert that string has a token.
-   */
-  protected static function dateRelativeStringHasToken(string $string): bool {
-    return str_contains($string, '[relative:');
-  }
-
-  /**
    * Process date values to convert relative timestamps to actual values.
    *
    * Public API: a composing context may call this directly to resolve a token
@@ -129,6 +122,13 @@ trait DateTrait {
 
       return $formatted;
     }, $value);
+  }
+
+  /**
+   * Assert that string has a token.
+   */
+  protected static function dateRelativeStringHasToken(string $string): bool {
+    return str_contains($string, '[relative:');
   }
 
   /**

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -25,22 +25,6 @@ trait ContentBlockTrait {
   use HelperTrait;
 
   /**
-   * Assert that a content block type exists.
-   *
-   * @code
-   * Then the content block type "Search" should exist
-   * @endcode
-   */
-  #[Then('the content block type :content_block_type should exist')]
-  public function contentBlockAssertTypeExists(string $content_block_type): void {
-    $block_content_type = \Drupal::entityTypeManager()->getStorage('block_content_type')->load($content_block_type);
-
-    if (!$block_content_type instanceof BlockContentTypeInterface) {
-      throw new ExpectationException(sprintf('Content block type "%s" does not exist.', $content_block_type), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
    * Remove content blocks of a specified type with the given descriptions.
    *
    * Delete all content blocks of the specified type that match any of the
@@ -68,34 +52,6 @@ trait ContentBlockTrait {
         $content_block->delete();
       }
     }
-  }
-
-  /**
-   * Navigate to the edit page for a specified content block.
-   *
-   * Find a content block by its type and description (admin title) and
-   * navigate to its edit page. Throws an exception if no matching block
-   * is found.
-   *
-   * @code
-   * When I edit the "basic" content block with the description "[TEST] Footer Block"
-   * @endcode
-   */
-  #[When('I edit the :content_block_type content block with the description :description')]
-  public function contentBlockEditBlockContentWithDescription(string $content_block_type, string $description): void {
-    $block_ids = $this->contentBlockLoadMultiple($content_block_type, [
-      'info' => $description,
-    ]);
-
-    if (empty($block_ids)) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" content block with the description "%s".', $content_block_type, $description));
-    }
-
-    ksort($block_ids);
-    $block_id = end($block_ids);
-
-    $path = $this->locatePath('/admin/content/block/' . $block_id);
-    $this->getSession()->visit($path);
   }
 
   /**
@@ -156,6 +112,50 @@ trait ContentBlockTrait {
 
     foreach ($entities as $entity_data) {
       $this->contentBlockCreateSingle($content_block_type, $entity_data);
+    }
+  }
+
+  /**
+   * Navigate to the edit page for a specified content block.
+   *
+   * Find a content block by its type and description (admin title) and
+   * navigate to its edit page. Throws an exception if no matching block
+   * is found.
+   *
+   * @code
+   * When I edit the "basic" content block with the description "[TEST] Footer Block"
+   * @endcode
+   */
+  #[When('I edit the :content_block_type content block with the description :description')]
+  public function contentBlockEditBlockContentWithDescription(string $content_block_type, string $description): void {
+    $block_ids = $this->contentBlockLoadMultiple($content_block_type, [
+      'info' => $description,
+    ]);
+
+    if (empty($block_ids)) {
+      throw new \RuntimeException(sprintf('Unable to find "%s" content block with the description "%s".', $content_block_type, $description));
+    }
+
+    ksort($block_ids);
+    $block_id = end($block_ids);
+
+    $path = $this->locatePath('/admin/content/block/' . $block_id);
+    $this->getSession()->visit($path);
+  }
+
+  /**
+   * Assert that a content block type exists.
+   *
+   * @code
+   * Then the content block type "Search" should exist
+   * @endcode
+   */
+  #[Then('the content block type :content_block_type should exist')]
+  public function contentBlockAssertTypeExists(string $content_block_type): void {
+    $block_content_type = \Drupal::entityTypeManager()->getStorage('block_content_type')->load($content_block_type);
+
+    if (!$block_content_type instanceof BlockContentTypeInterface) {
+      throw new ExpectationException(sprintf('Content block type "%s" does not exist.', $content_block_type), $this->getSession()->getDriver());
     }
   }
 

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -37,6 +37,24 @@ trait ContentTrait {
   use HelperTrait;
 
   /**
+   * Expand fixture file paths for file/image fields on nodes.
+   *
+   * Rewrites fixture paths (e.g. 'document.pdf', 'images/photo.png') on
+   * 'file' and 'image' field types to absolute paths under the Mink
+   * 'files_path'. drupal-driver's FileHandler can then read and upload them
+   * during node creation.
+   *
+   * Without this, scenarios with file fields on nodes have to pre-create
+   * managed files explicitly via FileTrait.
+   *
+   * Backed by 'HelperTrait::helperExpandEntityFieldsFixtures()'.
+   */
+  #[BeforeNodeCreate]
+  public function contentBeforeNodeCreate(BeforeNodeCreateScope $scope): void {
+    $this->helperExpandEntityFieldsFixtures('node', $scope->getStub());
+  }
+
+  /**
    * Delete content type.
    *
    * @code
@@ -156,23 +174,6 @@ trait ContentTrait {
   #[When('I visit the :content_type content revisions page with the title :title')]
   public function contentVisitRevisionsPageWithTitle(string $content_type, string $title): void {
     $this->contentVisitActionPageWithTitle($content_type, $title, '/revisions');
-  }
-
-  /**
-   * Visit the action page of the content with a specified title.
-   *
-   * @param string $content_type
-   *   The content type.
-   * @param string $title
-   *   The title of the content.
-   * @param string $action_subpath
-   *   The operation to perform.
-   */
-  protected function contentVisitActionPageWithTitle(string $content_type, string $title, string $action_subpath = ''): void {
-    $nid = $this->contentResolveNidByTitle($content_type, $title);
-    $path = $this->locatePath('/node/' . $nid . $action_subpath);
-
-    $this->getSession()->visit($path);
   }
 
   /**
@@ -337,21 +338,20 @@ trait ContentTrait {
   }
 
   /**
-   * Expand fixture file paths for file/image fields on nodes.
+   * Visit the action page of the content with a specified title.
    *
-   * Rewrites fixture paths (e.g. 'document.pdf', 'images/photo.png') on
-   * 'file' and 'image' field types to absolute paths under the Mink
-   * 'files_path'. drupal-driver's FileHandler can then read and upload them
-   * during node creation.
-   *
-   * Without this, scenarios with file fields on nodes have to pre-create
-   * managed files explicitly via FileTrait.
-   *
-   * Backed by 'HelperTrait::helperExpandEntityFieldsFixtures()'.
+   * @param string $content_type
+   *   The content type.
+   * @param string $title
+   *   The title of the content.
+   * @param string $action_subpath
+   *   The operation to perform.
    */
-  #[BeforeNodeCreate]
-  public function contentBeforeNodeCreate(BeforeNodeCreateScope $scope): void {
-    $this->helperExpandEntityFieldsFixtures('node', $scope->getStub());
+  protected function contentVisitActionPageWithTitle(string $content_type, string $title, string $action_subpath = ''): void {
+    $nid = $this->contentResolveNidByTitle($content_type, $title);
+    $path = $this->locatePath('/node/' . $nid . $action_subpath);
+
+    $this->getSession()->visit($path);
   }
 
   /**

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -114,6 +114,137 @@ trait EmailTrait {
   }
 
   /**
+   * Follow a specific link number in an email with the given subject.
+   *
+   * @code
+   * When I follow link number "1" in the email with the subject "Account Verification"
+   * @endcode
+   */
+  #[When('I follow link number :link_number in the email with the subject :subject')]
+  public function emailFollowLinkNumber(string $link_number, string $subject): void {
+    $link_number = $this->emailAssertLinkNumber($link_number);
+
+    $message = $this->emailFindMessage('subject', new PyStringNode([$subject], 0));
+
+    if (!$message) {
+      throw new ExpectationException(sprintf('Unable to find email with subject "%s" retrieved from test email collector.', $subject), $this->getSession()->getDriver());
+    }
+
+    if (isset($message['params']['body']) && is_string($message['params']['body'])) {
+      $body = $message['params']['body'];
+    }
+    // @codeCoverageIgnoreStart
+    elseif (is_string($message['body'])) {
+      $body = $message['body'];
+    }
+    else {
+      throw new \RuntimeException('No body found in email.');
+    }
+    // @codeCoverageIgnoreEnd
+    $links = self::emailExtractLinks($body);
+
+    if (empty($links)) {
+      throw new ExpectationException(sprintf('No links were found in the email with subject "%s".', $subject), $this->getSession()->getDriver());
+    }
+
+    if (count($links) < $link_number) {
+      throw new ExpectationException(sprintf('The link with number %s was not found among %s links.', $link_number, count($links)), $this->getSession()->getDriver());
+    }
+
+    $link = $links[$link_number - 1];
+    $this->getSession()->visit($link);
+  }
+
+  /**
+   * Follow a specific link number in an email whose subject contains the given substring.
+   *
+   * @code
+   * When I follow link number "1" in the email with the subject containing "Verification"
+   * @endcode
+   */
+  #[When('I follow link number :link_number in the email with the subject containing :subject')]
+  public function emailFollowLinkNumberWithSubjectContaining(string $link_number, string $subject): void {
+    $link_number = $this->emailAssertLinkNumber($link_number);
+
+    $message = NULL;
+    foreach ($this->emailGetCollectedMessages() as $m) {
+      if (str_contains(strtolower((string) $m['subject']), strtolower($subject))) {
+        $message = $m;
+        break;
+      }
+    }
+
+    if (!$message) {
+      throw new ExpectationException(sprintf('Unable to find email with subject containing "%s" retrieved from test email collector.', $subject), $this->getSession()->getDriver());
+    }
+
+    if (isset($message['params']['body']) && is_string($message['params']['body'])) {
+      $body = $message['params']['body'];
+    }
+    // @codeCoverageIgnoreStart
+    elseif (is_string($message['body'])) {
+      $body = $message['body'];
+    }
+    else {
+      throw new \RuntimeException('No body found in email.');
+    }
+    // @codeCoverageIgnoreEnd
+    $links = self::emailExtractLinks($body);
+
+    if (empty($links)) {
+      throw new ExpectationException(sprintf('No links were found in the email with subject containing "%s".', $subject), $this->getSession()->getDriver());
+    }
+
+    if (count($links) < $link_number) {
+      throw new ExpectationException(sprintf('The link with number %s was not found among %s links.', $link_number, count($links)), $this->getSession()->getDriver());
+    }
+
+    $link = $links[$link_number - 1];
+
+    $this->getSession()->visit($link);
+  }
+
+  /**
+   * Enable the test email system.
+   *
+   * @code
+   * When I enable the test email system
+   * @endcode
+   */
+  #[When('I enable the test email system')]
+  public function emailEnableTestSystem(): void {
+    foreach ($this->emailHandlerTypes as $type) {
+      $original_test_system = self::emailGetMailSystemDefault($type);
+      if (!self::emailGetMailSystemOriginal($type)) {
+        self::emailSetMailSystemOriginal($type, $original_test_system);
+      }
+      self::emailSetMailSystemDefault($type, 'test_mail_collector');
+    }
+
+    // Clearing here lets this step definition be reused to clear existing
+    // mail.
+    $this->emailClearTestQueue(TRUE);
+  }
+
+  /**
+   * Disable test email system.
+   *
+   * @code
+   * When I disable the test email system
+   * @endcode
+   */
+  #[When('I disable the test email system')]
+  public function emailDisableTestEmailSystem(): void {
+    foreach ($this->emailHandlerTypes as $type) {
+      $original_test_system = self::emailGetMailSystemOriginal($type);
+      self::emailSetMailSystemDefault($type, $original_test_system);
+    }
+
+    self::emailDeleteMailSystemOriginal();
+    $this->emailClearTestQueue(TRUE);
+  }
+
+  /**
    * Assert that an email should be sent to an address.
    *
    * @code
@@ -380,97 +511,6 @@ trait EmailTrait {
   }
 
   /**
-   * Follow a specific link number in an email with the given subject.
-   *
-   * @code
-   * When I follow link number "1" in the email with the subject "Account Verification"
-   * @endcode
-   */
-  #[When('I follow link number :link_number in the email with the subject :subject')]
-  public function emailFollowLinkNumber(string $link_number, string $subject): void {
-    $link_number = $this->emailAssertLinkNumber($link_number);
-
-    $message = $this->emailFindMessage('subject', new PyStringNode([$subject], 0));
-
-    if (!$message) {
-      throw new ExpectationException(sprintf('Unable to find email with subject "%s" retrieved from test email collector.', $subject), $this->getSession()->getDriver());
-    }
-
-    if (isset($message['params']['body']) && is_string($message['params']['body'])) {
-      $body = $message['params']['body'];
-    }
-    // @codeCoverageIgnoreStart
-    elseif (is_string($message['body'])) {
-      $body = $message['body'];
-    }
-    else {
-      throw new \RuntimeException('No body found in email.');
-    }
-    // @codeCoverageIgnoreEnd
-    $links = self::emailExtractLinks($body);
-
-    if (empty($links)) {
-      throw new ExpectationException(sprintf('No links were found in the email with subject "%s".', $subject), $this->getSession()->getDriver());
-    }
-
-    if (count($links) < $link_number) {
-      throw new ExpectationException(sprintf('The link with number %s was not found among %s links.', $link_number, count($links)), $this->getSession()->getDriver());
-    }
-
-    $link = $links[$link_number - 1];
-    $this->getSession()->visit($link);
-  }
-
-  /**
-   * Follow a specific link number in an email whose subject contains the given substring.
-   *
-   * @code
-   * When I follow link number "1" in the email with the subject containing "Verification"
-   * @endcode
-   */
-  #[When('I follow link number :link_number in the email with the subject containing :subject')]
-  public function emailFollowLinkNumberWithSubjectContaining(string $link_number, string $subject): void {
-    $link_number = $this->emailAssertLinkNumber($link_number);
-
-    $message = NULL;
-    foreach ($this->emailGetCollectedMessages() as $m) {
-      if (str_contains(strtolower((string) $m['subject']), strtolower($subject))) {
-        $message = $m;
-        break;
-      }
-    }
-
-    if (!$message) {
-      throw new ExpectationException(sprintf('Unable to find email with subject containing "%s" retrieved from test email collector.', $subject), $this->getSession()->getDriver());
-    }
-
-    if (isset($message['params']['body']) && is_string($message['params']['body'])) {
-      $body = $message['params']['body'];
-    }
-    // @codeCoverageIgnoreStart
-    elseif (is_string($message['body'])) {
-      $body = $message['body'];
-    }
-    else {
-      throw new \RuntimeException('No body found in email.');
-    }
-    // @codeCoverageIgnoreEnd
-    $links = self::emailExtractLinks($body);
-
-    if (empty($links)) {
-      throw new ExpectationException(sprintf('No links were found in the email with subject containing "%s".', $subject), $this->getSession()->getDriver());
-    }
-
-    if (count($links) < $link_number) {
-      throw new ExpectationException(sprintf('The link with number %s was not found among %s links.', $link_number, count($links)), $this->getSession()->getDriver());
-    }
-
-    $link = $links[$link_number - 1];
-
-    $this->getSession()->visit($link);
-  }
-
-  /**
    * Assert that a file is attached to an email message with specified subject.
    *
    * @code
@@ -526,46 +566,6 @@ trait EmailTrait {
     }
 
     throw new ExpectationException(sprintf('No attachments were found in the email with subject containing "%s".', $subject), $this->getSession()->getDriver());
-  }
-
-  /**
-   * Enable the test email system.
-   *
-   * @code
-   * When I enable the test email system
-   * @endcode
-   */
-  #[When('I enable the test email system')]
-  public function emailEnableTestSystem(): void {
-    foreach ($this->emailHandlerTypes as $type) {
-      $original_test_system = self::emailGetMailSystemDefault($type);
-      if (!self::emailGetMailSystemOriginal($type)) {
-        self::emailSetMailSystemOriginal($type, $original_test_system);
-      }
-      self::emailSetMailSystemDefault($type, 'test_mail_collector');
-    }
-
-    // Clearing here lets this step definition be reused to clear existing
-    // mail.
-    $this->emailClearTestQueue(TRUE);
-  }
-
-  /**
-   * Disable test email system.
-   *
-   * @code
-   * When I disable the test email system
-   * @endcode
-   */
-  #[When('I disable the test email system')]
-  public function emailDisableTestEmailSystem(): void {
-    foreach ($this->emailHandlerTypes as $type) {
-      $original_test_system = self::emailGetMailSystemOriginal($type);
-      self::emailSetMailSystemDefault($type, $original_test_system);
-    }
-
-    self::emailDeleteMailSystemOriginal();
-    $this->emailClearTestQueue(TRUE);
   }
 
   /**

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -71,6 +71,21 @@ trait FileTrait {
   }
 
   /**
+   * Remove unmanaged files created during the scenario.
+   *
+   * Managed file entities are removed by the shared entity registry cleanup.
+   */
+  #[AfterScenario('@api')]
+  public function fileAfterScenario(AfterScenarioScope $scope): void {
+    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+    foreach ($this->filesUnmanagedUris as $uri) {
+      @unlink($uri);
+    }
+  }
+
+  /**
    * Create managed files with properties provided in the table.
    *
    * @code
@@ -93,101 +108,6 @@ trait FileTrait {
 
       $stub = new EntityStub('file', NULL, $hash);
       $this->fileCreateManagedSingle($path, $stub, $uri);
-    }
-  }
-
-  /**
-   * Create a single managed file.
-   *
-   * @param string $path
-   *   The source file path relative to 'files_path'.
-   * @param \Drupal\Driver\Entity\EntityStub $stub
-   *   Entity fields stub (must not contain 'path' or 'uri').
-   * @param string|null $uri
-   *   Optional destination URI. Defaults to 'public://filename'.
-   *
-   * @return \Drupal\file\FileInterface
-   *   Created file entity.
-   */
-  protected function fileCreateManagedSingle(string $path, EntityStub $stub, ?string $uri = NULL): FileInterface {
-    $this->parseEntityFields($stub);
-
-    $entity = $this->fileCreateEntity($path, $stub, $uri);
-
-    $this->helperEntityRegister($entity);
-
-    return $entity;
-  }
-
-  /**
-   * Create file entity.
-   *
-   * @param string $path
-   *   The source file path relative to 'files_path'.
-   * @param \Drupal\Driver\Entity\EntityStub $stub
-   *   Entity fields stub.
-   * @param string|null $uri
-   *   Optional destination URI. Defaults to 'public://filename'.
-   *
-   * @return \Drupal\file\FileInterface
-   *   Created file entity.
-   */
-  protected function fileCreateEntity(string $path, EntityStub $stub, ?string $uri = NULL): FileInterface {
-    $path = ltrim($path, '/');
-
-    if (!empty($this->getMinkParameter('files_path'))) {
-      $full_path = rtrim((string) realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $path;
-      if (is_file($full_path)) {
-        $path = $full_path;
-      }
-    }
-
-    // @codeCoverageIgnoreStart
-    if (!is_readable($path)) {
-      throw new \RuntimeException(sprintf('Unable to find file "%s".', $path));
-    }
-    // @codeCoverageIgnoreEnd
-    $destination = 'public://' . basename($path);
-    if (!empty($uri)) {
-      $destination = $uri;
-      $directory = dirname($destination);
-      $dir = \Drupal::service('file_system')->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY + FileSystemInterface::MODIFY_PERMISSIONS);
-      // @codeCoverageIgnoreStart
-      if (!$dir) {
-        throw new \RuntimeException(sprintf('Unable to prepare directory "%s".', $directory));
-      }
-      // @codeCoverageIgnoreEnd
-    }
-
-    $content = file_get_contents($path);
-    // @codeCoverageIgnoreStart
-    if ($content === FALSE) {
-      throw new \RuntimeException(sprintf('Unable to read file "%s".', $path));
-    }
-    // @codeCoverageIgnoreEnd
-    $entity = \Drupal::service('file.repository')->writeData($content, $destination, FileExists::Replace);
-
-    foreach ($stub->getValues() as $property => $value) {
-      $entity->set($property, $value);
-    }
-
-    $entity->save();
-
-    return $entity;
-  }
-
-  /**
-   * Remove unmanaged files created during the scenario.
-   *
-   * Managed file entities are removed by the shared entity registry cleanup.
-   */
-  #[AfterScenario('@api')]
-  public function fileAfterScenario(AfterScenarioScope $scope): void {
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-    foreach ($this->filesUnmanagedUris as $uri) {
-      @unlink($uri);
     }
   }
 
@@ -231,27 +151,6 @@ trait FileTrait {
       $entities = $storage->loadMultiple($ids);
       $storage->delete($entities);
     }
-  }
-
-  /**
-   * Load multiple files with specified conditions.
-   *
-   * @param array<string, string> $conditions
-   *   Conditions keyed by field names.
-   *
-   * @return array<int, string>
-   *   Array of file ids.
-   */
-  protected function fileLoadMultiple(array $conditions = []): array {
-    $query = \Drupal::entityQuery('file')->accessCheck(FALSE);
-
-    foreach ($conditions as $k => $v) {
-      $and = $query->andConditionGroup();
-      $and->condition($k, $v);
-      $query->condition($and);
-    }
-
-    return $query->execute();
   }
 
   /**
@@ -360,6 +259,107 @@ trait FileTrait {
     if (str_contains($file_content, $content)) {
       throw new ExpectationException(sprintf('File contents "%s" contains "%s", but should not.', $file_content, $content), $this->getSession()->getDriver());
     }
+  }
+
+  /**
+   * Create a single managed file.
+   *
+   * @param string $path
+   *   The source file path relative to 'files_path'.
+   * @param \Drupal\Driver\Entity\EntityStub $stub
+   *   Entity fields stub (must not contain 'path' or 'uri').
+   * @param string|null $uri
+   *   Optional destination URI. Defaults to 'public://filename'.
+   *
+   * @return \Drupal\file\FileInterface
+   *   Created file entity.
+   */
+  protected function fileCreateManagedSingle(string $path, EntityStub $stub, ?string $uri = NULL): FileInterface {
+    $this->parseEntityFields($stub);
+
+    $entity = $this->fileCreateEntity($path, $stub, $uri);
+
+    $this->helperEntityRegister($entity);
+
+    return $entity;
+  }
+
+  /**
+   * Create file entity.
+   *
+   * @param string $path
+   *   The source file path relative to 'files_path'.
+   * @param \Drupal\Driver\Entity\EntityStub $stub
+   *   Entity fields stub.
+   * @param string|null $uri
+   *   Optional destination URI. Defaults to 'public://filename'.
+   *
+   * @return \Drupal\file\FileInterface
+   *   Created file entity.
+   */
+  protected function fileCreateEntity(string $path, EntityStub $stub, ?string $uri = NULL): FileInterface {
+    $path = ltrim($path, '/');
+
+    if (!empty($this->getMinkParameter('files_path'))) {
+      $full_path = rtrim((string) realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $path;
+      if (is_file($full_path)) {
+        $path = $full_path;
+      }
+    }
+
+    // @codeCoverageIgnoreStart
+    if (!is_readable($path)) {
+      throw new \RuntimeException(sprintf('Unable to find file "%s".', $path));
+    }
+    // @codeCoverageIgnoreEnd
+    $destination = 'public://' . basename($path);
+    if (!empty($uri)) {
+      $destination = $uri;
+      $directory = dirname($destination);
+      $dir = \Drupal::service('file_system')->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY + FileSystemInterface::MODIFY_PERMISSIONS);
+      // @codeCoverageIgnoreStart
+      if (!$dir) {
+        throw new \RuntimeException(sprintf('Unable to prepare directory "%s".', $directory));
+      }
+      // @codeCoverageIgnoreEnd
+    }
+
+    $content = file_get_contents($path);
+    // @codeCoverageIgnoreStart
+    if ($content === FALSE) {
+      throw new \RuntimeException(sprintf('Unable to read file "%s".', $path));
+    }
+    // @codeCoverageIgnoreEnd
+    $entity = \Drupal::service('file.repository')->writeData($content, $destination, FileExists::Replace);
+
+    foreach ($stub->getValues() as $property => $value) {
+      $entity->set($property, $value);
+    }
+
+    $entity->save();
+
+    return $entity;
+  }
+
+  /**
+   * Load multiple files with specified conditions.
+   *
+   * @param array<string, string> $conditions
+   *   Conditions keyed by field names.
+   *
+   * @return array<int, string>
+   *   Array of file ids.
+   */
+  protected function fileLoadMultiple(array $conditions = []): array {
+    $query = \Drupal::entityQuery('file')->accessCheck(FALSE);
+
+    foreach ($conditions as $k => $v) {
+      $and = $query->andConditionGroup();
+      $and->condition($k, $v);
+      $query->condition($and);
+    }
+
+    return $query->execute();
   }
 
 }

--- a/src/Drupal/HelperTrait.php
+++ b/src/Drupal/HelperTrait.php
@@ -64,6 +64,20 @@ trait HelperTrait {
   protected array $helperEntityRegistry = [];
 
   /**
+   * Delete registered entities in reverse creation order at scenario teardown.
+   */
+  #[AfterScenario('@api')]
+  public function helperEntityCleanupAfterScenario(AfterScenarioScope $scope): void {
+    $scenario = $scope->getScenario();
+
+    if ($scenario->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+
+    $this->helperEntityCleanupRun($this->helperEntityCleanupSkippedTypes($scenario->getTags()));
+  }
+
+  /**
    * Register a saved entity.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
@@ -87,20 +101,6 @@ trait HelperTrait {
    */
   protected function helperEntityRegisterId(string $entity_type_id, int|string $entity_id): void {
     $this->helperEntityRegistry[] = [$entity_type_id, $entity_id];
-  }
-
-  /**
-   * Delete registered entities in reverse creation order at scenario teardown.
-   */
-  #[AfterScenario('@api')]
-  public function helperEntityCleanupAfterScenario(AfterScenarioScope $scope): void {
-    $scenario = $scope->getScenario();
-
-    if ($scenario->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-
-    $this->helperEntityCleanupRun($this->helperEntityCleanupSkippedTypes($scenario->getTags()));
   }
 
   /**

--- a/src/Drupal/QueueTrait.php
+++ b/src/Drupal/QueueTrait.php
@@ -28,6 +28,23 @@ trait QueueTrait {
   protected array $queueNames = [];
 
   /**
+   * Clean up queues after scenario.
+   */
+  #[AfterScenario('@queue')]
+  public function queueAfterScenario(AfterScenarioScope $scope): void {
+    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
+      return;
+    }
+
+    foreach ($this->queueNames as $queue_name) {
+      $queue_instance = \Drupal::service('queue')->get($queue_name);
+      $queue_instance->deleteQueue();
+    }
+
+    $this->queueNames = [];
+  }
+
+  /**
    * Empty a queue.
    *
    * @code
@@ -141,23 +158,6 @@ trait QueueTrait {
     if ($actual !== 0) {
       throw new ExpectationException(sprintf('Expected queue "%s" to be empty, but it has %d items.', $queue, $actual), $this->getSession()->getDriver());
     }
-  }
-
-  /**
-   * Clean up queues after scenario.
-   */
-  #[AfterScenario('@queue')]
-  public function queueAfterScenario(AfterScenarioScope $scope): void {
-    if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
-      return;
-    }
-
-    foreach ($this->queueNames as $queue_name) {
-      $queue_instance = \Drupal::service('queue')->get($queue_name);
-      $queue_instance->deleteQueue();
-    }
-
-    $this->queueNames = [];
   }
 
   /**

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -24,15 +24,6 @@ trait TaxonomyTrait {
   use HelperTrait;
 
   /**
-   * {@inheritdoc}
-   */
-  public function createTerms(mixed $vocabulary, TableNode $table): void {
-    $vocabulary = (string) $vocabulary;
-    $this->taxonomyDeleteTerms($vocabulary, $table);
-    parent::createTerms($vocabulary, $table);
-  }
-
-  /**
    * Create taxonomy terms with vertical field format.
    *
    * Supports both single and multiple entity creation using vertical table
@@ -84,6 +75,42 @@ trait TaxonomyTrait {
         $term->delete();
       }
     }
+  }
+
+  /**
+   * Visit specified vocabulary term page.
+   *
+   * @code
+   * When I visit the "fruits" term page with the name "Apple"
+   * @endcode
+   */
+  #[When('I visit the :vocabulary term page with the name :term_name')]
+  public function taxonomyVisitTermPageWithName(string $vocabulary, string $term_name): void {
+    $this->taxonomyVisitActionPageWithName($vocabulary, $term_name);
+  }
+
+  /**
+   * Visit specified vocabulary term edit page.
+   *
+   * @code
+   * When I visit the "fruits" term edit page with the name "Apple"
+   * @endcode
+   */
+  #[When('I visit the :vocabulary term edit page with the name :term_name')]
+  public function taxonomyVisitTermEditPageWithName(string $vocabulary, string $term_name): void {
+    $this->taxonomyVisitActionPageWithName($vocabulary, $term_name, '/edit');
+  }
+
+  /**
+   * Visit specified vocabulary term delete page.
+   *
+   * @code
+   * When I visit the "tags" term delete page with the name "[TEST] Remove"
+   * @endcode
+   */
+  #[When('I visit the :vocabulary term delete page with the name :term_name')]
+  public function taxonomyVisitTermDeletePageWithName(string $vocabulary, string $term_name): void {
+    $this->taxonomyVisitActionPageWithName($vocabulary, $term_name, '/delete');
   }
 
   /**
@@ -178,39 +205,12 @@ trait TaxonomyTrait {
   }
 
   /**
-   * Visit specified vocabulary term page.
-   *
-   * @code
-   * When I visit the "fruits" term page with the name "Apple"
-   * @endcode
+   * {@inheritdoc}
    */
-  #[When('I visit the :vocabulary term page with the name :term_name')]
-  public function taxonomyVisitTermPageWithName(string $vocabulary, string $term_name): void {
-    $this->taxonomyVisitActionPageWithName($vocabulary, $term_name);
-  }
-
-  /**
-   * Visit specified vocabulary term edit page.
-   *
-   * @code
-   * When I visit the "fruits" term edit page with the name "Apple"
-   * @endcode
-   */
-  #[When('I visit the :vocabulary term edit page with the name :term_name')]
-  public function taxonomyVisitTermEditPageWithName(string $vocabulary, string $term_name): void {
-    $this->taxonomyVisitActionPageWithName($vocabulary, $term_name, '/edit');
-  }
-
-  /**
-   * Visit specified vocabulary term delete page.
-   *
-   * @code
-   * When I visit the "tags" term delete page with the name "[TEST] Remove"
-   * @endcode
-   */
-  #[When('I visit the :vocabulary term delete page with the name :term_name')]
-  public function taxonomyVisitTermDeletePageWithName(string $vocabulary, string $term_name): void {
-    $this->taxonomyVisitActionPageWithName($vocabulary, $term_name, '/delete');
+  public function createTerms(mixed $vocabulary, TableNode $table): void {
+    $vocabulary = (string) $vocabulary;
+    $this->taxonomyDeleteTerms($vocabulary, $table);
+    parent::createTerms($vocabulary, $table);
   }
 
   /**

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -156,6 +156,64 @@ trait UserTrait {
   }
 
   /**
+   * Create a single role with specified permissions.
+   *
+   * @code
+   * Given the role "Content Manager" has the permissions "access content, create article content, edit any article content"
+   * @endcode
+   */
+  #[Given('the role :role_name has the permissions :permissions')]
+  public function userCreateRole(string $role_name, string $permissions): void {
+    $permissions = $this->helperSplitCommaSeparated($permissions);
+
+    $rid = strtolower($role_name);
+    $role_name = trim($role_name);
+
+    $existing_role = Role::load($rid);
+    if ($existing_role) {
+      $existing_role->delete();
+    }
+
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = \Drupal::entityTypeManager()->getStorage('user_role')->create([
+      'id' => $rid,
+      'label' => $role_name,
+    ]);
+    $saved = $role->save();
+
+    // @codeCoverageIgnoreStart
+    if ($saved !== SAVED_NEW) {
+      throw new \RuntimeException(sprintf('Failed to create a role with "%s" permission(s).', implode(', ', $permissions)));
+    }
+    // @codeCoverageIgnoreEnd
+    $this->roles[] = (string) $role->id();
+
+    user_role_grant_permissions($role->id(), $permissions);
+  }
+
+  /**
+   * Create multiple roles from the specified table.
+   *
+   * @code
+   * Given the following roles exist:
+   *   | name              | permissions                              |
+   *   | Content Editor    | access content, create article content   |
+   *   | Content Approver  | access content, edit any article content |
+   * @endcode
+   */
+  #[Given('the following roles exist:')]
+  public function userCreateRoles(TableNode $table): void {
+    foreach ($table->getHash() as $hash) {
+      if (!isset($hash['name'])) {
+        throw new \RuntimeException('Missing required column "name".');
+      }
+
+      $permissions = $hash['permissions'] ?: '';
+      $this->userCreateRole($hash['name'], $permissions);
+    }
+  }
+
+  /**
    * Visit the profile page of the specified user.
    *
    * @code
@@ -269,24 +327,6 @@ trait UserTrait {
   }
 
   /**
-   * Visit the password reset link for a given user object.
-   *
-   * @param \Drupal\user\UserInterface $user
-   *   The user object.
-   */
-  protected function userVisitPasswordResetLinkForUser(UserInterface $user): void {
-    $timestamp = \Drupal::time()->getRequestTime();
-
-    $path = Url::fromRoute('user.reset', [
-      'uid' => $user->id(),
-      'timestamp' => $timestamp,
-      'hash' => \Drupal::service(OneTimeAuthentication::class)->generateHmac($user, $timestamp),
-    ])->toString();
-
-    $this->visitPath($path);
-  }
-
-  /**
    * Assert that a user has roles assigned.
    *
    * @code
@@ -355,29 +395,6 @@ trait UserTrait {
   }
 
   /**
-   * Check whether a user with the given email address exists.
-   *
-   * Performs a case-insensitive match against the user mail property.
-   *
-   * @param string $mail
-   *   The email address to check.
-   *
-   * @return bool
-   *   TRUE if a user with the email exists, FALSE otherwise.
-   */
-  protected function userExistsByMail(string $mail): bool {
-    $ids = \Drupal::entityTypeManager()
-      ->getStorage('user')
-      ->getQuery()
-      ->accessCheck(FALSE)
-      ->condition('mail', $mail, 'LIKE')
-      ->range(0, 1)
-      ->execute();
-
-    return !empty($ids);
-  }
-
-  /**
    * Assert that a user is blocked.
    *
    * @code
@@ -407,6 +424,47 @@ trait UserTrait {
     if (!$user->isActive()) {
       throw new ExpectationException(sprintf('User "%s" is expected to not be blocked, but they are.', $name), $this->getSession()->getDriver());
     }
+  }
+
+  /**
+   * Visit the password reset link for a given user object.
+   *
+   * @param \Drupal\user\UserInterface $user
+   *   The user object.
+   */
+  protected function userVisitPasswordResetLinkForUser(UserInterface $user): void {
+    $timestamp = \Drupal::time()->getRequestTime();
+
+    $path = Url::fromRoute('user.reset', [
+      'uid' => $user->id(),
+      'timestamp' => $timestamp,
+      'hash' => \Drupal::service(OneTimeAuthentication::class)->generateHmac($user, $timestamp),
+    ])->toString();
+
+    $this->visitPath($path);
+  }
+
+  /**
+   * Check whether a user with the given email address exists.
+   *
+   * Performs a case-insensitive match against the user mail property.
+   *
+   * @param string $mail
+   *   The email address to check.
+   *
+   * @return bool
+   *   TRUE if a user with the email exists, FALSE otherwise.
+   */
+  protected function userExistsByMail(string $mail): bool {
+    $ids = \Drupal::entityTypeManager()
+      ->getStorage('user')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('mail', $mail, 'LIKE')
+      ->range(0, 1)
+      ->execute();
+
+    return !empty($ids);
   }
 
   /**
@@ -486,64 +544,6 @@ trait UserTrait {
     }
 
     $this->visitPath('/user/' . $uid . $action_subpath);
-  }
-
-  /**
-   * Create a single role with specified permissions.
-   *
-   * @code
-   * Given the role "Content Manager" has the permissions "access content, create article content, edit any article content"
-   * @endcode
-   */
-  #[Given('the role :role_name has the permissions :permissions')]
-  public function userCreateRole(string $role_name, string $permissions): void {
-    $permissions = $this->helperSplitCommaSeparated($permissions);
-
-    $rid = strtolower($role_name);
-    $role_name = trim($role_name);
-
-    $existing_role = Role::load($rid);
-    if ($existing_role) {
-      $existing_role->delete();
-    }
-
-    /** @var \Drupal\user\RoleInterface $role */
-    $role = \Drupal::entityTypeManager()->getStorage('user_role')->create([
-      'id' => $rid,
-      'label' => $role_name,
-    ]);
-    $saved = $role->save();
-
-    // @codeCoverageIgnoreStart
-    if ($saved !== SAVED_NEW) {
-      throw new \RuntimeException(sprintf('Failed to create a role with "%s" permission(s).', implode(', ', $permissions)));
-    }
-    // @codeCoverageIgnoreEnd
-    $this->roles[] = (string) $role->id();
-
-    user_role_grant_permissions($role->id(), $permissions);
-  }
-
-  /**
-   * Create multiple roles from the specified table.
-   *
-   * @code
-   * Given the following roles exist:
-   *   | name              | permissions                              |
-   *   | Content Editor    | access content, create article content   |
-   *   | Content Approver  | access content, edit any article content |
-   * @endcode
-   */
-  #[Given('the following roles exist:')]
-  public function userCreateRoles(TableNode $table): void {
-    foreach ($table->getHash() as $hash) {
-      if (!isset($hash['name'])) {
-        throw new \RuntimeException('Missing required column "name".');
-      }
-
-      $permissions = $hash['permissions'] ?: '';
-      $this->userCreateRole($hash['name'], $permissions);
-    }
   }
 
 }

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -82,32 +82,6 @@ trait WatchdogTrait {
   }
 
   /**
-   * Parse scenario tags into message types.
-   *
-   * @code
-   * @watchdog:my_module_type @watchdog:my_other_module_type
-   * @endcode
-   *
-   * @param array<int, string> $tags
-   *   Array of scenario tags.
-   * @param string $prefix
-   *   Optional tag prefix to filter by.
-   *
-   * @return array<int, string>
-   *   Array of message types. 'php' is always added to the list.
-   */
-  protected function watchdogParseMessageTypes(array $tags = [], string $prefix = 'watchdog:'): array {
-    $types = [];
-    foreach ($tags as $tag) {
-      if (str_starts_with((string) $tag, $prefix) && strlen((string) $tag) > strlen($prefix)) {
-        $types[] = substr((string) $tag, strlen($prefix));
-      }
-    }
-
-    return array_unique(array_merge($types, ['php']));
-  }
-
-  /**
    * Check for every error logged since the scenario started, on its last step.
    *
    * Add @error to any scenario that is expected to trigger an error - the
@@ -164,6 +138,32 @@ trait WatchdogTrait {
     }
 
     $this->watchdogAssertNotHasErrors($context);
+  }
+
+  /**
+   * Parse scenario tags into message types.
+   *
+   * @code
+   * @watchdog:my_module_type @watchdog:my_other_module_type
+   * @endcode
+   *
+   * @param array<int, string> $tags
+   *   Array of scenario tags.
+   * @param string $prefix
+   *   Optional tag prefix to filter by.
+   *
+   * @return array<int, string>
+   *   Array of message types. 'php' is always added to the list.
+   */
+  protected function watchdogParseMessageTypes(array $tags = [], string $prefix = 'watchdog:'): array {
+    $types = [];
+    foreach ($tags as $tag) {
+      if (str_starts_with((string) $tag, $prefix) && strlen((string) $tag) > strlen($prefix)) {
+        $types[] = substr((string) $tag, strlen($prefix));
+      }
+    }
+
+    return array_unique(array_merge($types, ['php']));
   }
 
   /**

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -21,28 +21,169 @@ use Behat\Step\When;
 trait ElementTrait {
 
   /**
-   * Whether to scroll elements to the center of the viewport.
+   * Accept confirmation dialogs appearing on the page.
    *
-   * Returns TRUE (default) to use scrollIntoView() with center alignment,
-   * which positions the element in the middle of the viewport. This avoids
-   * interaction failures caused by sticky headers, admin toolbars, or fixed
-   * navigation.
-   *
-   * Returns FALSE to use the scrollIntoView(true) behavior, which aligns
-   * the element to the top of the viewport.
-   *
-   * Override this method in the context class to change the behavior:
    * @code
-   * class FeatureContext extends DrupalContext {
-   *   use ElementTrait;
-   *   protected function elementGetScrollIntoViewCenter(): bool {
-   *     return FALSE;
-   *   }
-   * }
+   * Given confirmation dialogs are accepted
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Given('confirmation dialogs are accepted')]
+  public function elementAcceptConfirmation(): void {
+    $this->getSession()->getDriver()->executeScript('window.confirm = function(){return true;};');
+  }
+
+  /**
+   * Do not accept confirmation dialogs appearing on the page.
+   *
+   * @code
+   * Given confirmation dialogs are declined
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Given('confirmation dialogs are declined')]
+  public function elementDeclineConfirmation(): void {
+    $this->getSession()->getDriver()->executeScript('window.confirm = function(){return false;};');
+  }
+
+  /**
+   * Click on the element defined by the selector.
+   *
+   * @code
+   * When I click on the element ".button"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[When('I click on the element :selector')]
+  public function elementClick(string $selector): void {
+    $element = $this->getSession()->getPage()->find('css', $selector);
+
+    if (!$element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    $element->click();
+  }
+
+  /**
+   * Click on the element at the 1-based index among all selector matches.
+   *
+   * Useful when a selector matches several repeated components (cards, rows,
+   * menu items) and only the Nth one should be clicked.
+   *
+   * @code
+   * When I click on the element ".card" with the index 2
+   * @endcode
+   *
+   * @javascript
+   */
+  #[When('I click on the element :selector with the index :index')]
+  public function elementClickByIndex(string $selector, int $index): void {
+    $elements = $this->getSession()->getPage()->findAll('css', $selector);
+    $this->elementFindNthOrFail($elements, $index, sprintf('element matching "%s"', $selector))->click();
+  }
+
+  /**
+   * Follow the link at the 1-based index among all links with the text.
+   *
+   * @code
+   * When I follow the link "Read more" with the index 2
    * @endcode
    */
-  protected function elementGetScrollIntoViewCenter(): bool {
-    return TRUE;
+  #[When('I follow the link :text with the index :index')]
+  public function elementFollowLinkByIndex(string $text, int $index): void {
+    $elements = $this->getSession()->getPage()->findAll('named', ['link', $text]);
+    $this->elementFindNthOrFail($elements, $index, sprintf('link "%s"', $text))->click();
+  }
+
+  /**
+   * Press the button at the 1-based index among all buttons with the label.
+   *
+   * @code
+   * When I press the button "Delete" with the index 2
+   * @endcode
+   */
+  #[When('I press the button :label with the index :index')]
+  public function elementPressButtonByIndex(string $label, int $index): void {
+    $elements = $this->getSession()->getPage()->findAll('named', ['button', $label]);
+    $this->elementFindNthOrFail($elements, $index, sprintf('button "%s"', $label))->press();
+  }
+
+  /**
+   * When I trigger the JS event :event on the element :selector.
+   *
+   * @code
+   * When I trigger the JS event "click" on the element "#submit-button"
+   * @endcode
+   */
+  #[When('I trigger the JS event :event on the element :selector')]
+  public function elementTriggerEvent(string $event, string $selector): void {
+    $event_js = json_encode($event, JSON_UNESCAPED_SLASHES);
+    $this->elementExecuteJs($selector, sprintf('var event = new Event(%s, { bubbles: true }); {{ELEMENT}}.dispatchEvent(event); return true;', $event_js));
+  }
+
+  /**
+   * Scroll to an element with ID.
+   *
+   * By default, scrolls the element to the center of the viewport. Override
+   * the elementGetScrollIntoViewCenter() method to return FALSE to use the
+   * legacy behavior that aligns the element to the top of the viewport.
+   *
+   * @code
+   * When I scroll to the element "#footer"
+   * @endcode
+   */
+  #[When('I scroll to the element :selector')]
+  public function elementScrollTo(string $selector): void {
+    if ($this->elementGetScrollIntoViewCenter()) {
+      $this->elementExecuteJs($selector, '{{ELEMENT}}.scrollIntoView({ behavior: "auto", block: "center", inline: "center" });');
+    }
+    else {
+      $this->elementExecuteJs($selector, '{{ELEMENT}}.scrollIntoView(true);');
+    }
+  }
+
+  /**
+   * Hover over an element identified by CSS selector.
+   *
+   * @code
+   * When I hover over the element ".menu-item"
+   * When I hover over the element "#tooltip-trigger"
+   * @endcode
+   */
+  #[When('I hover over the element :selector')]
+  public function elementHover(string $selector): void {
+    $element = $this->getSession()->getPage()->find('css', $selector);
+
+    if ($element === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    $element->mouseOver();
+  }
+
+  /**
+   * Focus on an element by CSS selector.
+   *
+   * @code
+   * When I focus on the element "#edit-name"
+   * When I focus on the element ".form-text"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[When('I focus on the element :selector')]
+  public function elementFocus(string $selector): void {
+    $element = $this->getSession()->getPage()->find('css', $selector);
+
+    if (!$element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    $this->elementExecuteJs($selector, '{{ELEMENT}}.focus();');
   }
 
   /**
@@ -162,71 +303,6 @@ trait ElementTrait {
   }
 
   /**
-   * Assert an element with selector and attribute with a value.
-   *
-   * @param string $selector
-   *   The CSS selector.
-   * @param string $attribute
-   *   The attribute name.
-   * @param mixed $value
-   *   The value to assert.
-   * @param bool $is_exact
-   *   Whether to assert the value exactly.
-   * @param bool $is_inverted
-   *   Whether to assert the value is not present.
-   *
-   * @throws \Behat\Mink\Exception\ElementNotFoundException
-   *   If no element matches the selector.
-   * @throws \Behat\Mink\Exception\ExpectationException
-   *   If the attribute or its value does not match the expectation.
-   */
-  protected function elementAssertAttributeWithValue(string $selector, string $attribute, mixed $value, bool $is_exact, bool $is_inverted): void {
-    $page = $this->getSession()->getPage();
-    $elements = $page->findAll('css', $selector);
-
-    if (empty($elements)) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
-    }
-
-    $attribute_found = FALSE;
-    $attribute_value_found = FALSE;
-    foreach ($elements as $element) {
-      $attribute_value = (string) $element->getAttribute($attribute);
-      if (!empty($attribute_value)) {
-        $attribute_found = TRUE;
-        if ($is_exact) {
-          if ($attribute_value === (string) $value) {
-            $attribute_value_found = TRUE;
-            break;
-          }
-        }
-        elseif (str_contains($attribute_value, (string) $value)) {
-          $attribute_value_found = TRUE;
-          break;
-        }
-      }
-    }
-
-    if (!$attribute_found) {
-      throw new ExpectationException(sprintf('The "%s" attribute does not exist on the element "%s".', $attribute, $selector), $this->getSession()->getDriver());
-    }
-
-    if ($is_inverted && $attribute_value_found) {
-      $message = $is_exact
-        ? sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it should not.', $attribute, $selector, $value)
-        : sprintf('The "%s" attribute exists on the element "%s" with a value containing "%s", but it should not.', $attribute, $selector, $value);
-      throw new ExpectationException($message, $this->getSession()->getDriver());
-    }
-
-    if (!$is_inverted && !$attribute_value_found) {
-      $message = $is_exact
-        ? sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it does not have a value "%s".', $attribute, $selector, $attribute_value, $value)
-        : sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it does not contain a value "%s".', $attribute, $selector, $attribute_value, $value);
-      throw new ExpectationException($message, $this->getSession()->getDriver());
-    }
-  }
-
-  /**
    * Assert an element has a computed CSS property with a value.
    *
    * The value is compared against the value computed by the browser, not
@@ -290,6 +366,416 @@ trait ElementTrait {
   #[Then('the element :selector should not have the CSS property :property with the value containing :value')]
   public function elementAssertNotHasCssPropertyContainingValue(string $selector, string $property, string $value): void {
     $this->elementAssertCssProperty($selector, $property, $value, FALSE, TRUE);
+  }
+
+  /**
+   * Assert that one element stacks above another.
+   *
+   * Compares the effective paint order rather than the `z-index` property:
+   * a `z-index` read from an element is only meaningful within its own
+   * stacking context, so a child of a stacking-context-forming ancestor can
+   * carry a high `z-index` and still paint below an element with a lower one.
+   *
+   * The comparison walks the stacking context chain of both elements, finds
+   * the context they share, and compares the two participants that branch off
+   * it, using document order to break a tie. Painting order within a single
+   * stacking context (floats, inline content and positioned descendants) is
+   * not modelled.
+   *
+   * @code
+   * Then the element "#modal" should stack above the element "#page-header"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector1 should stack above the element :selector2')]
+  public function elementAssertStacksAbove(string $selector1, string $selector2): void {
+    $this->elementAssertStackingOrder($selector1, $selector2, TRUE);
+  }
+
+  /**
+   * Assert that one element stacks below another.
+   *
+   * @code
+   * Then the element "#page-header" should stack below the element "#modal"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector1 should stack below the element :selector2')]
+  public function elementAssertStacksBelow(string $selector1, string $selector2): void {
+    $this->elementAssertStackingOrder($selector1, $selector2, FALSE);
+  }
+
+  /**
+   * Assert the element :selector should be at the top of the viewport.
+   *
+   * @code
+   * Then the element "#header" should be at the top of the viewport
+   * @endcode
+   */
+  #[Then('the element :selector should be at the top of the viewport')]
+  public function elementAssertElementAtTopOfViewport(string $selector): void {
+    $result = $this->elementExecuteJs($selector, 'var rect = {{ELEMENT}}.getBoundingClientRect(); return (rect.top >= 0 && rect.top <= window.innerHeight);');
+    if (!$result) {
+      throw new ExpectationException(sprintf('Element with selector "%s" is not at the top of the viewport.', $selector), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert the element :selector should be centered in the viewport.
+   *
+   * Checks that the vertical center of the element is within the middle third
+   * of the viewport.
+   *
+   * @code
+   * Then the element "#content" should be centered in the viewport
+   * @endcode
+   */
+  #[Then('the element :selector should be centered in the viewport')]
+  public function elementAssertElementCenteredInViewport(string $selector): void {
+    $result = $this->elementExecuteJs($selector, 'var rect = {{ELEMENT}}.getBoundingClientRect(); var element_center = rect.top + rect.height / 2; var viewport_third = window.innerHeight / 3; return (element_center >= viewport_third && element_center <= viewport_third * 2);');
+    if (!$result) {
+      throw new ExpectationException(sprintf('Element with selector "%s" is not centered in the viewport.', $selector), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that an element is pinned to the top of the viewport.
+   *
+   * The element's top edge has to sit within 2 pixels of the viewport top,
+   * which absorbs the sub-pixel offsets that normal rendering produces. Use
+   * the step with an explicit tolerance for layouts that need more slack.
+   *
+   * This asserts where the element currently renders, so scroll the page
+   * first to tell a pinned element apart from one that merely starts at the
+   * top of the document.
+   *
+   * @code
+   * When I scroll to the element "#footer"
+   * Then the element "#header" should be pinned to the top of the viewport
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should be pinned to the top of the viewport')]
+  public function elementAssertPinnedToTop(string $selector): void {
+    $this->elementAssertPinnedToTopWithin($selector, 2, FALSE);
+  }
+
+  /**
+   * Assert that an element is pinned to the top of the viewport within a tolerance.
+   *
+   * @code
+   * Then the element "#header" should be pinned to the top of the viewport within 10 pixels
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should be pinned to the top of the viewport within :tolerance pixels')]
+  public function elementAssertPinnedToTopWithTolerance(string $selector, int $tolerance): void {
+    $this->elementAssertPinnedToTopWithin($selector, $tolerance, FALSE);
+  }
+
+  /**
+   * Assert that an element is not pinned to the top of the viewport.
+   *
+   * @code
+   * When I scroll to the element "#footer"
+   * Then the element "#header" should not be pinned to the top of the viewport
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should not be pinned to the top of the viewport')]
+  public function elementAssertNotPinnedToTop(string $selector): void {
+    $this->elementAssertPinnedToTopWithin($selector, 2, TRUE);
+  }
+
+  /**
+   * Assert that the element has keyboard focus.
+   *
+   * Verifies that the element matched by the selector is the current
+   * `document.activeElement`. This is the canonical check for tab-order tests,
+   * skip-link behaviour, modal focus traps, autofocus, and focus-after-action
+   * flows.
+   *
+   * @code
+   * Then the element "#edit-name" should have keyboard focus
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should have keyboard focus')]
+  public function elementAssertHasKeyboardFocus(string $selector): void {
+    $this->elementAssertKeyboardFocus($selector, FALSE);
+  }
+
+  /**
+   * Assert that the element does not have keyboard focus.
+   *
+   * @code
+   * Then the element "#edit-name" should not have keyboard focus
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should not have keyboard focus')]
+  public function elementAssertNotHasKeyboardFocus(string $selector): void {
+    $this->elementAssertKeyboardFocus($selector, TRUE);
+  }
+
+  /**
+   * Assert that the element has a visible focus indicator.
+   *
+   * Verifies that the element renders a visible focus indicator via either
+   * a CSS outline (non-`none` outline-style with a width greater than 0) or
+   * a non-`none` box-shadow. Guards WCAG 2.4.7 (Focus Visible) and catches
+   * accidental `outline: none` regressions introduced by stylesheet changes.
+   *
+   * @code
+   * Then the element "#edit-name" should have a visible focus outline
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should have a visible focus outline')]
+  public function elementAssertHasVisibleFocusOutline(string $selector): void {
+    $this->elementAssertVisibleFocusOutline($selector, FALSE);
+  }
+
+  /**
+   * Assert that the element does not have a visible focus indicator.
+   *
+   * @code
+   * Then the element "#decorative-icon" should not have a visible focus outline
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should not have a visible focus outline')]
+  public function elementAssertNotHasVisibleFocusOutline(string $selector): void {
+    $this->elementAssertVisibleFocusOutline($selector, TRUE);
+  }
+
+  /**
+   * Assert that element with specified CSS is visible on page.
+   *
+   * @code
+   * Then the element ".alert-success" should be displayed
+   * @endcode
+   */
+  #[Then('the element :selector should be displayed')]
+  public function elementAssertVisible(string $selector): void {
+    $page = $this->getSession()->getPage();
+    $elements = $page->findAll('css', $selector);
+
+    if ($elements === []) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    foreach ($elements as $element) {
+      if ($element->isVisible()) {
+        return;
+      }
+    }
+
+    throw new ExpectationException(sprintf('None of the elements defined by "%s" selector are visible on the page.', $selector), $this->getSession()->getDriver());
+  }
+
+  /**
+   * Assert that element with specified CSS is not visible on page.
+   *
+   * @code
+   * Then the element ".error-message" should not be displayed
+   * @endcode
+   */
+  #[Then('the element :selector should not be displayed')]
+  public function elementAssertNotVisible(string $selector): void {
+    $page = $this->getSession()->getPage();
+    $elements = $page->findAll('css', $selector);
+
+    foreach ($elements as $element) {
+      if ($element->isVisible()) {
+        throw new ExpectationException(sprintf('Element defined by "%s" selector is visible on the page, but should not be.', $selector), $this->getSession()->getDriver());
+      }
+    }
+  }
+
+  /**
+   * Assert that element with specified CSS is displayed within a viewport.
+   *
+   * @code
+   * Then the element ".hero-banner" should be displayed within a viewport
+   * @endcode
+   */
+  #[Then('the element :selector should be displayed within a viewport')]
+  public function elementAssertVisuallyVisible(string $selector): void {
+    $this->elementAssertVisible($selector);
+
+    if (!$this->elementIsVisuallyVisible($selector, 0)) {
+      throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is not displayed within a viewport.', $selector), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that element with specified CSS is displayed within a viewport with a top offset.
+   *
+   * @code
+   * Then the element ".sticky-header" should be displayed within a viewport with a top offset of 50 pixels
+   * @endcode
+   */
+  #[Then('the element :selector should be displayed within a viewport with a top offset of :offset pixels')]
+  public function elementAssertVisuallyVisibleWithOffset(string $selector, int $offset): void {
+    $this->elementAssertVisible($selector);
+    if (!$this->elementIsVisuallyVisible($selector, $offset)) {
+      throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is not displayed within a viewport with a top offset of %d pixels.', $selector, $offset), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that element with specified CSS is not displayed within a viewport with a top offset.
+   *
+   * @code
+   * Then the element ".below-fold-content" should not be displayed within a viewport with a top offset of 0 pixels
+   * @endcode
+   */
+  #[Then('the element :selector should not be displayed within a viewport with a top offset of :offset pixels')]
+  public function elementAssertNotVisuallyVisibleWithOffset(string $selector, int $offset): void {
+    if ($this->elementIsVisuallyVisible($selector, $offset)) {
+      throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is displayed within a viewport with a top offset of %d pixels, but should not be.', $selector, $offset), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that element with specified CSS is visually hidden on page.
+   *
+   * Visually hidden means either:
+   * - element is not rendered in the layout (i.e., CSS is "display: none").
+   * - element is rendered in the layout, but not visible to the viewer (i.e.,
+   *   when one of the screen reader-only techniques is used).
+   *
+   * @code
+   * Then the element ".visually-hidden" should not be displayed within a viewport
+   * @endcode
+   */
+  #[Then('the element :selector should not be displayed within a viewport')]
+  public function elementAssertNotVisuallyVisible(string $selector, int $offset = 0): void {
+    if ($this->elementIsVisuallyVisible($selector, $offset)) {
+      throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is displayed within a viewport, but should not be.', $selector), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert the number of elements matching a selector within a parent element.
+   *
+   * @code
+   * Then the element "#main-nav" should contain 3 elements matching ".menu-item"
+   * @endcode
+   */
+  #[Then('the element :parent should contain :count element(s) matching :selector')]
+  public function elementAssertChildElementCount(string $parent, int $count, string $selector): void {
+    $parent_element = $this->getSession()->getPage()->find('css', $parent);
+
+    if (!$parent_element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $parent);
+    }
+
+    $actual = count($parent_element->findAll('css', $selector));
+
+    if ($actual !== $count) {
+      throw new ExpectationException(sprintf('Expected the element "%s" to contain %d element(s) matching "%s", but found %d.', $parent, $count, $selector, $actual), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Whether to scroll elements to the center of the viewport.
+   *
+   * Returns TRUE (default) to use scrollIntoView() with center alignment,
+   * which positions the element in the middle of the viewport. This avoids
+   * interaction failures caused by sticky headers, admin toolbars, or fixed
+   * navigation.
+   *
+   * Returns FALSE to use the scrollIntoView(true) behavior, which aligns
+   * the element to the top of the viewport.
+   *
+   * Override this method in the context class to change the behavior:
+   * @code
+   * class FeatureContext extends DrupalContext {
+   *   use ElementTrait;
+   *   protected function elementGetScrollIntoViewCenter(): bool {
+   *     return FALSE;
+   *   }
+   * }
+   * @endcode
+   */
+  protected function elementGetScrollIntoViewCenter(): bool {
+    return TRUE;
+  }
+
+  /**
+   * Assert an element with selector and attribute with a value.
+   *
+   * @param string $selector
+   *   The CSS selector.
+   * @param string $attribute
+   *   The attribute name.
+   * @param mixed $value
+   *   The value to assert.
+   * @param bool $is_exact
+   *   Whether to assert the value exactly.
+   * @param bool $is_inverted
+   *   Whether to assert the value is not present.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   *   If no element matches the selector.
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   If the attribute or its value does not match the expectation.
+   */
+  protected function elementAssertAttributeWithValue(string $selector, string $attribute, mixed $value, bool $is_exact, bool $is_inverted): void {
+    $page = $this->getSession()->getPage();
+    $elements = $page->findAll('css', $selector);
+
+    if (empty($elements)) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
+    }
+
+    $attribute_found = FALSE;
+    $attribute_value_found = FALSE;
+    foreach ($elements as $element) {
+      $attribute_value = (string) $element->getAttribute($attribute);
+      if (!empty($attribute_value)) {
+        $attribute_found = TRUE;
+        if ($is_exact) {
+          if ($attribute_value === (string) $value) {
+            $attribute_value_found = TRUE;
+            break;
+          }
+        }
+        elseif (str_contains($attribute_value, (string) $value)) {
+          $attribute_value_found = TRUE;
+          break;
+        }
+      }
+    }
+
+    if (!$attribute_found) {
+      throw new ExpectationException(sprintf('The "%s" attribute does not exist on the element "%s".', $attribute, $selector), $this->getSession()->getDriver());
+    }
+
+    if ($is_inverted && $attribute_value_found) {
+      $message = $is_exact
+        ? sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it should not.', $attribute, $selector, $value)
+        : sprintf('The "%s" attribute exists on the element "%s" with a value containing "%s", but it should not.', $attribute, $selector, $value);
+      throw new ExpectationException($message, $this->getSession()->getDriver());
+    }
+
+    if (!$is_inverted && !$attribute_value_found) {
+      $message = $is_exact
+        ? sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it does not have a value "%s".', $attribute, $selector, $attribute_value, $value)
+        : sprintf('The "%s" attribute exists on the element "%s" with a value "%s", but it does not contain a value "%s".', $attribute, $selector, $attribute_value, $value);
+      throw new ExpectationException($message, $this->getSession()->getDriver());
+    }
   }
 
   /**
@@ -360,45 +846,6 @@ trait ElementTrait {
     }
 
     return strtolower((string) preg_replace('/([a-z0-9])([A-Z])/', '$1-$2', $property));
-  }
-
-  /**
-   * Assert that one element stacks above another.
-   *
-   * Compares the effective paint order rather than the `z-index` property:
-   * a `z-index` read from an element is only meaningful within its own
-   * stacking context, so a child of a stacking-context-forming ancestor can
-   * carry a high `z-index` and still paint below an element with a lower one.
-   *
-   * The comparison walks the stacking context chain of both elements, finds
-   * the context they share, and compares the two participants that branch off
-   * it, using document order to break a tie. Painting order within a single
-   * stacking context (floats, inline content and positioned descendants) is
-   * not modelled.
-   *
-   * @code
-   * Then the element "#modal" should stack above the element "#page-header"
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Then('the element :selector1 should stack above the element :selector2')]
-  public function elementAssertStacksAbove(string $selector1, string $selector2): void {
-    $this->elementAssertStackingOrder($selector1, $selector2, TRUE);
-  }
-
-  /**
-   * Assert that one element stacks below another.
-   *
-   * @code
-   * Then the element "#page-header" should stack below the element "#modal"
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Then('the element :selector1 should stack below the element :selector2')]
-  public function elementAssertStacksBelow(string $selector1, string $selector2): void {
-    $this->elementAssertStackingOrder($selector1, $selector2, FALSE);
   }
 
   /**
@@ -580,91 +1027,6 @@ JS;
   }
 
   /**
-   * Assert the element :selector should be at the top of the viewport.
-   *
-   * @code
-   * Then the element "#header" should be at the top of the viewport
-   * @endcode
-   */
-  #[Then('the element :selector should be at the top of the viewport')]
-  public function elementAssertElementAtTopOfViewport(string $selector): void {
-    $result = $this->elementExecuteJs($selector, 'var rect = {{ELEMENT}}.getBoundingClientRect(); return (rect.top >= 0 && rect.top <= window.innerHeight);');
-    if (!$result) {
-      throw new ExpectationException(sprintf('Element with selector "%s" is not at the top of the viewport.', $selector), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert the element :selector should be centered in the viewport.
-   *
-   * Checks that the vertical center of the element is within the middle third
-   * of the viewport.
-   *
-   * @code
-   * Then the element "#content" should be centered in the viewport
-   * @endcode
-   */
-  #[Then('the element :selector should be centered in the viewport')]
-  public function elementAssertElementCenteredInViewport(string $selector): void {
-    $result = $this->elementExecuteJs($selector, 'var rect = {{ELEMENT}}.getBoundingClientRect(); var element_center = rect.top + rect.height / 2; var viewport_third = window.innerHeight / 3; return (element_center >= viewport_third && element_center <= viewport_third * 2);');
-    if (!$result) {
-      throw new ExpectationException(sprintf('Element with selector "%s" is not centered in the viewport.', $selector), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that an element is pinned to the top of the viewport.
-   *
-   * The element's top edge has to sit within 2 pixels of the viewport top,
-   * which absorbs the sub-pixel offsets that normal rendering produces. Use
-   * the step with an explicit tolerance for layouts that need more slack.
-   *
-   * This asserts where the element currently renders, so scroll the page
-   * first to tell a pinned element apart from one that merely starts at the
-   * top of the document.
-   *
-   * @code
-   * When I scroll to the element "#footer"
-   * Then the element "#header" should be pinned to the top of the viewport
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Then('the element :selector should be pinned to the top of the viewport')]
-  public function elementAssertPinnedToTop(string $selector): void {
-    $this->elementAssertPinnedToTopWithin($selector, 2, FALSE);
-  }
-
-  /**
-   * Assert that an element is pinned to the top of the viewport within a tolerance.
-   *
-   * @code
-   * Then the element "#header" should be pinned to the top of the viewport within 10 pixels
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Then('the element :selector should be pinned to the top of the viewport within :tolerance pixels')]
-  public function elementAssertPinnedToTopWithTolerance(string $selector, int $tolerance): void {
-    $this->elementAssertPinnedToTopWithin($selector, $tolerance, FALSE);
-  }
-
-  /**
-   * Assert that an element is not pinned to the top of the viewport.
-   *
-   * @code
-   * When I scroll to the element "#footer"
-   * Then the element "#header" should not be pinned to the top of the viewport
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Then('the element :selector should not be pinned to the top of the viewport')]
-  public function elementAssertNotPinnedToTop(string $selector): void {
-    $this->elementAssertPinnedToTopWithin($selector, 2, TRUE);
-  }
-
-  /**
    * Assert that an element is pinned to the top of the viewport.
    *
    * @param string $selector
@@ -711,238 +1073,6 @@ JS;
     if ($is_inverted && $is_pinned) {
       throw new ExpectationException(sprintf('Expected element "%s" to not be pinned to the top of the viewport, but its top edge is at %s pixels.', $selector, $top), $this->getSession()->getDriver());
     }
-  }
-
-  /**
-   * Accept confirmation dialogs appearing on the page.
-   *
-   * @code
-   * Given confirmation dialogs are accepted
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Given('confirmation dialogs are accepted')]
-  public function elementAcceptConfirmation(): void {
-    $this->getSession()->getDriver()->executeScript('window.confirm = function(){return true;};');
-  }
-
-  /**
-   * Do not accept confirmation dialogs appearing on the page.
-   *
-   * @code
-   * Given confirmation dialogs are declined
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Given('confirmation dialogs are declined')]
-  public function elementDeclineConfirmation(): void {
-    $this->getSession()->getDriver()->executeScript('window.confirm = function(){return false;};');
-  }
-
-  /**
-   * Click on the element defined by the selector.
-   *
-   * @code
-   * When I click on the element ".button"
-   * @endcode
-   *
-   * @javascript
-   */
-  #[When('I click on the element :selector')]
-  public function elementClick(string $selector): void {
-    $element = $this->getSession()->getPage()->find('css', $selector);
-
-    if (!$element) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
-    }
-
-    $element->click();
-  }
-
-  /**
-   * Click on the element at the 1-based index among all selector matches.
-   *
-   * Useful when a selector matches several repeated components (cards, rows,
-   * menu items) and only the Nth one should be clicked.
-   *
-   * @code
-   * When I click on the element ".card" with the index 2
-   * @endcode
-   *
-   * @javascript
-   */
-  #[When('I click on the element :selector with the index :index')]
-  public function elementClickByIndex(string $selector, int $index): void {
-    $elements = $this->getSession()->getPage()->findAll('css', $selector);
-    $this->elementFindNthOrFail($elements, $index, sprintf('element matching "%s"', $selector))->click();
-  }
-
-  /**
-   * Follow the link at the 1-based index among all links with the text.
-   *
-   * @code
-   * When I follow the link "Read more" with the index 2
-   * @endcode
-   */
-  #[When('I follow the link :text with the index :index')]
-  public function elementFollowLinkByIndex(string $text, int $index): void {
-    $elements = $this->getSession()->getPage()->findAll('named', ['link', $text]);
-    $this->elementFindNthOrFail($elements, $index, sprintf('link "%s"', $text))->click();
-  }
-
-  /**
-   * Press the button at the 1-based index among all buttons with the label.
-   *
-   * @code
-   * When I press the button "Delete" with the index 2
-   * @endcode
-   */
-  #[When('I press the button :label with the index :index')]
-  public function elementPressButtonByIndex(string $label, int $index): void {
-    $elements = $this->getSession()->getPage()->findAll('named', ['button', $label]);
-    $this->elementFindNthOrFail($elements, $index, sprintf('button "%s"', $label))->press();
-  }
-
-  /**
-   * When I trigger the JS event :event on the element :selector.
-   *
-   * @code
-   * When I trigger the JS event "click" on the element "#submit-button"
-   * @endcode
-   */
-  #[When('I trigger the JS event :event on the element :selector')]
-  public function elementTriggerEvent(string $event, string $selector): void {
-    $event_js = json_encode($event, JSON_UNESCAPED_SLASHES);
-    $this->elementExecuteJs($selector, sprintf('var event = new Event(%s, { bubbles: true }); {{ELEMENT}}.dispatchEvent(event); return true;', $event_js));
-  }
-
-  /**
-   * Scroll to an element with ID.
-   *
-   * By default, scrolls the element to the center of the viewport. Override
-   * the elementGetScrollIntoViewCenter() method to return FALSE to use the
-   * legacy behavior that aligns the element to the top of the viewport.
-   *
-   * @code
-   * When I scroll to the element "#footer"
-   * @endcode
-   */
-  #[When('I scroll to the element :selector')]
-  public function elementScrollTo(string $selector): void {
-    if ($this->elementGetScrollIntoViewCenter()) {
-      $this->elementExecuteJs($selector, '{{ELEMENT}}.scrollIntoView({ behavior: "auto", block: "center", inline: "center" });');
-    }
-    else {
-      $this->elementExecuteJs($selector, '{{ELEMENT}}.scrollIntoView(true);');
-    }
-  }
-
-  /**
-   * Hover over an element identified by CSS selector.
-   *
-   * @code
-   * When I hover over the element ".menu-item"
-   * When I hover over the element "#tooltip-trigger"
-   * @endcode
-   */
-  #[When('I hover over the element :selector')]
-  public function elementHover(string $selector): void {
-    $element = $this->getSession()->getPage()->find('css', $selector);
-
-    if ($element === NULL) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
-    }
-
-    $element->mouseOver();
-  }
-
-  /**
-   * Focus on an element by CSS selector.
-   *
-   * @code
-   * When I focus on the element "#edit-name"
-   * When I focus on the element ".form-text"
-   * @endcode
-   *
-   * @javascript
-   */
-  #[When('I focus on the element :selector')]
-  public function elementFocus(string $selector): void {
-    $element = $this->getSession()->getPage()->find('css', $selector);
-
-    if (!$element) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
-    }
-
-    $this->elementExecuteJs($selector, '{{ELEMENT}}.focus();');
-  }
-
-  /**
-   * Assert that the element has keyboard focus.
-   *
-   * Verifies that the element matched by the selector is the current
-   * `document.activeElement`. This is the canonical check for tab-order tests,
-   * skip-link behaviour, modal focus traps, autofocus, and focus-after-action
-   * flows.
-   *
-   * @code
-   * Then the element "#edit-name" should have keyboard focus
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Then('the element :selector should have keyboard focus')]
-  public function elementAssertHasKeyboardFocus(string $selector): void {
-    $this->elementAssertKeyboardFocus($selector, FALSE);
-  }
-
-  /**
-   * Assert that the element does not have keyboard focus.
-   *
-   * @code
-   * Then the element "#edit-name" should not have keyboard focus
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Then('the element :selector should not have keyboard focus')]
-  public function elementAssertNotHasKeyboardFocus(string $selector): void {
-    $this->elementAssertKeyboardFocus($selector, TRUE);
-  }
-
-  /**
-   * Assert that the element has a visible focus indicator.
-   *
-   * Verifies that the element renders a visible focus indicator via either
-   * a CSS outline (non-`none` outline-style with a width greater than 0) or
-   * a non-`none` box-shadow. Guards WCAG 2.4.7 (Focus Visible) and catches
-   * accidental `outline: none` regressions introduced by stylesheet changes.
-   *
-   * @code
-   * Then the element "#edit-name" should have a visible focus outline
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Then('the element :selector should have a visible focus outline')]
-  public function elementAssertHasVisibleFocusOutline(string $selector): void {
-    $this->elementAssertVisibleFocusOutline($selector, FALSE);
-  }
-
-  /**
-   * Assert that the element does not have a visible focus indicator.
-   *
-   * @code
-   * Then the element "#decorative-icon" should not have a visible focus outline
-   * @endcode
-   *
-   * @javascript
-   */
-  #[Then('the element :selector should not have a visible focus outline')]
-  public function elementAssertNotHasVisibleFocusOutline(string $selector): void {
-    $this->elementAssertVisibleFocusOutline($selector, TRUE);
   }
 
   /**
@@ -1028,136 +1158,6 @@ JS;
 
     if ($is_inverted && $is_visible) {
       throw new ExpectationException(sprintf('Expected element "%s" to not have a visible focus outline, but outline-style is "%s", outline-width is "%s", box-shadow is "%s".', $selector, $outline_style, $outline_width, $box_shadow), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that element with specified CSS is visible on page.
-   *
-   * @code
-   * Then the element ".alert-success" should be displayed
-   * @endcode
-   */
-  #[Then('the element :selector should be displayed')]
-  public function elementAssertVisible(string $selector): void {
-    $page = $this->getSession()->getPage();
-    $elements = $page->findAll('css', $selector);
-
-    if ($elements === []) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
-    }
-
-    foreach ($elements as $element) {
-      if ($element->isVisible()) {
-        return;
-      }
-    }
-
-    throw new ExpectationException(sprintf('None of the elements defined by "%s" selector are visible on the page.', $selector), $this->getSession()->getDriver());
-  }
-
-  /**
-   * Assert that element with specified CSS is not visible on page.
-   *
-   * @code
-   * Then the element ".error-message" should not be displayed
-   * @endcode
-   */
-  #[Then('the element :selector should not be displayed')]
-  public function elementAssertNotVisible(string $selector): void {
-    $page = $this->getSession()->getPage();
-    $elements = $page->findAll('css', $selector);
-
-    foreach ($elements as $element) {
-      if ($element->isVisible()) {
-        throw new ExpectationException(sprintf('Element defined by "%s" selector is visible on the page, but should not be.', $selector), $this->getSession()->getDriver());
-      }
-    }
-  }
-
-  /**
-   * Assert that element with specified CSS is displayed within a viewport.
-   *
-   * @code
-   * Then the element ".hero-banner" should be displayed within a viewport
-   * @endcode
-   */
-  #[Then('the element :selector should be displayed within a viewport')]
-  public function elementAssertVisuallyVisible(string $selector): void {
-    $this->elementAssertVisible($selector);
-
-    if (!$this->elementIsVisuallyVisible($selector, 0)) {
-      throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is not displayed within a viewport.', $selector), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that element with specified CSS is displayed within a viewport with a top offset.
-   *
-   * @code
-   * Then the element ".sticky-header" should be displayed within a viewport with a top offset of 50 pixels
-   * @endcode
-   */
-  #[Then('the element :selector should be displayed within a viewport with a top offset of :offset pixels')]
-  public function elementAssertVisuallyVisibleWithOffset(string $selector, int $offset): void {
-    $this->elementAssertVisible($selector);
-    if (!$this->elementIsVisuallyVisible($selector, $offset)) {
-      throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is not displayed within a viewport with a top offset of %d pixels.', $selector, $offset), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that element with specified CSS is not displayed within a viewport with a top offset.
-   *
-   * @code
-   * Then the element ".below-fold-content" should not be displayed within a viewport with a top offset of 0 pixels
-   * @endcode
-   */
-  #[Then('the element :selector should not be displayed within a viewport with a top offset of :offset pixels')]
-  public function elementAssertNotVisuallyVisibleWithOffset(string $selector, int $offset): void {
-    if ($this->elementIsVisuallyVisible($selector, $offset)) {
-      throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is displayed within a viewport with a top offset of %d pixels, but should not be.', $selector, $offset), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that element with specified CSS is visually hidden on page.
-   *
-   * Visually hidden means either:
-   * - element is not rendered in the layout (i.e., CSS is "display: none").
-   * - element is rendered in the layout, but not visible to the viewer (i.e.,
-   *   when one of the screen reader-only techniques is used).
-   *
-   * @code
-   * Then the element ".visually-hidden" should not be displayed within a viewport
-   * @endcode
-   */
-  #[Then('the element :selector should not be displayed within a viewport')]
-  public function elementAssertNotVisuallyVisible(string $selector, int $offset = 0): void {
-    if ($this->elementIsVisuallyVisible($selector, $offset)) {
-      throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is displayed within a viewport, but should not be.', $selector), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert the number of elements matching a selector within a parent element.
-   *
-   * @code
-   * Then the element "#main-nav" should contain 3 elements matching ".menu-item"
-   * @endcode
-   */
-  #[Then('the element :parent should contain :count element(s) matching :selector')]
-  public function elementAssertChildElementCount(string $parent, int $count, string $selector): void {
-    $parent_element = $this->getSession()->getPage()->find('css', $parent);
-
-    if (!$parent_element) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $parent);
-    }
-
-    $actual = count($parent_element->findAll('css', $selector));
-
-    if ($actual !== $count) {
-      throw new ExpectationException(sprintf('Expected the element "%s" to contain %d element(s) matching "%s", but found %d.', $parent, $count, $selector, $actual), $this->getSession()->getDriver());
     }
   }
 

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -117,143 +117,27 @@ trait FieldTrait {
   }
 
   /**
-   * Assert that field is empty.
+   * Disable browser validation for the form for validating errors.
+   *
+   * The form selector is registered and validation disabling will be
+   * automatically applied after each step when the form becomes available.
    *
    * @code
-   * Then the field "Name" should be empty
+   * Given the browser validation for the form "#node-article-form" is disabled
+   * When I go to "node/add/article"
+   * And I press "Save"
+   * Then I should see "Title field is required"
    * @endcode
    */
-  #[Then('the field :field should be empty')]
-  public function fieldAssertEmpty(string $field): void {
-    $field_element = $this->fieldAssertExists($field);
-
-    $value = $field_element->getValue();
-
-    if ($value !== NULL && $value !== '') {
-      throw new ExpectationException(sprintf('The field "%s" is not empty, but should be.', $field), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that a field is not empty.
-   *
-   * @code
-   * Then the field "Name" should not be empty
-   * @endcode
-   */
-  #[Then('the field :field should not be empty')]
-  public function fieldAssertNotEmpty(string $field): void {
-    $field_element = $this->fieldAssertExists($field);
-
-    $value = $field_element->getValue();
-
-    if ($value === NULL || $value === '') {
-      throw new ExpectationException(sprintf('The field "%s" is empty, but should not be.', $field), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that field exists on the page using id,name,label or value.
-   *
-   * @code
-   * Then the field "Body" should exist
-   * Then the field "field_body" should exist
-   * @endcode
-   */
-  #[Then('the field :field should exist')]
-  public function fieldAssertExists(string $field): NodeElement {
-    $page = $this->getSession()->getPage();
-    $field_element = $page->findField($field);
-    $field_element = $field_element ?: $page->findById($field);
-
-    if ($field_element === NULL) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'form field', 'id|name|label|value', $field);
+  #[Given('the browser validation for the form :selector is disabled')]
+  public function fieldDisableFormBrowserValidation(string $selector): void {
+    if (!in_array($selector, $this->fieldFormValidationRegistry, TRUE)) {
+      $this->fieldFormValidationRegistry[] = $selector;
     }
 
-    return $field_element;
-  }
-
-  /**
-   * Assert that field does not exist on the page using id,name,label or value.
-   *
-   * @code
-   * Then the field "Body" should not exist
-   * Then the field "field_body" should not exist
-   * @endcode
-   */
-  #[Then('the field :field should not exist')]
-  public function fieldAssertNotExists(string $field): void {
-    $page = $this->getSession()->getPage();
-    $field_element = $page->findField($field);
-    $field_element = $field_element ?: $page->findById($field);
-
-    if ($field_element !== NULL) {
-      throw new ExpectationException(sprintf('A field "%s" appears on this page, but it should not.', $field), $this->getSession()->getDriver());
+    if ($this->helperIsJavascriptSupported()) {
+      $this->fieldDisableFormValidation($selector);
     }
-  }
-
-  /**
-   * Assert whether the field has a state.
-   *
-   * @code
-   * Then the field "Body" should have the "disabled" state
-   * Then the field "field_body" should have the "disabled" state
-   * Then the field "Tags" should have the "enabled" state
-   * Then the field "field_tags" should have the "not enabled" state
-   * @endcode
-   */
-  #[Then('the field :field should have the :enabled_or_disabled state')]
-  public function fieldAssertState(string $field, string $enabled_or_disabled): void {
-    $field_element = $this->fieldAssertExists($field);
-
-    if ($enabled_or_disabled === 'disabled' && !$field_element->hasAttribute('disabled')) {
-      throw new ExpectationException(sprintf('A field "%s" should be disabled, but it is not.', $field), $this->getSession()->getDriver());
-    }
-
-    if ($enabled_or_disabled !== 'disabled' && $field_element->hasAttribute('disabled')) {
-      throw new ExpectationException(sprintf('A field "%s" should not be disabled, but it is.', $field), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that a field is marked as required.
-   *
-   * Checks three common markers in order:
-   * 1. The native HTML `required` attribute on the field.
-   * 2. The `form-required` CSS class on the field or its label.
-   * 3. A `*` character inside the `<label>` associated with the field.
-   *
-   * @code
-   * Then the field "Email" should be required
-   * @endcode
-   */
-  #[Then('the field :field should be required')]
-  public function fieldAssertRequired(string $field): void {
-    $field_element = $this->fieldAssertExists($field);
-
-    if ($this->fieldIsMarkedRequired($field_element)) {
-      return;
-    }
-
-    throw new ExpectationException(sprintf('The field "%s" is not marked as required, but should be.', $field), $this->getSession()->getDriver());
-  }
-
-  /**
-   * Assert that a field is not marked as required.
-   *
-   * @code
-   * Then the field "Nickname" should not be required
-   * @endcode
-   */
-  #[Then('the field :field should not be required')]
-  public function fieldAssertNotRequired(string $field): void {
-    $field_element = $this->fieldAssertExists($field);
-
-    if (!$this->fieldIsMarkedRequired($field_element)) {
-      return;
-    }
-
-    throw new ExpectationException(sprintf('The field "%s" is marked as required, but should not be.', $field), $this->getSession()->getDriver());
   }
 
   /**
@@ -364,107 +248,6 @@ trait FieldTrait {
   }
 
   /**
-   * CSS selectors for the "Add another item" button.
-   *
-   * Returned selectors are tried in order. Override in a subclass to
-   * customise the selectors for custom themes or widget implementations.
-   *
-   * @return array<int, string>
-   *   CSS selectors to probe for the add-another-item button.
-   */
-  protected function fieldGetAddMoreButtonSelectors(): array {
-    return [
-      'input[value="Add another item"]',
-      'button.field-add-more-submit',
-    ];
-  }
-
-  /**
-   * CSS selectors that indicate a required-field marker.
-   *
-   * Nothing consumes this list yet: ::fieldIsMarkedRequired() probes for the
-   * `required` attribute and the `form-required` class directly. It is kept as
-   * the intended override point for that check.
-   *
-   * @return array<int, string>
-   *   CSS selectors to probe for a required marker.
-   */
-  protected function fieldGetRequiredMarkerSelectors(): array {
-    return ['.form-required', '[required]'];
-  }
-
-  /**
-   * Check if a given field element is marked as required.
-   *
-   * Checks the native `required` attribute, the `form-required` class on
-   * the field or any associated label, and the presence of a `*` character
-   * inside any associated label.
-   */
-  protected function fieldIsMarkedRequired(NodeElement $field_element): bool {
-    if ($field_element->hasAttribute('required')) {
-      return TRUE;
-    }
-
-    $classes = (string) $field_element->getAttribute('class');
-    if (str_contains($classes, 'form-required')) {
-      return TRUE;
-    }
-
-    $page = $this->getSession()->getPage();
-
-    $field_id = $field_element->getAttribute('id');
-    $label = NULL;
-    if ($field_id !== NULL && $field_id !== '') {
-      $label = $page->find('xpath', sprintf('//label[@for=%s]', $this->fieldXpathLiteral($field_id)));
-    }
-
-    $label ??= $field_element->find('xpath', 'ancestor::label[1]');
-
-    if ($label instanceof NodeElement) {
-      $label_classes = (string) $label->getAttribute('class');
-      if (str_contains($label_classes, 'form-required')) {
-        return TRUE;
-      }
-
-      if (str_contains($label->getText(), '*')) {
-        return TRUE;
-      }
-
-      if ($label->find('css', '.form-required') !== NULL) {
-        return TRUE;
-      }
-    }
-
-    return FALSE;
-  }
-
-  /**
-   * The path of the current page, as used in failure messages.
-   *
-   * @return string
-   *   The path component of the current URL.
-   */
-  protected function fieldCurrentPath(): string {
-    return (string) parse_url((string) $this->getSession()->getCurrentUrl(), PHP_URL_PATH);
-  }
-
-  /**
-   * Wrap a string in an XPath-safe literal.
-   *
-   * Handles strings containing single quotes, double quotes, or both.
-   */
-  protected function fieldXpathLiteral(string $value): string {
-    if (!str_contains($value, "'")) {
-      return "'" . $value . "'";
-    }
-    if (!str_contains($value, '"')) {
-      return '"' . $value . '"';
-    }
-    $parts = explode("'", $value);
-    return "concat('" . implode("', \"'\", '", $parts) . "')";
-  }
-
-  /**
    * Fill value for color field.
    *
    * @code
@@ -487,32 +270,6 @@ trait FieldTrait {
       })();
 JS;
     return $this->getSession()->evaluateScript($script);
-  }
-
-  /**
-   * Assert that a color field has a value.
-   *
-   * @code
-   * Then the color field "#edit-background-color" should have the value "#FF5733"
-   * @endcode
-   */
-  #[Then('the color field :field should have the value :value')]
-  public function fieldAssertColorFieldHasValue(string $field, string $value): void {
-    $field_js = json_encode($field, JSON_UNESCAPED_SLASHES);
-    $script = <<<JS
-      (function() {
-        var element = document.querySelector({$field_js});
-        if (!element) {
-          throw new Error('Element not found: ' + {$field_js});
-        }
-        return element.value;
-      })();
-JS;
-    $actual = $this->getSession()->evaluateScript($script);
-
-    if ($actual !== $value) {
-      throw new ExpectationException(sprintf('Color field "%s" expected a value "%s" but has a value "%s".', $field, $value, $actual), $this->getSession()->getDriver());
-    }
   }
 
   /**
@@ -576,107 +333,6 @@ JS;
 JS;
     }
     $this->getSession()->executeScript($script);
-  }
-
-  /**
-   * Assert that a select has an option.
-   *
-   * @code
-   * Then the option "Administrator" should exist within the select element "edit-roles"
-   * @endcode
-   */
-  #[Then('the option :option should exist within the select element :selector')]
-  public function fieldAssertSelectOptionExists(string $selector, string $option): void {
-    $select_element = $this->getSession()->getPage()->findField($selector);
-
-    if ($select_element === NULL) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
-    }
-
-    $option_element = $select_element->find('named', ['option', $option]);
-
-    if ($option_element === NULL) {
-      throw new ExpectationException(sprintf('The option "%s" was not found in the select "%s" on the page %s.', $option, $selector, $this->fieldCurrentPath()), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that a select does not have an option.
-   *
-   * @code
-   * Then the option "Guest" should not exist within the select element "edit-roles"
-   * @endcode
-   */
-  #[Then('the option :option should not exist within the select element :selector')]
-  public function fieldAssertSelectOptionNotExists(string $selector, string $option): void {
-    $select_element = $this->getSession()->getPage()->findField($selector);
-
-    if ($select_element === NULL) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
-    }
-
-    $option_element = $select_element->find('named', ['option', $option]);
-
-    if ($option_element !== NULL) {
-      throw new ExpectationException(sprintf('The option "%s" was found in the select "%s" on the page %s, but should not exist.', $option, $selector, $this->fieldCurrentPath()), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that a select option is selected.
-   *
-   * @code
-   * Then the option "Administrator" should be selected within the select element "edit-roles"
-   * @endcode
-   */
-  #[Then('the option :option should be selected within the select element :selector')]
-  public function fieldAssertSelectOptionSelected(string $option, string $selector): void {
-    $select_field = $this->getSession()->getPage()->findField($selector);
-    $path = $this->fieldCurrentPath();
-
-    if (!$select_field) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
-    }
-
-    $option_field = $select_field->find('named', [
-      'option',
-      $option,
-    ]);
-
-    if (!$option_field) {
-      throw new ExpectationException(sprintf('No option is selected in the %s select on the page %s.', $selector, $path), $this->getSession()->getDriver());
-    }
-
-    if (!$option_field->isSelected()) {
-      throw new ExpectationException(sprintf('The option "%s" was not selected on the page %s.', $option, $path), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that a select option is not selected.
-   *
-   * @code
-   * Then the option "Editor" should not be selected within the select element "edit-roles"
-   * @endcode
-   */
-  #[Then('the option :option should not be selected within the select element :selector')]
-  public function fieldAssertSelectOptionNotSelected(string $option, string $selector): void {
-    $select_field = $this->getSession()->getPage()->findField($selector);
-    $path = $this->fieldCurrentPath();
-
-    if (!$select_field) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
-    }
-
-    $option_field = $select_field->find('named', ['option', $option]);
-
-    if (!$option_field) {
-      throw new ExpectationException(sprintf('The option "%s" was not found in the select "%s" on the page %s.', $option, $selector, $path), $this->getSession()->getDriver());
-    }
-
-    if ($option_field->isSelected()) {
-      throw new ExpectationException(sprintf('The option "%s" was selected in the select "%s" on the page %s, but should not be.', $option, $selector, $path), $this->getSession()->getDriver());
-    }
   }
 
   /**
@@ -836,60 +492,6 @@ JS;
   }
 
   /**
-   * Assert that a radio button is selected.
-   *
-   * @param string $selector
-   *   The radio button id, name, label or value.
-   *
-   * @code
-   *   Then the radio button "Option A" should be selected
-   *   Then the radio button "edit-field-choice-option-a" should be selected
-   * @endcode
-   */
-  #[Then('the radio button :selector should be selected')]
-  public function fieldAssertRadioSelected(string $selector): void {
-    $selector = $this->helperFixStepArgument($selector);
-
-    $page = $this->getSession()->getPage();
-    $radio_button = $page->findField($selector);
-
-    if ($radio_button === NULL) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'radio button', 'id|name|label|value', $selector);
-    }
-
-    if (!$radio_button->isChecked()) {
-      throw new ExpectationException(sprintf('The radio button "%s" is not selected, but should be.', $selector), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Assert that a radio button is not selected.
-   *
-   * @param string $selector
-   *   The radio button id, name, label or value.
-   *
-   * @code
-   *   Then the radio button "Option B" should not be selected
-   *   Then the radio button "edit-field-choice-option-b" should not be selected
-   * @endcode
-   */
-  #[Then('the radio button :selector should not be selected')]
-  public function fieldAssertRadioNotSelected(string $selector): void {
-    $selector = $this->helperFixStepArgument($selector);
-
-    $page = $this->getSession()->getPage();
-    $radio_button = $page->findField($selector);
-
-    if ($radio_button === NULL) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'radio button', 'id|name|label|value', $selector);
-    }
-
-    if ($radio_button->isChecked()) {
-      throw new ExpectationException(sprintf('The radio button "%s" is selected, but should not be.', $selector), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
    * Fill in a field identified by CSS selector.
    *
    * Use this when the field cannot be reliably located by label, id, or name
@@ -909,56 +511,6 @@ JS;
     }
 
     $field->setValue($value);
-  }
-
-  /**
-   * Disable browser validation for the form for validating errors.
-   *
-   * The form selector is registered and validation disabling will be
-   * automatically applied after each step when the form becomes available.
-   *
-   * @code
-   * Given the browser validation for the form "#node-article-form" is disabled
-   * When I go to "node/add/article"
-   * And I press "Save"
-   * Then I should see "Title field is required"
-   * @endcode
-   */
-  #[Given('the browser validation for the form :selector is disabled')]
-  public function fieldDisableFormBrowserValidation(string $selector): void {
-    if (!in_array($selector, $this->fieldFormValidationRegistry, TRUE)) {
-      $this->fieldFormValidationRegistry[] = $selector;
-    }
-
-    if ($this->helperIsJavascriptSupported()) {
-      $this->fieldDisableFormValidation($selector);
-    }
-  }
-
-  /**
-   * Disable browser validation for forms.
-   *
-   * Silently handles cases where forms don't exist yet (deferred execution).
-   *
-   * @param string|null $selector
-   *   The CSS selector for form(s). If NULL, disables all forms on page.
-   */
-  protected function fieldDisableFormValidation(?string $selector = NULL): void {
-    $selector ??= 'form';
-    $selector_js = json_encode($selector, JSON_UNESCAPED_SLASHES);
-
-    $script = <<<JS
-      (function() {
-        var forms = document.querySelectorAll({$selector_js});
-        if (forms.length > 0) {
-          forms.forEach(function(form) {
-            form.setAttribute('novalidate', 'novalidate');
-          });
-        }
-      })();
-JS;
-
-    $this->getSession()->executeScript($script);
   }
 
   /**
@@ -1037,6 +589,454 @@ JS;
     if ($time !== '') {
       $this->fieldFillDatetimeHelper($label, 'end_value', 'time', $time);
     }
+  }
+
+  /**
+   * Assert that field is empty.
+   *
+   * @code
+   * Then the field "Name" should be empty
+   * @endcode
+   */
+  #[Then('the field :field should be empty')]
+  public function fieldAssertEmpty(string $field): void {
+    $field_element = $this->fieldAssertExists($field);
+
+    $value = $field_element->getValue();
+
+    if ($value !== NULL && $value !== '') {
+      throw new ExpectationException(sprintf('The field "%s" is not empty, but should be.', $field), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a field is not empty.
+   *
+   * @code
+   * Then the field "Name" should not be empty
+   * @endcode
+   */
+  #[Then('the field :field should not be empty')]
+  public function fieldAssertNotEmpty(string $field): void {
+    $field_element = $this->fieldAssertExists($field);
+
+    $value = $field_element->getValue();
+
+    if ($value === NULL || $value === '') {
+      throw new ExpectationException(sprintf('The field "%s" is empty, but should not be.', $field), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that field exists on the page using id,name,label or value.
+   *
+   * @code
+   * Then the field "Body" should exist
+   * Then the field "field_body" should exist
+   * @endcode
+   */
+  #[Then('the field :field should exist')]
+  public function fieldAssertExists(string $field): NodeElement {
+    $page = $this->getSession()->getPage();
+    $field_element = $page->findField($field);
+    $field_element = $field_element ?: $page->findById($field);
+
+    if ($field_element === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'form field', 'id|name|label|value', $field);
+    }
+
+    return $field_element;
+  }
+
+  /**
+   * Assert that field does not exist on the page using id,name,label or value.
+   *
+   * @code
+   * Then the field "Body" should not exist
+   * Then the field "field_body" should not exist
+   * @endcode
+   */
+  #[Then('the field :field should not exist')]
+  public function fieldAssertNotExists(string $field): void {
+    $page = $this->getSession()->getPage();
+    $field_element = $page->findField($field);
+    $field_element = $field_element ?: $page->findById($field);
+
+    if ($field_element !== NULL) {
+      throw new ExpectationException(sprintf('A field "%s" appears on this page, but it should not.', $field), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert whether the field has a state.
+   *
+   * @code
+   * Then the field "Body" should have the "disabled" state
+   * Then the field "field_body" should have the "disabled" state
+   * Then the field "Tags" should have the "enabled" state
+   * Then the field "field_tags" should have the "not enabled" state
+   * @endcode
+   */
+  #[Then('the field :field should have the :enabled_or_disabled state')]
+  public function fieldAssertState(string $field, string $enabled_or_disabled): void {
+    $field_element = $this->fieldAssertExists($field);
+
+    if ($enabled_or_disabled === 'disabled' && !$field_element->hasAttribute('disabled')) {
+      throw new ExpectationException(sprintf('A field "%s" should be disabled, but it is not.', $field), $this->getSession()->getDriver());
+    }
+
+    if ($enabled_or_disabled !== 'disabled' && $field_element->hasAttribute('disabled')) {
+      throw new ExpectationException(sprintf('A field "%s" should not be disabled, but it is.', $field), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a field is marked as required.
+   *
+   * Checks three common markers in order:
+   * 1. The native HTML `required` attribute on the field.
+   * 2. The `form-required` CSS class on the field or its label.
+   * 3. A `*` character inside the `<label>` associated with the field.
+   *
+   * @code
+   * Then the field "Email" should be required
+   * @endcode
+   */
+  #[Then('the field :field should be required')]
+  public function fieldAssertRequired(string $field): void {
+    $field_element = $this->fieldAssertExists($field);
+
+    if ($this->fieldIsMarkedRequired($field_element)) {
+      return;
+    }
+
+    throw new ExpectationException(sprintf('The field "%s" is not marked as required, but should be.', $field), $this->getSession()->getDriver());
+  }
+
+  /**
+   * Assert that a field is not marked as required.
+   *
+   * @code
+   * Then the field "Nickname" should not be required
+   * @endcode
+   */
+  #[Then('the field :field should not be required')]
+  public function fieldAssertNotRequired(string $field): void {
+    $field_element = $this->fieldAssertExists($field);
+
+    if (!$this->fieldIsMarkedRequired($field_element)) {
+      return;
+    }
+
+    throw new ExpectationException(sprintf('The field "%s" is marked as required, but should not be.', $field), $this->getSession()->getDriver());
+  }
+
+  /**
+   * Assert that a color field has a value.
+   *
+   * @code
+   * Then the color field "#edit-background-color" should have the value "#FF5733"
+   * @endcode
+   */
+  #[Then('the color field :field should have the value :value')]
+  public function fieldAssertColorFieldHasValue(string $field, string $value): void {
+    $field_js = json_encode($field, JSON_UNESCAPED_SLASHES);
+    $script = <<<JS
+      (function() {
+        var element = document.querySelector({$field_js});
+        if (!element) {
+          throw new Error('Element not found: ' + {$field_js});
+        }
+        return element.value;
+      })();
+JS;
+    $actual = $this->getSession()->evaluateScript($script);
+
+    if ($actual !== $value) {
+      throw new ExpectationException(sprintf('Color field "%s" expected a value "%s" but has a value "%s".', $field, $value, $actual), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a select has an option.
+   *
+   * @code
+   * Then the option "Administrator" should exist within the select element "edit-roles"
+   * @endcode
+   */
+  #[Then('the option :option should exist within the select element :selector')]
+  public function fieldAssertSelectOptionExists(string $selector, string $option): void {
+    $select_element = $this->getSession()->getPage()->findField($selector);
+
+    if ($select_element === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
+    }
+
+    $option_element = $select_element->find('named', ['option', $option]);
+
+    if ($option_element === NULL) {
+      throw new ExpectationException(sprintf('The option "%s" was not found in the select "%s" on the page %s.', $option, $selector, $this->fieldCurrentPath()), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a select does not have an option.
+   *
+   * @code
+   * Then the option "Guest" should not exist within the select element "edit-roles"
+   * @endcode
+   */
+  #[Then('the option :option should not exist within the select element :selector')]
+  public function fieldAssertSelectOptionNotExists(string $selector, string $option): void {
+    $select_element = $this->getSession()->getPage()->findField($selector);
+
+    if ($select_element === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
+    }
+
+    $option_element = $select_element->find('named', ['option', $option]);
+
+    if ($option_element !== NULL) {
+      throw new ExpectationException(sprintf('The option "%s" was found in the select "%s" on the page %s, but should not exist.', $option, $selector, $this->fieldCurrentPath()), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a select option is selected.
+   *
+   * @code
+   * Then the option "Administrator" should be selected within the select element "edit-roles"
+   * @endcode
+   */
+  #[Then('the option :option should be selected within the select element :selector')]
+  public function fieldAssertSelectOptionSelected(string $option, string $selector): void {
+    $select_field = $this->getSession()->getPage()->findField($selector);
+    $path = $this->fieldCurrentPath();
+
+    if (!$select_field) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
+    }
+
+    $option_field = $select_field->find('named', [
+      'option',
+      $option,
+    ]);
+
+    if (!$option_field) {
+      throw new ExpectationException(sprintf('No option is selected in the %s select on the page %s.', $selector, $path), $this->getSession()->getDriver());
+    }
+
+    if (!$option_field->isSelected()) {
+      throw new ExpectationException(sprintf('The option "%s" was not selected on the page %s.', $option, $path), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a select option is not selected.
+   *
+   * @code
+   * Then the option "Editor" should not be selected within the select element "edit-roles"
+   * @endcode
+   */
+  #[Then('the option :option should not be selected within the select element :selector')]
+  public function fieldAssertSelectOptionNotSelected(string $option, string $selector): void {
+    $select_field = $this->getSession()->getPage()->findField($selector);
+    $path = $this->fieldCurrentPath();
+
+    if (!$select_field) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
+    }
+
+    $option_field = $select_field->find('named', ['option', $option]);
+
+    if (!$option_field) {
+      throw new ExpectationException(sprintf('The option "%s" was not found in the select "%s" on the page %s.', $option, $selector, $path), $this->getSession()->getDriver());
+    }
+
+    if ($option_field->isSelected()) {
+      throw new ExpectationException(sprintf('The option "%s" was selected in the select "%s" on the page %s, but should not be.', $option, $selector, $path), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a radio button is selected.
+   *
+   * @param string $selector
+   *   The radio button id, name, label or value.
+   *
+   * @code
+   *   Then the radio button "Option A" should be selected
+   *   Then the radio button "edit-field-choice-option-a" should be selected
+   * @endcode
+   */
+  #[Then('the radio button :selector should be selected')]
+  public function fieldAssertRadioSelected(string $selector): void {
+    $selector = $this->helperFixStepArgument($selector);
+
+    $page = $this->getSession()->getPage();
+    $radio_button = $page->findField($selector);
+
+    if ($radio_button === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'radio button', 'id|name|label|value', $selector);
+    }
+
+    if (!$radio_button->isChecked()) {
+      throw new ExpectationException(sprintf('The radio button "%s" is not selected, but should be.', $selector), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * Assert that a radio button is not selected.
+   *
+   * @param string $selector
+   *   The radio button id, name, label or value.
+   *
+   * @code
+   *   Then the radio button "Option B" should not be selected
+   *   Then the radio button "edit-field-choice-option-b" should not be selected
+   * @endcode
+   */
+  #[Then('the radio button :selector should not be selected')]
+  public function fieldAssertRadioNotSelected(string $selector): void {
+    $selector = $this->helperFixStepArgument($selector);
+
+    $page = $this->getSession()->getPage();
+    $radio_button = $page->findField($selector);
+
+    if ($radio_button === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'radio button', 'id|name|label|value', $selector);
+    }
+
+    if ($radio_button->isChecked()) {
+      throw new ExpectationException(sprintf('The radio button "%s" is selected, but should not be.', $selector), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
+   * CSS selectors for the "Add another item" button.
+   *
+   * Returned selectors are tried in order. Override in a subclass to
+   * customise the selectors for custom themes or widget implementations.
+   *
+   * @return array<int, string>
+   *   CSS selectors to probe for the add-another-item button.
+   */
+  protected function fieldGetAddMoreButtonSelectors(): array {
+    return [
+      'input[value="Add another item"]',
+      'button.field-add-more-submit',
+    ];
+  }
+
+  /**
+   * CSS selectors that indicate a required-field marker.
+   *
+   * Nothing consumes this list yet: ::fieldIsMarkedRequired() probes for the
+   * `required` attribute and the `form-required` class directly. It is kept as
+   * the intended override point for that check.
+   *
+   * @return array<int, string>
+   *   CSS selectors to probe for a required marker.
+   */
+  protected function fieldGetRequiredMarkerSelectors(): array {
+    return ['.form-required', '[required]'];
+  }
+
+  /**
+   * Check if a given field element is marked as required.
+   *
+   * Checks the native `required` attribute, the `form-required` class on
+   * the field or any associated label, and the presence of a `*` character
+   * inside any associated label.
+   */
+  protected function fieldIsMarkedRequired(NodeElement $field_element): bool {
+    if ($field_element->hasAttribute('required')) {
+      return TRUE;
+    }
+
+    $classes = (string) $field_element->getAttribute('class');
+    if (str_contains($classes, 'form-required')) {
+      return TRUE;
+    }
+
+    $page = $this->getSession()->getPage();
+
+    $field_id = $field_element->getAttribute('id');
+    $label = NULL;
+    if ($field_id !== NULL && $field_id !== '') {
+      $label = $page->find('xpath', sprintf('//label[@for=%s]', $this->fieldXpathLiteral($field_id)));
+    }
+
+    $label ??= $field_element->find('xpath', 'ancestor::label[1]');
+
+    if ($label instanceof NodeElement) {
+      $label_classes = (string) $label->getAttribute('class');
+      if (str_contains($label_classes, 'form-required')) {
+        return TRUE;
+      }
+
+      if (str_contains($label->getText(), '*')) {
+        return TRUE;
+      }
+
+      if ($label->find('css', '.form-required') !== NULL) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * The path of the current page, as used in failure messages.
+   *
+   * @return string
+   *   The path component of the current URL.
+   */
+  protected function fieldCurrentPath(): string {
+    return (string) parse_url((string) $this->getSession()->getCurrentUrl(), PHP_URL_PATH);
+  }
+
+  /**
+   * Wrap a string in an XPath-safe literal.
+   *
+   * Handles strings containing single quotes, double quotes, or both.
+   */
+  protected function fieldXpathLiteral(string $value): string {
+    if (!str_contains($value, "'")) {
+      return "'" . $value . "'";
+    }
+    if (!str_contains($value, '"')) {
+      return '"' . $value . '"';
+    }
+    $parts = explode("'", $value);
+    return "concat('" . implode("', \"'\", '", $parts) . "')";
+  }
+
+  /**
+   * Disable browser validation for forms.
+   *
+   * Silently handles cases where forms don't exist yet (deferred execution).
+   *
+   * @param string|null $selector
+   *   The CSS selector for form(s). If NULL, disables all forms on page.
+   */
+  protected function fieldDisableFormValidation(?string $selector = NULL): void {
+    $selector ??= 'form';
+    $selector_js = json_encode($selector, JSON_UNESCAPED_SLASHES);
+
+    $script = <<<JS
+      (function() {
+        var forms = document.querySelectorAll({$selector_js});
+        if (forms.length > 0) {
+          forms.forEach(function(form) {
+            form.setAttribute('novalidate', 'novalidate');
+          });
+        }
+      })();
+JS;
+
+    $this->getSession()->executeScript($script);
   }
 
   /**

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -155,20 +155,6 @@ trait FileDownloadTrait {
   }
 
   /**
-   * Assert that an HTML link is present on the page.
-   */
-  protected function fileDownloadAssertLinkPresent(string $link): NodeElement {
-    $page = $this->getSession()->getPage();
-    $link_element = $page->findLink($link);
-
-    if (!$link_element) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'link', 'text', $link);
-    }
-
-    return $link_element;
-  }
-
-  /**
    * Assert the contents of the download file.
    *
    * @code
@@ -327,6 +313,20 @@ trait FileDownloadTrait {
     if (!empty($errors)) {
       throw new ExpectationException(implode(PHP_EOL, $errors), $this->getSession()->getDriver());
     }
+  }
+
+  /**
+   * Assert that an HTML link is present on the page.
+   */
+  protected function fileDownloadAssertLinkPresent(string $link): NodeElement {
+    $page = $this->getSession()->getPage();
+    $link_element = $page->findLink($link);
+
+    if (!$link_element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'link', 'text', $link);
+    }
+
+    return $link_element;
   }
 
   /**

--- a/src/JsonTrait.php
+++ b/src/JsonTrait.php
@@ -98,6 +98,20 @@ trait JsonTrait {
   }
 
   /**
+   * Print the last JSON response.
+   *
+   * @code
+   * When I print last JSON response
+   * @endcode
+   */
+  #[When('I print last JSON response')]
+  public function jsonPrintLastResponse(): void {
+    $data = $this->jsonDecodeLoose($this->jsonResolveContent());
+
+    print (string) json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+  }
+
+  /**
    * Assert that a response is valid JSON.
    *
    * @code
@@ -375,20 +389,6 @@ trait JsonTrait {
   #[Then('the response should match the JSON schema in the file :filename')]
   public function jsonAssertMatchesSchemaFromFile(string $filename): void {
     $this->jsonValidateSchema($this->jsonReadFile($filename));
-  }
-
-  /**
-   * Print the last JSON response.
-   *
-   * @code
-   * When I print last JSON response
-   * @endcode
-   */
-  #[When('I print last JSON response')]
-  public function jsonPrintLastResponse(): void {
-    $data = $this->jsonDecodeLoose($this->jsonResolveContent());
-
-    print (string) json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
   }
 
   /**

--- a/src/LinkTrait.php
+++ b/src/LinkTrait.php
@@ -21,6 +21,25 @@ trait LinkTrait {
   use HelperTrait;
 
   /**
+   * Click on the link with a title.
+   *
+   * @code
+   * When I click on the link with the title "Return to site content"
+   * @endcode
+   */
+  #[When('I click on the link with the title :title')]
+  public function linkClickWithTitle(string $title): void {
+    $title = $this->helperFixStepArgument($title);
+    $element = $this->getSession()->getPage()->find('css', 'a[title="' . addslashes((string) $title) . '"]');
+
+    if (!$element) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'link', 'title', $title);
+    }
+
+    $element->click();
+  }
+
+  /**
    * Assert a link with a href exists.
    *
    * Note that simplified wildcard is supported in "href".
@@ -206,25 +225,6 @@ trait LinkTrait {
     if (parse_url((string) $href, PHP_URL_SCHEME)) {
       throw new ExpectationException(sprintf('The link "%s" is an absolute link.', $link), $this->getSession()->getDriver());
     }
-  }
-
-  /**
-   * Click on the link with a title.
-   *
-   * @code
-   * When I click on the link with the title "Return to site content"
-   * @endcode
-   */
-  #[When('I click on the link with the title :title')]
-  public function linkClickWithTitle(string $title): void {
-    $title = $this->helperFixStepArgument($title);
-    $element = $this->getSession()->getPage()->find('css', 'a[title="' . addslashes((string) $title) . '"]');
-
-    if (!$element) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'link', 'title', $title);
-    }
-
-    $element->click();
   }
 
 }

--- a/src/ModalTrait.php
+++ b/src/ModalTrait.php
@@ -23,6 +23,88 @@ use Behat\Step\When;
 trait ModalTrait {
 
   /**
+   * Close the modal by clicking the close button.
+   *
+   * @code
+   * When I close the modal
+   * @endcode
+   *
+   * @javascript
+   */
+  #[When('I close the modal')]
+  public function modalClose(): void {
+    $modal = $this->modalFindVisible();
+    $close = $this->modalFindElementIn($modal, $this->modalGetCloseSelectors());
+
+    if ($close === NULL) {
+      throw new ExpectationException('The modal close button was not found.', $this->getSession()->getDriver());
+    }
+
+    $close->click();
+  }
+
+  /**
+   * Click an element in the modal by CSS selector, button label, or link text.
+   *
+   * Resolves the element in the following order:
+   * 1. CSS selector (e.g., ".btn-save", "a.close").
+   * 2. Button by id, name, value, or visible text (via Mink findButton).
+   * 3. Link by visible text or title (via Mink findLink).
+   *
+   * @code
+   * When I click on "Save" in the modal
+   * When I click on ".btn-save" in the modal
+   * When I click on "Cancel" in the modal
+   * @endcode
+   *
+   * @javascript
+   */
+  #[When('I click on :selector in the modal')]
+  public function modalClick(string $selector): void {
+    $modal = $this->modalFindVisible();
+
+    $element = $modal->find('css', $selector);
+
+    if ($element === NULL || !$element->isVisible()) {
+      $element = $modal->findButton($selector);
+    }
+
+    if ($element === NULL || !$element->isVisible()) {
+      $element = $modal->findLink($selector);
+    }
+
+    if ($element === NULL || !$element->isVisible()) {
+      throw new ExpectationException(sprintf('The element "%s" was not found in the modal.', $selector), $this->getSession()->getDriver());
+    }
+
+    $element->click();
+  }
+
+  /**
+   * Wait for the modal to appear.
+   *
+   * @code
+   * When I wait for the modal to appear
+   * @endcode
+   *
+   * @javascript
+   */
+  #[When('I wait for the modal to appear')]
+  public function modalWaitForAppear(): void {
+    $timeout = $this->modalGetWaitTimeout();
+
+    $result = $this->getSession()->getPage()->waitFor($timeout, function (): bool {
+      $modal = $this->modalFind();
+
+      return $modal !== NULL && $modal->isVisible();
+    });
+
+    if (!$result) {
+      throw new ExpectationException(sprintf('The modal did not appear within %d seconds.', $timeout), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
    * Assert that the modal is visible.
    *
    * @code
@@ -105,88 +187,6 @@ trait ModalTrait {
 
     if (str_contains((string) $actual_text, $text)) {
       throw new ExpectationException(sprintf('The modal contains the text "%s", but it should not.', $text), $this->getSession()->getDriver());
-    }
-  }
-
-  /**
-   * Close the modal by clicking the close button.
-   *
-   * @code
-   * When I close the modal
-   * @endcode
-   *
-   * @javascript
-   */
-  #[When('I close the modal')]
-  public function modalClose(): void {
-    $modal = $this->modalFindVisible();
-    $close = $this->modalFindElementIn($modal, $this->modalGetCloseSelectors());
-
-    if ($close === NULL) {
-      throw new ExpectationException('The modal close button was not found.', $this->getSession()->getDriver());
-    }
-
-    $close->click();
-  }
-
-  /**
-   * Click an element in the modal by CSS selector, button label, or link text.
-   *
-   * Resolves the element in the following order:
-   * 1. CSS selector (e.g., ".btn-save", "a.close").
-   * 2. Button by id, name, value, or visible text (via Mink findButton).
-   * 3. Link by visible text or title (via Mink findLink).
-   *
-   * @code
-   * When I click on "Save" in the modal
-   * When I click on ".btn-save" in the modal
-   * When I click on "Cancel" in the modal
-   * @endcode
-   *
-   * @javascript
-   */
-  #[When('I click on :selector in the modal')]
-  public function modalClick(string $selector): void {
-    $modal = $this->modalFindVisible();
-
-    $element = $modal->find('css', $selector);
-
-    if ($element === NULL || !$element->isVisible()) {
-      $element = $modal->findButton($selector);
-    }
-
-    if ($element === NULL || !$element->isVisible()) {
-      $element = $modal->findLink($selector);
-    }
-
-    if ($element === NULL || !$element->isVisible()) {
-      throw new ExpectationException(sprintf('The element "%s" was not found in the modal.', $selector), $this->getSession()->getDriver());
-    }
-
-    $element->click();
-  }
-
-  /**
-   * Wait for the modal to appear.
-   *
-   * @code
-   * When I wait for the modal to appear
-   * @endcode
-   *
-   * @javascript
-   */
-  #[When('I wait for the modal to appear')]
-  public function modalWaitForAppear(): void {
-    $timeout = $this->modalGetWaitTimeout();
-
-    $result = $this->getSession()->getPage()->waitFor($timeout, function (): bool {
-      $modal = $this->modalFind();
-
-      return $modal !== NULL && $modal->isVisible();
-    });
-
-    if (!$result) {
-      throw new ExpectationException(sprintf('The modal did not appear within %d seconds.', $timeout), $this->getSession()->getDriver());
     }
   }
 

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -19,6 +19,30 @@ use Behat\Step\When;
 trait PathTrait {
 
   /**
+   * Set basic authentication for the current session.
+   *
+   * @code
+   * Given the basic authentication has the username "myusername" and the password "mypassword"
+   * @endcode
+   */
+  #[Given('the basic authentication has the username :username and the password :password')]
+  public function pathSetBasicAuth(string $username, string $password): void {
+    $this->getSession()->setBasicAuth($username, $password);
+  }
+
+  /**
+   * Navigate back in browser history.
+   *
+   * @code
+   * When I go back
+   * @endcode
+   */
+  #[When('I go back')]
+  public function pathGoBack(): void {
+    $this->getSession()->back();
+  }
+
+  /**
    * Assert that the current page is a specified path.
    *
    * Note that "<front>" is supported as path.
@@ -162,30 +186,6 @@ trait PathTrait {
     if ($query[$param] === $value) {
       throw new ExpectationException(sprintf('The parameter "%s" with value "%s" is in the URL but should not be.', $param, $value), $this->getSession()->getDriver());
     }
-  }
-
-  /**
-   * Set basic authentication for the current session.
-   *
-   * @code
-   * Given the basic authentication has the username "myusername" and the password "mypassword"
-   * @endcode
-   */
-  #[Given('the basic authentication has the username :username and the password :password')]
-  public function pathSetBasicAuth(string $username, string $password): void {
-    $this->getSession()->setBasicAuth($username, $password);
-  }
-
-  /**
-   * Navigate back in browser history.
-   *
-   * @code
-   * When I go back
-   * @endcode
-   */
-  #[When('I go back')]
-  public function pathGoBack(): void {
-    $this->getSession()->back();
   }
 
   /**

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -86,47 +86,6 @@ trait ResponsiveTrait {
   protected ?string $responsiveBreakpointFromTag = NULL;
 
   /**
-   * Set custom breakpoints.
-   *
-   * Public API: a composing context may call this directly to register
-   * breakpoints outside a step.
-   *
-   * Custom breakpoints override default breakpoints with the same name.
-   *
-   * @param array<string, string> $breakpoints
-   *   Array of breakpoints in format ['name' => 'WIDTHxHEIGHT'].
-   *
-   * @throws \RuntimeException
-   *   If breakpoint format is invalid.
-   */
-  public function responsiveSetBreakpoints(array $breakpoints): void {
-    foreach ($breakpoints as $name => $dimensions) {
-      // Validate format by extracting dimensions.
-      $this->responsiveExtractDimensions($dimensions, $name);
-      $this->responsiveCustomBreakpoints[$name] = $dimensions;
-    }
-  }
-
-  /**
-   * Set custom responsive breakpoints from a table.
-   *
-   * @code
-   * Given the following responsive breakpoints exist:
-   *   | name       | dimensions |
-   *   | iphone_12  | 390x844    |
-   *   | 4k_display | 3840x2160  |
-   * @endcode
-   */
-  #[Given('the following responsive breakpoints exist:')]
-  public function responsiveSetBreakpointsFromTable(TableNode $table): void {
-    $breakpoints = [];
-    foreach ($table->getHash() as $row) {
-      $breakpoints[$row['name']] = $row['dimensions'];
-    }
-    $this->responsiveSetBreakpoints($breakpoints);
-  }
-
-  /**
    * Validate @breakpoint:NAME tag before scenario.
    */
   #[BeforeScenario]
@@ -175,6 +134,25 @@ trait ResponsiveTrait {
     $breakpoint_name = $this->responsiveBreakpointFromTag;
     $this->responsiveBreakpointFromTag = NULL;
     $this->responsiveResizeToBreakpoint($breakpoint_name);
+  }
+
+  /**
+   * Set custom responsive breakpoints from a table.
+   *
+   * @code
+   * Given the following responsive breakpoints exist:
+   *   | name       | dimensions |
+   *   | iphone_12  | 390x844    |
+   *   | 4k_display | 3840x2160  |
+   * @endcode
+   */
+  #[Given('the following responsive breakpoints exist:')]
+  public function responsiveSetBreakpointsFromTable(TableNode $table): void {
+    $breakpoints = [];
+    foreach ($table->getHash() as $row) {
+      $breakpoints[$row['name']] = $row['dimensions'];
+    }
+    $this->responsiveSetBreakpoints($breakpoints);
   }
 
   /**
@@ -246,6 +224,28 @@ trait ResponsiveTrait {
   #[When('I set the viewport to :width by :height')]
   public function responsiveSetViewportDimensions(string $width, string $height): void {
     $this->responsiveResize((int) $width, (int) $height);
+  }
+
+  /**
+   * Set custom breakpoints.
+   *
+   * Public API: a composing context may call this directly to register
+   * breakpoints outside a step.
+   *
+   * Custom breakpoints override default breakpoints with the same name.
+   *
+   * @param array<string, string> $breakpoints
+   *   Array of breakpoints in format ['name' => 'WIDTHxHEIGHT'].
+   *
+   * @throws \RuntimeException
+   *   If breakpoint format is invalid.
+   */
+  public function responsiveSetBreakpoints(array $breakpoints): void {
+    foreach ($breakpoints as $name => $dimensions) {
+      // Validate format by extracting dimensions.
+      $this->responsiveExtractDimensions($dimensions, $name);
+      $this->responsiveCustomBreakpoints[$name] = $dimensions;
+    }
   }
 
   /**

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -107,6 +107,27 @@ trait XmlTrait {
   }
 
   /**
+   * Print the last XML response.
+   *
+   * @code
+   * When I print last XML response
+   * @endcode
+   */
+  #[When('I print last XML response')]
+  public function xmlPrintLastResponse(): void {
+    $this->xmlEnsureDocument();
+
+    $this->xmlDocument->formatOutput = TRUE;
+    $output = $this->xmlDocument->saveXML();
+
+    if ($output === FALSE) {
+      throw new ExpectationException('Failed to format the XML response.', $this->getSession()->getDriver());
+    }
+
+    print $output;
+  }
+
+  /**
    * Assert that a response is valid XML.
    *
    * @code
@@ -656,27 +677,6 @@ trait XmlTrait {
   #[Then('the response should be a valid Atom feed')]
   public function xmlAssertValidAtomFeed(): void {
     $this->xmlValidateAtomFeed();
-  }
-
-  /**
-   * Print the last XML response.
-   *
-   * @code
-   * When I print last XML response
-   * @endcode
-   */
-  #[When('I print last XML response')]
-  public function xmlPrintLastResponse(): void {
-    $this->xmlEnsureDocument();
-
-    $this->xmlDocument->formatOutput = TRUE;
-    $output = $this->xmlDocument->saveXML();
-
-    if ($output === FALSE) {
-      throw new ExpectationException('Failed to format the XML response.', $this->getSession()->getDriver());
-    }
-
-    print $output;
   }
 
   /**

--- a/tests/phpunit/src/MemberOrderTest.php
+++ b/tests/phpunit/src/MemberOrderTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests;
+
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Asserts that every trait lays its members out in the documented order.
+ *
+ * A reader looking for a trait's hooks, its steps or its helpers finds them
+ * in the same place in every file. CONTRIBUTING.md states the layout; this
+ * test holds it.
+ *
+ * The order is settled between groups only. Members inside one group stay in
+ * whatever order reads best, which is also what keeps STEPS.md stable: docs.php
+ * sorts steps by Given, When and Then and preserves source order within each.
+ */
+#[CoversNothing]
+class MemberOrderTest extends UnitTestCase {
+
+  /**
+   * Ordering groups, low to high.
+   */
+  protected const GROUP_COMPOSITION = 0;
+
+  protected const GROUP_CONSTANT = 1;
+
+  protected const GROUP_PROPERTY = 2;
+
+  protected const GROUP_HOOK = 3;
+
+  protected const GROUP_GIVEN = 4;
+
+  protected const GROUP_WHEN = 5;
+
+  protected const GROUP_THEN = 6;
+
+  protected const GROUP_PUBLIC = 7;
+
+  protected const GROUP_PROTECTED = 8;
+
+  /**
+   * How each group is named in a failure message.
+   */
+  protected const GROUP_LABELS = [
+    self::GROUP_COMPOSITION => 'composed trait',
+    self::GROUP_CONSTANT => 'constant',
+    self::GROUP_PROPERTY => 'property',
+    self::GROUP_HOOK => 'hook',
+    self::GROUP_GIVEN => 'Given step',
+    self::GROUP_WHEN => 'When step',
+    self::GROUP_THEN => 'Then step',
+    self::GROUP_PUBLIC => 'public method',
+    self::GROUP_PROTECTED => 'protected helper',
+  ];
+
+  /**
+   * Step attributes mapped to the group the method they mark belongs to.
+   */
+  protected const STEP_GROUPS = [
+    Given::class => self::GROUP_GIVEN,
+    When::class => self::GROUP_WHEN,
+    Then::class => self::GROUP_THEN,
+  ];
+
+  /**
+   * Assert that a trait's members appear in non-descending group order.
+   *
+   * @param string $trait
+   *   Fully qualified trait name.
+   */
+  #[DataProvider('dataProviderMembersFollowDocumentedOrder')]
+  public function testMembersFollowDocumentedOrder(string $trait): void {
+    $members = static::orderedMembers($trait);
+
+    $this->assertNotSame([], $members, sprintf('No members were resolved for %s.', $trait));
+
+    $violations = [];
+    $highest = NULL;
+
+    foreach ($members as $member) {
+      if ($highest !== NULL && $member['group'] < $highest['group']) {
+        $violations[] = sprintf('%s is a %s but follows %s, a %s.', $member['name'], static::GROUP_LABELS[$member['group']], $highest['name'], static::GROUP_LABELS[$highest['group']]);
+        continue;
+      }
+
+      $highest = $member;
+    }
+
+    $this->assertSame([], $violations, sprintf('%s lays its members out against the order documented in CONTRIBUTING.md.', $trait));
+  }
+
+  /**
+   * Both conventions must cover the same traits, so discovery is shared.
+   */
+  public static function dataProviderMembersFollowDocumentedOrder(): array {
+    return PublicSurfaceTest::dataProviderPublicMethodsAreStepsOrHooks();
+  }
+
+  /**
+   * Return a trait's own members in source order, tagged with their group.
+   *
+   * Reflection flattens a composed trait's members into the composing trait,
+   * so a member is taken as this trait's own when its declaration is found in
+   * this trait's file.
+   *
+   * @param string $trait
+   *   Fully qualified trait name.
+   *
+   * @return array<int, array{name: string, group: int}>
+   *   Members ordered by the line declaring them.
+   */
+  protected static function orderedMembers(string $trait): array {
+    /** @var class-string $trait */
+    $reflection = new \ReflectionClass($trait);
+    $file = (string) realpath((string) $reflection->getFileName());
+    $lines = file($file) ?: [];
+
+    $members = [];
+
+    // A composition is read from the source rather than from
+    // ReflectionClass::getTraitNames(), which reports the composed trait's
+    // real name and so cannot be matched against an aliased import.
+    foreach ($lines as $index => $line) {
+      if (preg_match('/^\s+use\s+([A-Za-z\\\\][\w\\\\]*)\s*;/', $line, $matches) === 1) {
+        $members[] = ['name' => 'use ' . $matches[1], 'group' => static::GROUP_COMPOSITION, 'line' => $index + 1];
+      }
+    }
+
+    $constants = $reflection->getReflectionConstants();
+    foreach ($constants as $constant) {
+      $members[] = static::locate($lines, '/(^|\s)const\s+' . preg_quote($constant->getName(), '/') . '\s*=/', $constant->getName(), static::GROUP_CONSTANT);
+    }
+
+    $properties = $reflection->getProperties();
+    foreach ($properties as $property) {
+      $members[] = static::locate($lines, '/^\s*(public|protected|private)\s+(static\s+)?[^(){}]*\$' . preg_quote($property->getName(), '/') . '\s*(=|;)/', '$' . $property->getName(), static::GROUP_PROPERTY);
+    }
+
+    $methods = $reflection->getMethods();
+    foreach ($methods as $method) {
+      if (realpath((string) $method->getFileName()) !== $file) {
+        continue;
+      }
+
+      $members[] = ['name' => $method->getName() . '()', 'group' => static::methodGroup($method), 'line' => $method->getStartLine()];
+    }
+
+    $found = array_values(array_filter($members, static fn(?array $member): bool => $member !== NULL));
+    usort($found, static fn(array $a, array $b): int => $a['line'] <=> $b['line']);
+
+    return $found;
+  }
+
+  /**
+   * Locate a member declared without a reflectable line number.
+   *
+   * @param array<int, string> $lines
+   *   Lines of the file declaring the trait.
+   * @param string $pattern
+   *   Pattern matching the declaration.
+   * @param string $name
+   *   Member name for a failure message.
+   * @param int $group
+   *   Ordering group the member belongs to.
+   *
+   * @return array{name: string, group: int, line: int}|null
+   *   The member, or NULL when the declaration is in a composed trait.
+   */
+  protected static function locate(array $lines, string $pattern, string $name, int $group): ?array {
+    foreach ($lines as $index => $line) {
+      if (preg_match($pattern, $line) === 1) {
+        return ['name' => $name, 'group' => $group, 'line' => $index + 1];
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Return the ordering group a method belongs to.
+   *
+   * Hook attributes are recognised by namespace so that a hook from the Drupal
+   * Extension counts alongside Behat's own.
+   */
+  protected static function methodGroup(\ReflectionMethod $method): int {
+    $attributes = $method->getAttributes();
+
+    foreach ($attributes as $attribute) {
+      $name = $attribute->getName();
+
+      if (str_contains($name, '\\Hook\\')) {
+        return static::GROUP_HOOK;
+      }
+
+      if (array_key_exists($name, static::STEP_GROUPS)) {
+        return static::STEP_GROUPS[$name];
+      }
+    }
+
+    return $method->isPublic() ? static::GROUP_PUBLIC : static::GROUP_PROTECTED;
+  }
+
+}


### PR DESCRIPTION
Closes #724

## Summary

Every trait under `src` now lays its members out in one order: trait composition, constants and properties, then hooks, then `Given`, `When` and `Then` steps, then other public methods, then protected helpers. `CONTRIBUTING.md` states the layout under "Member ordering within a trait", and `tests/phpunit/src/MemberOrderTest.php` fails the build when a trait departs from it.

20 of the 51 traits sat outside the dominant layout because nothing recorded what it was, so each trait picked its own. `Drupal\QueueTrait` placed its `#[AfterScenario]` hook below the `Then` steps; `Drupal\HelperTrait` placed `helperEntityRegisterId()` above the `#[AfterScenario]` hook that calls it; `ResponsiveTrait` placed `responsiveSetBreakpoints()` above its own `#[BeforeScenario]` and `#[BeforeStep]` hooks; `Drupal\ContentTrait` buried `contentVisitActionPageWithTitle()` among the five `When` steps that call it.

Nothing about the shipped library changes. `STEPS.md` is byte-identical, every trait's reflected surface - composed traits, constants, properties, method signatures, return types and Behat attributes - compares equal before and after, and the `src` diff is 1887 insertions against 1887 deletions because every hunk is a member moved whole. No step text, method name, visibility or body is touched.

## Before / After

```
┌────────────────────────────────────────────────────────────────────────┐
│ Where a reader finds a trait's parts                                   │
├────────────────────────────────────────────────────────────────────────┤
│ BEFORE                                        AFTER                    │
│                                                                        │
│   Drupal\QueueTrait                             Drupal\QueueTrait      │
│     $queueNames                                   $queueNames          │
│     Given / When / Then ...                       #[AfterScenario]     │
│     #[AfterScenario]      <- hook below steps     Given / When / Then  │
│     helpers                                       helpers              │
│                                                                        │
│   Drupal\HelperTrait                            Drupal\HelperTrait     │
│     helperEntityRegisterId()                      const / $registry    │
│     #[AfterScenario]      <- hook below helper    #[AfterScenario]     │
│     helpers                                       helpers              │
│                                                                        │
│   ResponsiveTrait                               ResponsiveTrait        │
│     responsiveSetBreakpoints()                    properties           │
│     Given                                         #[BeforeScenario]    │
│     #[BeforeScenario]     <- hooks below step     #[BeforeStep]        │
│     #[BeforeStep]                                 Given / When         │
│     When / helpers                                public / helpers     │
│                                                                        │
│   ... 17 more traits, each with its own arrangement                    │
├────────────────────────────────────────────────────────────────────────┤
│ Enforcement                                                            │
│                                                                        │
│   BEFORE  nothing. The layout lived only in whichever file you opened. │
│   AFTER   MemberOrderTest resolves all 689 methods, 58 properties,     │
│           23 compositions and 6 constants in src and asserts each      │
│           trait's groups never descend.                                │
└────────────────────────────────────────────────────────────────────────┘
```

## Changes

**`CONTRIBUTING.md`** - new "Member ordering within a trait" section stating the 5 groups, noting that order within a group is free, and pointing at the test that enforces it. It also records why reordering an existing trait is safe: `docs.php` groups steps by `Given`, `When` and `Then` and preserves source order inside each group, so this layout only applies a sort the generated documentation already applies. #724 assumed the opposite - that `docs.php` renders in source order, so a sweep would drag `STEPS.md` with it - which is what made a mechanical sweep look not worth doing.

**20 traits reordered** - `AccessibilityTrait`, `DateTrait`, `ElementTrait`, `FieldTrait`, `FileDownloadTrait`, `JsonTrait`, `LinkTrait`, `ModalTrait`, `PathTrait`, `ResponsiveTrait`, `XmlTrait`, and `Drupal\ContentBlockTrait`, `Drupal\ContentTrait`, `Drupal\EmailTrait`, `Drupal\FileTrait`, `Drupal\HelperTrait`, `Drupal\QueueTrait`, `Drupal\TaxonomyTrait`, `Drupal\UserTrait`, `Drupal\WatchdogTrait`. Each member moved as a whole unit carrying its docblock and attributes, with relative order inside each group preserved. Boundaries came from PHP's tokenizer rather than brace counting, so the JavaScript heredocs in `ElementTrait` and `FieldTrait` survive intact.

**`tests/phpunit/src/MemberOrderTest.php`** - one data-provider row per trait, sharing `PublicSurfaceTest`'s trait discovery. Methods are classified from their attributes: anything in a `\Hook\` namespace is a hook, which covers the Drupal Extension's `#[BeforeNodeCreate]` alongside Behat's own; `#[Given]`, `#[When]` and `#[Then]` map to the step groups; everything else falls to public or protected. Compositions, constants and properties carry no reflectable line number, so they are located in the source, reading `use` lines from the file rather than from `getTraitNames()` so that `Drupal\HelperTrait`'s aliased `use CommonHelperTrait;` is matched.

## Verification

- `ahoy lint` passes: phpcs, PHPStan, Rector and gherkinlint all clean.
- `ahoy test-unit` passes: 884 tests, 1244 assertions, up from 833 with the 51 new ordering rows.
- `ahoy lint-docs` reports `STEPS.md` up to date; its MD5 is unchanged.
- A reflection snapshot of all 51 traits, covering composed traits, constants with values, property modifiers, and every method's modifiers, parameters, defaults, return type and attributes, is identical before and after.
- `MemberOrderTest` was checked against violations rather than only against the fixed tree: restoring `Drupal\QueueTrait`, `Drupal\HelperTrait` and `ResponsiveTrait` to their prior order produced 3 failures naming the exact members out of place.
- Every member in `src` is accounted for by the test, not merely a subset: 689 of 689 declared methods, 58 of 58 properties, 23 of 23 in-trait `use` statements and 6 of 6 constants.

## Screenshots

N/A
