### PR TITLE
Updated scaffold to 1.2.0.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,9 +13,6 @@ insert_final_newline = true
 [*.php]
 indent_size = 2
 
-[*.js]
-indent_size = 2
-
 [*.{json,lock}]
 indent_size = 4
 

--- a/.github/workflows/assign-author.yml
+++ b/.github/workflows/assign-author.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   assign-author:
+    name: Assign author
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -12,14 +12,33 @@ permissions:
 
 jobs:
   release-drafter:
+    name: Draft release notes
+    runs-on: ubuntu-latest
+
     permissions:
       contents: write
       pull-requests: write
 
-    runs-on: ubuntu-latest
-
     steps:
+      - name: Set version
+        id: version
+        env:
+          RELEASE_VERSION_SCHEME: ${{ vars.RELEASE_VERSION_SCHEME }}
+        run: |
+          SCHEME="${RELEASE_VERSION_SCHEME}"
+          if [ "${SCHEME}" = "calver" ]; then
+            VERSION="$(date "+%y.%-m").0"
+            echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+            echo "Using CalVer: ${VERSION}"
+          else
+            echo "Using SemVer (default)"
+          fi
+
       - name: Draft release notes
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
+        with:
+          tag: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
+          version: ${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@
 /patches.lock.json
 /docker-compose.override.yml
 /vendor
+
+# Temporary AI agent and developer artifacts (plans, scratch output, reports).
+/.artifacts/
+
+# Claude Code fetches the project update skill on demand; do not commit it.
+/.claude/skills/update-consumer-scaffold/

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         "behat/mink": ">=1.11"
     },
     "require-dev": {
-        "alexskrypnyk/phpunit-helpers": "^0.15.0",
+        "alexskrypnyk/phpunit-helpers": "^0.16.0",
         "cweagans/composer-patches": "^2.0",
         "dantleech/gherkin-lint": "^0.2.3",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
         "dmore/behat-chrome-extension": "^1.4",
         "drevops/behat-phpserver": "^2.1.1",
         "drevops/behat-screenshot": "^2.1",
@@ -33,7 +33,7 @@
         "drupal/coder": "^8.3.28",
         "drupal/drupal-extension": "^6.0",
         "dvdoug/behat-code-coverage": "^5.3.2.1",
-        "ergebnis/composer-normalize": "^2.47",
+        "ergebnis/composer-normalize": "^2.52.0",
         "justinrainbow/json-schema": "^6.0",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "mglaman/phpstan-drupal": "^2.0.0",
@@ -41,9 +41,9 @@
         "phpcompatibility/php-compatibility": "^9.3.5",
         "phpspec/prophecy-phpunit": "^2.3",
         "phpstan/extension-installer": "^1.4.3",
-        "phpstan/phpstan": "^2.0.0",
-        "phpunit/phpunit": "^11",
-        "rector/rector": "^2.0",
+        "phpstan/phpstan": "^2.2.8",
+        "phpunit/phpunit": "^11.5.56",
+        "rector/rector": "^2.6.2",
         "softcreatr/jsonpath": "^0.10 || ^1.0"
     },
     "conflict": {
@@ -73,7 +73,17 @@
             "ergebnis/composer-normalize": true,
             "phpstan/extension-installer": true
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "discard-changes": true,
+        "policy": {
+            "advisories": {
+                "block": false,
+                "audit": "fail"
+            },
+            "abandoned": {
+                "audit": "report"
+            }
+        }
     },
     "extra": {
         "patches": {
@@ -81,5 +91,7 @@
                 "Support for custom Drupal root": "https://patch-diff.githubusercontent.com/raw/mglaman/phpstan-drupal/pull/873.diff"
             }
         }
-    }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,8 @@
         "lullabot/mink-selenium2-driver": "JavaScript driver for @javascript scenarios: drives a Selenium/WebDriver server. Interchangeable with dmore/behat-chrome-extension - install one.",
         "softcreatr/jsonpath": "Required by JsonTrait for JSON path assertion steps ('the JSON path ... should ...')."
     },
+    "minimum-stability": "stable",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "DrevOps\\BehatSteps\\": "src/"
@@ -73,7 +75,6 @@
             "ergebnis/composer-normalize": true,
             "phpstan/extension-installer": true
         },
