### PR TITLE
[#725] Replaced coverage markers on reachable branches with tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,25 @@ ahoy test-bdd path/to/file   # Run all Behat scenarios in specific feature file
 ahoy test-bdd -- --tags=wip  # Run all Behat scenarios tagged with `@wip` tag
 ```
 
+### Coverage markers
+
+`@codeCoverageIgnoreStart` and `@codeCoverageIgnoreEnd` suppress **genuinely unreachable** defensive code. They are not a way to hide an untested branch.
+
+The distinction matters because PHPUnit drops ignored lines from the report entirely. Ignoring a line that a test would have covered lowers the reported rate, which is merely wasteful. Ignoring a line that no test covers *raises* it, which reports progress that does not exist. `codecov/patch` and `codecov/project` are required checks, so that second case shifts the baseline every later pull request is measured against.
+
+Mark a block only when a test cannot reach it in this environment:
+
+- An I/O failure that cannot be provoked - `file_get_contents()` returning `FALSE` on a file just written, `tempnam()` failing.
+- A type guard that the preceding call makes impossible - `!$node instanceof NodeInterface` directly after a successful load.
+- A capability branch for a driver the suite does not run.
+
+Do not mark a branch that a scenario could reach. In particular:
+
+- **Skip-tag guards** (`@behat-steps-skip:<method>`) are reachable by definition - add a scenario carrying the tag.
+- **Argument validation** driven by a step parameter is reachable by passing an invalid value.
+
+If a reachable branch has no test, the fix is the test, not the marker.
+
 ### Debugging tests
 
 - `ahoy debug`

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -52,11 +52,9 @@ trait EmailTrait {
    */
   #[BeforeScenario('@api')]
   public function emailBeforeScenario(BeforeScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
     if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
       return;
     }
-    // @codeCoverageIgnoreEnd
     if (!$scope->getScenario()->hasTag('email')) {
       return;
     }
@@ -350,11 +348,9 @@ trait EmailTrait {
    */
   #[Then('the email field :field should not contain:')]
   public function emailAssertMessageFieldNotContains(string $field, PyStringNode $string, bool $exact = FALSE): void {
-    // @codeCoverageIgnoreStart
     if (!in_array($field, ['subject', 'body', 'to', 'from', 'cc', 'bcc'], TRUE)) {
       throw new \RuntimeException(sprintf('Invalid email field %s was specified for assertion.', $field));
     }
-    // @codeCoverageIgnoreEnd
     $string = (string) $string;
     $string = $exact ? $string : $this->helperNormalizeWhitespace($string);
 
@@ -679,11 +675,9 @@ trait EmailTrait {
    *   Email message or NULL if not found.
    */
   protected function emailFindMessage(string $field, PyStringNode $string, bool $exact = FALSE): ?array {
-    // @codeCoverageIgnoreStart
     if (!in_array($field, ['subject', 'body', 'to', 'from', 'cc', 'bcc'], TRUE)) {
       throw new \RuntimeException(sprintf('Invalid email field %s was specified for assertion.', $field));
     }
-    // @codeCoverageIgnoreEnd
     $string = (string) $string;
     $string = $this->helperNormalizeWhitespace($string);
 

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -44,11 +44,9 @@ trait FileTrait {
    */
   #[BeforeScenario('@api')]
   public function fileBeforeScenario(BeforeScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
     if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
       return;
     }
-    // @codeCoverageIgnoreEnd
     // The 6.x Drupal driver bootstraps lazily on the first step that needs
     // Drupal, so the container may not exist yet when this hook fires. The
     // file operations that need the directories create them on demand.
@@ -185,11 +183,9 @@ trait FileTrait {
    */
   #[AfterScenario('@api')]
   public function fileAfterScenario(AfterScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
     if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
       return;
     }
-    // @codeCoverageIgnoreEnd
     foreach ($this->filesUnmanagedUris as $uri) {
       @unlink($uri);
     }

--- a/src/Drupal/ModuleTrait.php
+++ b/src/Drupal/ModuleTrait.php
@@ -38,11 +38,9 @@ trait ModuleTrait {
    */
   #[BeforeScenario('@api')]
   public function moduleBeforeScenario(BeforeScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
     if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
       return;
     }
-    // @codeCoverageIgnoreEnd
     $tags = $scope->getScenario()->getTags();
     foreach ($tags as $tag) {
       if (str_starts_with($tag, 'module:')) {

--- a/src/Drupal/TestmodeTrait.php
+++ b/src/Drupal/TestmodeTrait.php
@@ -26,11 +26,9 @@ trait TestmodeTrait {
    */
   #[BeforeScenario('@api')]
   public function testmodeBeforeScenario(BeforeScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
     if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
       return;
     }
-    // @codeCoverageIgnoreEnd
     if ($scope->getScenario()->hasTag('testmode')) {
       self::testmodeEnableTestMode();
     }
@@ -41,11 +39,9 @@ trait TestmodeTrait {
    */
   #[AfterScenario('@api')]
   public function testmodeAfterScenario(AfterScenarioScope $scope): void {
-    // @codeCoverageIgnoreStart
     if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__)) {
       return;
     }
-    // @codeCoverageIgnoreEnd
     if ($scope->getScenario()->hasTag('testmode')) {
       self::testmodeDisableTestMode();
     }

--- a/tests/behat/features/drupal_email.feature
+++ b/tests/behat/features/drupal_email.feature
@@ -757,3 +757,45 @@ Feature: Check that EmailTrait works
   @api @email
   Scenario: The mailsystem formatter should not be overridden when test email system is enabled
     Then the mailsystem formatter should be "php_mail"
+
+  @api @trait:Drupal\EmailTrait
+  Scenario: Assert that skip tag for beforeScenario hook works
+    Given some behat configuration
+    And scenario steps tagged with "@api @email @behat-steps-skip:emailBeforeScenario":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @api @trait:Drupal\EmailTrait
+  Scenario: Assert that an unknown email field is rejected by a positive assertion
+    Given some behat configuration
+    And scenario steps tagged with "@api @email":
+      """
+      Then the email field "nonexistent" should contain:
+        '''
+        anything
+        '''
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Invalid email field nonexistent was specified for assertion.
+      """
+
+  @api @trait:Drupal\EmailTrait
+  Scenario: Assert that an unknown email field is rejected by a negative assertion
+    Given some behat configuration
+    And scenario steps tagged with "@api @email":
+      """
+      Then the email field "nonexistent" should not contain:
+        '''
+        anything
+        '''
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an exception:
+      """
+      Invalid email field nonexistent was specified for assertion.
+      """

--- a/tests/behat/features/drupal_file.feature
+++ b/tests/behat/features/drupal_file.feature
@@ -193,3 +193,23 @@ Feature: Check that FileTrait works
       """
       File contents "test content" contains "test content", but should not.
       """
+
+  @api @trait:Drupal\FileTrait
+  Scenario: Assert that skip tag for beforeScenario hook works
+    Given some behat configuration
+    And scenario steps tagged with "@api @behat-steps-skip:fileBeforeScenario":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @api @trait:Drupal\FileTrait
+  Scenario: Assert that skip tag for afterScenario hook works
+    Given some behat configuration
+    And scenario steps tagged with "@api @behat-steps-skip:fileAfterScenario":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should pass

--- a/tests/behat/features/drupal_module.feature
+++ b/tests/behat/features/drupal_module.feature
@@ -215,3 +215,13 @@ Feature: Check that ModuleTrait works
       """
       The module "help" is enabled, but it should not be.
       """
+
+  @api @trait:Drupal\ModuleTrait
+  Scenario: Assert that skip tag for beforeScenario hook works
+    Given some behat configuration
+    And scenario steps tagged with "@api @behat-steps-skip:moduleBeforeScenario":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should pass

--- a/tests/behat/features/drupal_testmode.feature
+++ b/tests/behat/features/drupal_testmode.feature
@@ -38,3 +38,23 @@ Feature: Ensure TestmodeTrait works.
     And I should see the text "[MYTEST] Article 6"
     And I should see the text "[MYTEST] Article 7"
     And I save screenshot
+
+  @api @trait:Drupal\TestmodeTrait
+  Scenario: Assert that skip tag for beforeScenario hook works
+    Given some behat configuration
+    And scenario steps tagged with "@api @testmode @behat-steps-skip:testmodeBeforeScenario":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @api @trait:Drupal\TestmodeTrait
+  Scenario: Assert that skip tag for afterScenario hook works
+    Given some behat configuration
+    And scenario steps tagged with "@api @testmode @behat-steps-skip:testmodeAfterScenario":
+      """
+      When I visit "/"
+      """
+    When I run "behat --no-colors"
+    Then it should pass


### PR DESCRIPTION
Closes #725

## Summary

#725 asks for the ~70 marked blocks to be audited and split: branches that truly cannot be reached in a test environment keep the marker, branches that are merely untested lose it and get a test or an acknowledged gap. It also asks for the underlying question to be settled - what the markers are actually for.

All 92 marked blocks were inventoried and classified. Eight were reachable and are now tested. The rest are genuinely unreachable and keep their markers. The rule is written down.

## Why the direction of the error matters

PHPUnit drops an ignored line from the report entirely, so the two mistakes are not symmetric:

- Ignoring a line a test **would have covered** removes a covered line from both halves of the ratio, which lowers the reported rate. Wasteful, but conservative.
- Ignoring a line **no test covers** removes an uncovered line, which **raises** the reported rate. That reports progress that does not exist.

Only the second is a defect, and `codecov/patch` and `codecov/project` are required checks, so it shifts the baseline every later pull request is measured against. The audit targeted that direction.

## The eight reachable blocks

**Six skip-tag guards.** A `@behat-steps-skip:<method>` guard is reachable by definition: write a scenario carrying the tag. The suite already does this for thirteen other hooks, so these six were untested rather than unreachable - `emailBeforeScenario`, `fileBeforeScenario`, `fileAfterScenario`, `moduleBeforeScenario`, `testmodeBeforeScenario` and `testmodeAfterScenario`. All six hooks filter on `@api`, so each new scenario carries `@api` for the hook to fire and the guard to be evaluated.

**Two email field whitelists.** `emailAssertMessageFieldNotContains()` and `emailFindMessage()` reject a field outside `subject, body, to, from, cc, bcc`. The field arrives as a step argument, so an invalid value is reachable by writing one.

That is 92 markers down to 84, with eight scenarios added.

## The remaining 84, and why they stay

| Shape | Count | Decision |
|---|---|---|
| Bare throw after an I/O or init failure | 22 | Keep. `file_get_contents()` returning `FALSE` on a file just written, `tempnam()` failing, `curl_init()` returning `FALSE` - not provokable from a scenario. |
| Guard conditions on unreachable state | 36 | Keep. |
| Catch blocks on degradation paths | 7 | Keep. |
| Type guards | 5 | Keep. `!$node instanceof NodeInterface` directly after a successful load cannot be false. |
| Driver-capability throws | 14 | Keep. Reachable only under a driver the suite does not run. |

## Verification

Coverage was measured rather than assumed. Running `drupal_testmode.feature` with coverage reports `TestmodeTrait` uncovered lines as `35, 50, 58, 65`. The two skip-tag guards sit at lines `29` and `42`, and neither appears, so both are now genuinely executed rather than suppressed.

All affected suites pass: email 58 scenarios, module 24, file 14, testmode 4. `ahoy lint`, `ahoy test-unit` and `ahoy lint-docs` all pass. `STEPS.md` is unchanged.

This lands on its own so the coverage delta is attributable, as #725 asks.

## Before / After

```
┌───────────────────────────────────────────────────────────────────────┐
│ A skip-tag guard                                                      │
├───────────────────────────────────────────────────────────────────────┤
│ BEFORE                                                                │
│   // @codeCoverageIgnoreStart                                         │
│   if ($scope->getScenario()->hasTag('behat-steps-skip:' . __FUNCTION__│
│     return;                                                           │
│   }                                                                   │
│   // @codeCoverageIgnoreEnd                                           │
│                                                                       │
│   No test reaches it. The lines leave the report, and the reported    │
│   rate goes up because uncovered lines were removed.                  │
│                                                                       │
│ AFTER                                                                 │
│   The guard is unmarked, and a scenario tagged                        │
│   @behat-steps-skip:<method> executes it. The lines are in the        │
│   report and covered, because a test covers them.                     │
└───────────────────────────────────────────────────────────────────────┘
```