-        "sort-packages": true,
         "discard-changes": true,
         "policy": {
             "advisories": {
@@ -83,7 +84,8 @@
             "abandoned": {
                 "audit": "report"
             }
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "patches": {
@@ -91,7 +93,5 @@
                 "Support for custom Drupal root": "https://patch-diff.githubusercontent.com/raw/mglaman/phpstan-drupal/pull/873.diff"
             }
         }
-    },
-    "minimum-stability": "stable",
-    "prefer-stable": true
+    }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,21 @@
 {
     "extends": ["config:recommended"],
     "automerge": true,
+    "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "pinDigests": true,
     "branchPrefix": "deps/",
-    "enabledManagers": ["github-actions"],
     "packageRules": [
+        {
+            "matchDepNames": ["php"],
+            "matchManagers": ["composer"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["composer"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
         {
             "matchPackageNames": ["*"],
             "groupName": "all dependencies",


### PR DESCRIPTION
## Summary

This applies the [AlexSkrypnyk/scaffold](https://github.com/AlexSkrypnyk/scaffold) template v1.2.0 to the project via the full re-init flow: wipe root, extract template 1.2.0, run `init.sh`, then restore all project-owned code from git and reconcile file by file. Six files changed: `composer.json`, `renovate.json`, two GitHub Actions workflows, `.gitignore`, and `.editorconfig`. The update brings shared dev-tool floors and the Composer security-audit/stability policy in line with the template, while deliberately keeping this repository's PHP 8.2 / Drupal 10 support matrix and its bespoke Behat/Drupal-fixture CI pipeline, neither of which the template models.

## Changes

- **`composer.json`** - adopted the template's `minimum-stability: stable`, `prefer-stable: true`, `config.discard-changes` and the `config.policy` security-audit block (advisories `audit: fail`, abandoned `audit: report`); bumped shared dev-tool floors to the template's versions (`alexskrypnyk/phpunit-helpers` 0.16.0, `dealerdirect/phpcodesniffer-composer-installer` 1.2.1, `ergebnis/composer-normalize` 2.52.0, `phpstan/phpstan` 2.2.8, `phpunit/phpunit` 11.5.56, `rector/rector` 2.6.2); then normalized key ordering.
- **`renovate.json`** - took the template's version: adds `rangeStrategy: bump`, and drops `enabledManagers: ["github-actions"]` so Renovate now also manages Composer dependencies, with new guard rules disabling Composer *major* updates and pinning of the `php` constraint. This is a behavior change - Renovate will begin proposing Composer minor/patch PRs on this repo.
- **`.github/workflows/draft-release-notes.yml`** - template refresh adding an opt-in CalVer version scheme driven by the `RELEASE_VERSION_SCHEME` repository variable, defaulting to SemVer when the variable is unset.
- **`.github/workflows/assign-author.yml`** - template refresh adding an explicit job `name`.
- **`.gitignore`** - added the template's `/.artifacts/` ignore and an ignore for the on-demand `/.claude/skills/update-consumer-scaffold/` skill directory.
- **`.editorconfig`** - template refresh dropped the `[*.js]` block (no tracked JS in this repo); the `[*.{sh,bash,bats}]` block was kept because `scripts/provision.sh` exists.

### Deliberately not adopted

- `php: >=8.3` and `drupal/coder ^9` from the template - CI's matrix tests PHP 8.2 with Drupal 10, and raising the floor would break it and be a breaking change for library consumers.
- The template's generated `AGENTS.md`, `.github/workflows/test-php.yml` and `.github/workflows/release-php.yml` - they describe a Symfony CLI app with `src/Command/` and namespace `DrevOps\App\`, which misdescribes this trait library (`DrevOps\BehatSteps\`), and the two workflows would duplicate/conflict with the repo's bespoke `test.yml`; they were discarded during reconciliation and never committed to this branch.
- The project's own `.gitattributes` export-ignore list was kept over the template's shorter one, to avoid bloating the Packagist dist archive.
- The template's `/.claude/settings.local.json` gitignore line was not added.

## Before / After

```
RENOVATE DEPENDENCY SCOPE

  BEFORE
  ┌──────────────────────────────────────────────┐
  │ renovate.json                                │
  │   enabledManagers: ["github-actions"]        │
  │                                              │
  │   composer.json deps -> not watched          │
  └──────────────────────────────────────────────┘
                    │
                    ▼
  AFTER
  ┌──────────────────────────────────────────────┐
  │ renovate.json                                │
  │   rangeStrategy: "bump"                      │
  │   (enabledManagers restriction removed)      │
  │                                              │
  │   composer.json deps -> watched:             │
  │     minor/patch  -> PR proposed              │
  │     major        -> blocked (packageRule)    │
  │     "php" range  -> pinned (packageRule)     │
  └──────────────────────────────────────────────┘


COMPOSER INSTALL POLICY

  BEFORE
  ┌──────────────────────────────────────────────┐
  │ composer.json                                │
  │   minimum-stability   -> unset (implicit)    │
  │   security advisories -> not audited         │
  └──────────────────────────────────────────────┘
                    │
                    ▼
  AFTER
  ┌──────────────────────────────────────────────┐
  │ composer.json                                │
  │   minimum-stability: stable                  │
  │   prefer-stable: true                        │
  │   policy.advisories.audit: fail              │
  │   policy.abandoned.audit: report             │
  └──────────────────────────────────────────────┘
```
