### PR TITLE
[#746] Served fixtures for non-Drupal traits from the PHP server.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,19 @@ composer require --dev drevops/behat-steps:^3
 
 ### Fixture Files Management
 
-**CRITICAL: Always copy fixture files to all three locations**
+Static fixture files live in `tests/behat/fixtures/`.
 
-When creating or updating fixture files in `tests/behat/fixtures/`, you **MUST**
-immediately copy them to `build/web/sites/default/files/`
+Traits without a Drupal dependency read them from a PHP built-in server: tag the
+scenario `@phpserver` and address the file as `http://cli:8888/<file>`. The
+server serves `tests/behat/fixtures/` at its root, so an edited fixture applies
+on the next run.
 
-**Example:**
+Drupal traits read them through the fixture site, which receives a copy of the
+directory in `build/web/sites/default/files/` during provisioning. After editing
+a fixture that a Drupal-served scenario reaches, copy it across:
+
 ```bash
-cp tests/behat/fixtures/example.xml build/web/sites/default/files/example.xml
+ahoy copy-files
 ```
 
 ## Steps Format Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,23 @@ ahoy test-bdd path/to/file   # Run all Behat scenarios in specific feature file
 ahoy test-bdd -- --tags=wip  # Run all Behat scenarios tagged with `@wip` tag
 ```
 
+### Static fixtures
+
+Static fixture files - HTML pages, XML, JSON, images, archives - live in [tests/behat/fixtures](tests/behat/fixtures).
+
+Traits with no Drupal dependency are tested against those files served by a PHP built-in server instead of the fixture Drupal site. Tag the scenario `@phpserver` and address the file directly:
+
+```gherkin
+@phpserver
+Scenario: Assert that an element exists
+  When I visit "http://cli:8888/elements.html"
+  Then the element "#top" should exist
+```
+
+The server runs for the duration of a tagged scenario and serves `tests/behat/fixtures` at its root, so an edited fixture applies on the next run.
+
+Drupal traits are tested through the fixture site, which receives a copy of the same directory in `build/web/sites/default/files` during provisioning. Run `ahoy copy-files` after editing a fixture that such a scenario reaches through a Drupal path.
+
 ### Coverage markers
 
 `@codeCoverageIgnoreStart` and `@codeCoverageIgnoreEnd` suppress **genuinely unreachable** defensive code. They are not a way to hide an untested branch.

--- a/STEPS.md
+++ b/STEPS.md
@@ -1587,7 +1587,7 @@ Download a file from the specified URL
 <br/><br/>
 
 ```gherkin
-When I download the file from the URL "/sites/default/files/document.pdf"
+When I download the file from the URL "/files/document.pdf"
 When I download the file from the URL "http://example.com/files/report.xlsx"
 
 ```

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -73,7 +73,7 @@ trait FileDownloadTrait {
    * Download a file from the specified URL.
    *
    * @code
-   * When I download the file from the URL "/sites/default/files/document.pdf"
+   * When I download the file from the URL "/files/document.pdf"
    * When I download the file from the URL "http://example.com/files/report.xlsx"
    * @endcode
    */

--- a/tests/behat/bootstrap/FeatureContextTrait.php
+++ b/tests/behat/bootstrap/FeatureContextTrait.php
@@ -433,15 +433,6 @@ trait FeatureContextTrait {
   }
 
   /**
-   * Go to the phpserver test page.
-   */
-  #[Given('/^(?:|I )am on (?:|the )phpserver test page$/')]
-  #[When('/^(?:|I )go to (?:|the )phpserver test page$/')]
-  public function goToPhpServerTestPage(): void {
-    $this->getSession()->visit('http://cli:8888/elements_relative.html');
-  }
-
-  /**
    * Assert that the mailsystem formatter has the expected value.
    */
   #[Then('the mailsystem formatter should be :expected')]

--- a/tests/behat/bootstrap/FeatureContextTrait.php
+++ b/tests/behat/bootstrap/FeatureContextTrait.php
@@ -413,9 +413,12 @@ trait FeatureContextTrait {
       $cookie_jar->set($cookie);
     }
 
-    // CDP-based drivers like the Chrome (chrome-mink) driver.
+    // CDP-based drivers like the Chrome (chrome-mink) driver. Their own
+    // setCookie() binds the cookie to the configured base URL, so a page served
+    // from another origin never receives it. Writing through the document keeps
+    // the cookie on the origin the scenario is on.
     if (method_exists($driver, 'getCookies')) {
-      $driver->setCookie($name, $value);
+      $driver->evaluateScript(sprintf('document.cookie = %s;', json_encode($name . '=' . rawurlencode($value) . '; path=/')));
     }
   }
 

--- a/tests/behat/features/accessibility.feature
+++ b/tests/behat/features/accessibility.feature
@@ -3,34 +3,34 @@ Feature: Check that AccessibilityTrait works
   I want to assess accessibility of rendered pages
   So that consumers can fail scenarios on WCAG violations
 
-  @javascript
+  @javascript @phpserver
   Scenario: Clean page passes the explicit assertion
-    Given I visit "/sites/default/files/accessibility_clean.html"
+    Given I visit "http://cli:8888/accessibility_clean.html"
     Then the current page should pass accessibility checks
 
-  @javascript
+  @javascript @phpserver
   Scenario: Clean page passes the explicit assertion for a specific tag set
-    Given I visit "/sites/default/files/accessibility_clean.html"
+    Given I visit "http://cli:8888/accessibility_clean.html"
     Then the current page should pass accessibility checks for tags "wcag2a"
 
-  @javascript @accessibility
+  @javascript @accessibility @phpserver
   Scenario: Auto mode passes when navigating between clean pages
-    Given I visit "/sites/default/files/accessibility_clean.html"
+    Given I visit "http://cli:8888/accessibility_clean.html"
     Then I should see "Clean Accessibility Page"
     When I follow "Go to second clean page"
     Then I should see "Second Clean Accessibility Page"
 
-  @javascript @accessibility:warning
+  @javascript @accessibility:warning @phpserver
   Scenario: Auto mode with warning tag never fails even on a broken page
-    Given I visit "/sites/default/files/accessibility_violations.html"
+    Given I visit "http://cli:8888/accessibility_violations.html"
     Then I should see "Inaccessible Page"
 
   @trait:AccessibilityTrait
   Scenario: Explicit assertion fails on a page with violations
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
-      Given I visit "/sites/default/files/accessibility_violations.html"
+      Given I visit "http://cli:8888/accessibility_violations.html"
       Then the current page should pass accessibility checks
       """
     When I run "behat --no-colors"
@@ -40,7 +40,7 @@ Feature: Check that AccessibilityTrait works
       """
     And the output should contain:
       """
-      Accessibility gate failed on /sites/default/files/accessibility_violations.html
+      Accessibility gate failed on http://cli:8888/accessibility_violations.html
       """
     And the output should contain:
       """
@@ -54,9 +54,9 @@ Feature: Check that AccessibilityTrait works
   @trait:AccessibilityTrait
   Scenario: Auto mode fails on a page with violations
     Given some behat configuration
-    And scenario steps tagged with "@javascript @accessibility":
+    And scenario steps tagged with "@javascript @accessibility @phpserver":
       """
-      Given I visit "/sites/default/files/accessibility_violations.html"
+      Given I visit "http://cli:8888/accessibility_violations.html"
       Then I should see "Inaccessible Page"
       """
     When I run "behat --no-colors"
@@ -66,15 +66,15 @@ Feature: Check that AccessibilityTrait works
       """
     And the output should contain:
       """
-      violation [critical] image-alt on /sites/default/files/accessibility_violations.html
+      violation [critical] image-alt on http://cli:8888/accessibility_violations.html
       """
 
   @trait:AccessibilityTrait
   Scenario: Auto mode with critical threshold ignores serious violations only
     Given some behat configuration
-    And scenario steps tagged with "@javascript @accessibility:critical":
+    And scenario steps tagged with "@javascript @accessibility:critical @phpserver":
       """
-      Given I visit "/sites/default/files/accessibility_violations.html"
+      Given I visit "http://cli:8888/accessibility_violations.html"
       Then I should see "Inaccessible Page"
       """
     When I run "behat --no-colors"
@@ -90,11 +90,11 @@ Feature: Check that AccessibilityTrait works
   @trait:AccessibilityTrait
   Scenario: A cross-page aggregate report is written after the suite
     Given some behat configuration
-    And scenario steps tagged with "@javascript @accessibility:warning":
+    And scenario steps tagged with "@javascript @accessibility:warning @phpserver":
       """
-      Given I visit "/sites/default/files/accessibility_violations.html"
+      Given I visit "http://cli:8888/accessibility_violations.html"
       Then I should see "Inaccessible Page"
-      When I visit "/sites/default/files/accessibility_clean.html"
+      When I visit "http://cli:8888/accessibility_clean.html"
       Then I should see "Clean Accessibility Page"
       """
     When I run "behat --no-colors"
@@ -104,9 +104,9 @@ Feature: Check that AccessibilityTrait works
   @trait:AccessibilityTrait
   Scenario: Warning mode writes a JUnit report with no failures
     Given some behat configuration
-    And scenario steps tagged with "@javascript @accessibility:warning":
+    And scenario steps tagged with "@javascript @accessibility:warning @phpserver":
       """
-      Given I visit "/sites/default/files/accessibility_violations.html"
+      Given I visit "http://cli:8888/accessibility_violations.html"
       Then I should see "Inaccessible Page"
       """
     When I run "behat --no-colors"

--- a/tests/behat/features/behatcli_javascript.feature
+++ b/tests/behat/features/behatcli_javascript.feature
@@ -4,16 +4,16 @@ Feature: Behat CLI context Javascript steps
   Tests that JS sessions can be correctly started and ended when running
   multiple Behat runs through CLI.
 
-  @javascript
+  @javascript @phpserver
   Scenario: Test @javascript session can be started for the scenario
-    Given I visit "/sites/default/files/javascript_clean1.html"
+    Given I visit "http://cli:8888/javascript_clean1.html"
 
   @trait:PathTrait
   Scenario: Test @javascript session can be started for an assertion
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
-      Given I visit "/sites/default/files/javascript_clean1.html"
+      Given I visit "http://cli:8888/javascript_clean1.html"
       """
     When I run "behat --no-colors"
     Then it should pass
@@ -21,13 +21,13 @@ Feature: Behat CLI context Javascript steps
   @trait:PathTrait
   Scenario: Test @javascript session can be started for assertion in the second run
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
-      Given I visit "/sites/default/files/javascript_clean1.html"
+      Given I visit "http://cli:8888/javascript_clean1.html"
       """
     When I run "behat --no-colors"
     Then it should pass
 
-  @javascript
+  @javascript @phpserver
   Scenario: Test @javascript session can be started for the scenario in the third run
-    Given I visit "/sites/default/files/javascript_clean1.html"
+    Given I visit "http://cli:8888/javascript_clean1.html"

--- a/tests/behat/features/cookie.feature
+++ b/tests/behat/features/cookie.feature
@@ -3,15 +3,16 @@ Feature: Check that CookieTrait works
   I want to provide tools to verify browser cookies and their values
   So that users can test session management and user preferences
 
+  @phpserver
   Scenario: Assert step definition "a cookie with( the) name :name should exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     And I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with the name "testname" should exist
     And a cookie with the name "testname" should exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with( the) name :name should exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     And I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with the name "testname" should exist
     And a cookie with the name "testname" should exist
@@ -19,9 +20,9 @@ Feature: Check that CookieTrait works
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with( the) name :name should exist" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testothername" and value "testothervalue"
       Then a cookie with the name "testname" should exist
       """
@@ -31,15 +32,16 @@ Feature: Check that CookieTrait works
       The cookie with name "testname" was not set.
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with( the) name :name and value :value should exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with the name "testname" and the value "testvalue" should exist
     And a cookie with the name "testname" and the value "testvalue" should exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with( the) name :name and value :value should exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with the name "testname" and the value "testvalue" should exist
     And a cookie with the name "testname" and the value "testvalue" should exist
@@ -47,9 +49,9 @@ Feature: Check that CookieTrait works
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with( the) name :name and value :value should exist" fails with an error for incorrect name
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testothername" and value "testothervalue"
       Then a cookie with the name "testname" and the value "testvalue" should exist
       """
@@ -62,9 +64,9 @@ Feature: Check that CookieTrait works
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with( the) name :name and value :value should exist" fails with an error for incorrect value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testothername" and value "testothervalue"
       Then a cookie with the name "testothername" and the value "testvalue" should exist
       """
@@ -74,15 +76,16 @@ Feature: Check that CookieTrait works
       The cookie with name "testothername" was set with value "testothervalue", but it should be "testvalue".
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with the name :name and a value containing :partial_value should exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with the name "testname" and a value containing "estva" should exist
     And a cookie with the name "testname" and a value containing "estva" should exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with the name :name and a value containing :partial_value should exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with the name "testname" and a value containing "estva" should exist
     And a cookie with the name "testname" and a value containing "estva" should exist
@@ -90,9 +93,9 @@ Feature: Check that CookieTrait works
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with the name :name and a value containing :partial_value should exist" fails with an error for incorrect name
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testothername" and value "testvalue"
       Then a cookie with the name "testname" and a value containing "estva" should exist
       """
@@ -105,9 +108,9 @@ Feature: Check that CookieTrait works
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with the name :name and a value containing :partial_value should exist" fails with an error for incorrect value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testname" and value "testothervalue"
       Then a cookie with the name "testname" and a value containing "estva" should exist
       """
@@ -117,23 +120,24 @@ Feature: Check that CookieTrait works
       The cookie with name "testname" was set with value "testothervalue", but it should contain "estva".
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name should exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with a name containing "estna" should exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name should exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with a name containing "estna" should exist
 
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with a name containing :partial_name should exist" fails with an error for incorrect name
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testothername" and value "testvalue"
       Then a cookie with a name containing "estna" should exist
       """
@@ -143,23 +147,24 @@ Feature: Check that CookieTrait works
       The cookie with name containing "estna" was not set.
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name and the value :value should exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with a name containing "estna" and the value "testvalue" should exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name and the value :value should exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with a name containing "estna" and the value "testvalue" should exist
 
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with a name containing :partial_name and the value :value should exist" fails with an error for incorrect name
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testothername" and value "testvalue"
       Then a cookie with a name containing "estna" and the value "testvalue" should exist
       """
@@ -172,9 +177,9 @@ Feature: Check that CookieTrait works
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with a name containing :partial_name and the value :value should exist" fails with an error for incorrect value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testname" and value "prefixtestvaluesuffix"
       Then a cookie with a name containing "estna" and the value "testvalue" should exist
       """
@@ -184,23 +189,24 @@ Feature: Check that CookieTrait works
       The cookie with name containing "estna" was set with value "prefixtestvaluesuffix", but it should be "testvalue".
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name and a value containing :partial_value should exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with a name containing "estna" and a value containing "estval" should exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name and a value containing :partial_value should exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "testvalue"
     Then a cookie with a name containing "estna" and a value containing "estval" should exist
 
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with a name containing :partial_name and a value containing :partial_value should exist" fails with an error for incorrect name
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testothername" and value "testvalue"
       Then a cookie with a name containing "estna" and a value containing "estval" should exist
       """
@@ -213,9 +219,9 @@ Feature: Check that CookieTrait works
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with a name containing :partial_name and a value containing :partial_value should exist" fails with an error for incorrect value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testname" and value "testothervalue"
       Then a cookie with a name containing "estna" and a value containing "estval" should exist
       """
@@ -229,23 +235,24 @@ Feature: Check that CookieTrait works
   # NOT EXISTS
   #
 
+  @phpserver
   Scenario: Assert step definition "a cookie with the name :name should not exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "othername" and value "othervalue"
     Then a cookie with the name "testname" should not exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with the name :name should not exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "othername" and value "othervalue"
     Then a cookie with the name "testname" should not exist
 
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with the name :name should not exist" fails with an error when the cookie exists
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testname" and value "testvalue"
       Then a cookie with the name "testname" should not exist
       """
@@ -255,23 +262,24 @@ Feature: Check that CookieTrait works
       The cookie with name "testname" was set but it should not be.
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with the name :name and the value :value should not exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "othervalue"
     Then a cookie with the name "testname" and the value "testvalue" should not exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with the name :name and the value :value should not exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "othervalue"
     Then a cookie with the name "testname" and the value "testvalue" should not exist
 
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with the name :name and the value :value should not exist" fails with an error when the cookie exists with the specified value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testname" and value "testvalue"
       Then a cookie with the name "testname" and the value "testvalue" should not exist
       """
@@ -281,23 +289,24 @@ Feature: Check that CookieTrait works
       The cookie with name "testname" was set with value "testvalue", but it should not be "testvalue".
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with the name :name and a value containing :partial_value should not exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "othervalue"
     Then a cookie with the name "testname" and a value containing "testval" should not exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with the name :name and a value containing :partial_value should not exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "testname" and value "othervalue"
     Then a cookie with the name "testname" and a value containing "testval" should not exist
 
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with the name :name and a value containing :partial_value should not exist" fails with an error when the cookie exists with a value containing the partial value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "testname" and value "testvalue"
       Then a cookie with the name "testname" and a value containing "testval" should not exist
       """
@@ -307,23 +316,24 @@ Feature: Check that CookieTrait works
       The cookie with name "testname" was set with value containing "testvalue", but it should not contain "testval".
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name should not exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "othername" and value "testvalue"
     Then a cookie with a name containing "testname" should not exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name should not exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "othername" and value "testvalue"
     Then a cookie with a name containing "testname" should not exist
 
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with a name containing :partial_name should not exist" fails with an error when the cookie exists with a name containing the partial name
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "mytestname" and value "testvalue"
       Then a cookie with a name containing "testname" should not exist
       """
@@ -333,23 +343,24 @@ Feature: Check that CookieTrait works
       The cookie with name containing "testname" was set but it should not be.
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name and the value :value should not exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "mytestname" and value "othervalue"
     Then a cookie with a name containing "testname" and the value "testvalue" should not exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name and the value :value should not exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "mytestname" and value "othervalue"
     Then a cookie with a name containing "testname" and the value "testvalue" should not exist
 
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with a name containing :partial_name and the value :value should not exist" fails with an error when the cookie exists with matching name and value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "mytestname" and value "testvalue"
       Then a cookie with a name containing "testname" and the value "testvalue" should not exist
       """
@@ -359,23 +370,24 @@ Feature: Check that CookieTrait works
       The cookie with name containing "testname" was set with value "testvalue", but it should not be "testvalue".
       """
 
+  @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name and a value containing :partial_value should not exist" works as expected
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "othername" and value "othervalue"
     Then a cookie with a name containing "testname" and a value containing "testval" should not exist
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert step definition "a cookie with a name containing :partial_name and a value containing :partial_value should not exist" works as expected with real browser
-    When I visit "/sites/default/files/cookies.html"
+    When I visit "http://cli:8888/cookies.html"
     When I set a test cookie with name "othername" and value "othervalue"
     Then a cookie with a name containing "testname" and a value containing "testval" should not exist
 
   @trait:CookieTrait
   Scenario: Assert that negative assertion for "a cookie with a name containing :partial_name and a value containing :partial_value should not exist" fails with an error when the cookie exists with matching partial name and value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/cookies.html"
+      When I visit "http://cli:8888/cookies.html"
       When I set a test cookie with name "mytestname" and value "mytestvalue"
       Then a cookie with a name containing "testname" and a value containing "testval" should not exist
       """

--- a/tests/behat/features/dropzone.feature
+++ b/tests/behat/features/dropzone.feature
@@ -6,7 +6,7 @@ Feature: Check that DropzoneTrait works
   @javascript @phpserver
   Scenario: Assert single-file drop on default selector
     Given I am an anonymous user
-    When I visit "/sites/default/files/dropzone.html"
+    When I visit "http://cli:8888/dropzone.html"
     And I drop the file "document.pdf" on the ".dropzone" dropzone
     Then I should see "document.pdf"
     And the "#event-count" element should contain "1"
@@ -14,7 +14,7 @@ Feature: Check that DropzoneTrait works
   @javascript @phpserver
   Scenario: Assert multi-file drop fires a single drop event
     Given I am an anonymous user
-    When I visit "/sites/default/files/dropzone.html"
+    When I visit "http://cli:8888/dropzone.html"
     And I drop the following files on the ".dropzone" dropzone:
       | document.pdf |
       | image.png    |
@@ -27,7 +27,7 @@ Feature: Check that DropzoneTrait works
   @javascript @phpserver
   Scenario: Assert drop on a non-default selector
     Given I am an anonymous user
-    When I visit "/sites/default/files/dropzone.html"
+    When I visit "http://cli:8888/dropzone.html"
     And I drop the file "image.png" on the "#secondary-zone" dropzone
     Then the "#secondary-output" element should contain "image.png"
     And the "#primary-output" element should not contain "image.png"
@@ -35,7 +35,7 @@ Feature: Check that DropzoneTrait works
   @javascript @phpserver
   Scenario: Assert two consecutive drops in one scenario do not collide
     Given I am an anonymous user
-    When I visit "/sites/default/files/dropzone.html"
+    When I visit "http://cli:8888/dropzone.html"
     And I drop the file "document.pdf" on the ".dropzone" dropzone
     And I drop the file "text.txt" on the ".dropzone" dropzone
     Then I should see "document.pdf"
@@ -47,7 +47,7 @@ Feature: Check that DropzoneTrait works
   @javascript @phpserver
   Scenario: Assert multi-file drop populates a real Dropzone.js instance
     Given I am an anonymous user
-    When I visit "/sites/default/files/dropzone_dropzonejs.html"
+    When I visit "http://cli:8888/dropzone_dropzonejs.html"
     And I drop the following files on the "#real-dropzone" dropzone:
       | document.pdf |
       | image.png    |
@@ -65,7 +65,7 @@ Feature: Check that DropzoneTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/dropzone.html"
+      When I visit "http://cli:8888/dropzone.html"
       And I drop the file "document.pdf" on the ".nonexistent-zone" dropzone
       """
     When I run "behat --no-colors"
@@ -80,7 +80,7 @@ Feature: Check that DropzoneTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/dropzone.html"
+      When I visit "http://cli:8888/dropzone.html"
       And I drop the file "missing-fixture.bin" on the ".dropzone" dropzone
       """
     When I run "behat --no-colors"
@@ -95,7 +95,7 @@ Feature: Check that DropzoneTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/dropzone.html"
+      When I visit "http://cli:8888/dropzone.html"
       And I drop the following files on the ".dropzone" dropzone:
         | document.pdf       |
         | missing-second.bin |

--- a/tests/behat/features/element.feature
+++ b/tests/behat/features/element.feature
@@ -3,18 +3,19 @@ Feature: Check that ElementTrait works
   I want to provide tools to verify HTML element attributes, properties, and visibility
   So that users can test DOM structure, styling, and UI element behaviors correctly
 
+  @phpserver
   Scenario: Assert "Then the element :selector with the attribute :attribute and the value :value should exist" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the element "html" with the attribute "dir" and the value "ltr" should exist
 
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value :value should exist" fails as expected when the element does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#nonexisting-element" with the attribute "dir" and the value "ltr" should exist
       """
     When I run "behat --no-colors"
@@ -26,10 +27,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value :value should exist" fails as expected when the attribute does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "html" with the attribute "no-existing-attribute" and the value "ltr" should exist
       """
     When I run "behat --no-colors"
@@ -41,10 +42,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value :value should exist" fails as expected when the attribute does not contain the exact value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "html" with the attribute "dir" and the value "lt" should exist
       """
     When I run "behat --no-colors"
@@ -53,18 +54,19 @@ Feature: Check that ElementTrait works
       The "dir" attribute exists on the element "html" with a value "ltr", but it does not have a value "lt".
       """
 
+  @phpserver
   Scenario: Assert "Then the element :selector with the attribute :attribute and the value containing :value should exist" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the element "html" with the attribute "dir" and the value containing "lt" should exist
 
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value containing :value should exist" fails as expected when the element does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#nonexisting-element" with the attribute "dir" and the value containing "ltr" should exist
       """
     When I run "behat --no-colors"
@@ -76,10 +78,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value containing :value should exist" fails as expected when the attribute is not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "html" with the attribute "no-existing-attribute" and the value containing "ltr" should exist
       """
     When I run "behat --no-colors"
@@ -91,10 +93,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value containing :value should exist" fails as expected when the attribute does not contain the partial value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "html" with the attribute "dir" and the value containing "ltr1" should exist
       """
     When I run "behat --no-colors"
@@ -103,18 +105,19 @@ Feature: Check that ElementTrait works
       The "dir" attribute exists on the element "html" with a value "ltr", but it does not contain a value "ltr1".
       """
 
+  @phpserver
   Scenario: Assert "Then the element :selector with the attribute :attribute and the value :value should not exist" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the element "html" with the attribute "dir" and the value "nonexistingvalue" should not exist
 
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value :value should not exist" fails as expected when the element does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#nonexisting-element" with the attribute "dir" and the value "ltr" should not exist
       """
     When I run "behat --no-colors"
@@ -126,10 +129,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value :value should not exist" fails as expected when the attribute does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "html" with the attribute "no-existing-attribute" and the value "ltr" should not exist
       """
     When I run "behat --no-colors"
@@ -141,10 +144,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value :value should not exist" fails as expected when the attribute does not contain the exact value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "html" with the attribute "dir" and the value "ltr" should not exist
       """
     When I run "behat --no-colors"
@@ -153,18 +156,19 @@ Feature: Check that ElementTrait works
       The "dir" attribute exists on the element "html" with a value "ltr", but it should not.
       """
 
+  @phpserver
   Scenario: Assert "Then the element :selector with the attribute :attribute and the value containing :value should not exist" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the element "html" with the attribute "dir" and the value containing "nonexistingvalue" should not exist
 
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value containing :value should not exist" fails as expected when the element does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#nonexisting-element" with the attribute "dir" and the value containing "ltr" should not exist
       """
     When I run "behat --no-colors"
@@ -176,10 +180,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value containing :value should not exist" fails as expected when the attribute does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "html" with the attribute "no-existing-attribute" and the value containing "ltr" should not exist
       """
     When I run "behat --no-colors"
@@ -191,10 +195,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Negative assertion for "Then the element :selector with the attribute :attribute and the value containing :value should not exist" fails as expected when the attribute does not contain the exact value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "html" with the attribute "dir" and the value containing "lt" should not exist
       """
     When I run "behat --no-colors"
@@ -205,19 +209,19 @@ Feature: Check that ElementTrait works
 
   @javascript @phpserver
   Scenario: Assert click on element
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     When I click on the element "#overlay-off-canvas-trigger"
 
   @javascript @phpserver
   Scenario: Assert trigger event on element
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     Then I should not see an ".overlay-visible" element
     When I trigger the JS event "click" on the element "#overlay-off-canvas-trigger"
     Then I should see an ".overlay-visible" element
 
   @javascript @phpserver
   Scenario: Assert Accept/Not Accept confirmation
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     Then I should see the button "Test confirm"
     And I should not see the button "You pressed OK!"
     When I accept all confirmation dialogs
@@ -226,7 +230,7 @@ Feature: Check that ElementTrait works
 
   @javascript @phpserver
   Scenario: Assert Not Accept confirmation
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     Then I should see the button "Test confirm"
     And I should not see the button "You canceled!"
     When I do not accept any confirmation dialogs
@@ -235,20 +239,20 @@ Feature: Check that ElementTrait works
 
   @javascript @phpserver
   Scenario: Assert scroll to an element with selector uses center alignment by default
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     When I scroll to the element "#main-inner"
     Then the element "#main-inner" should be centered in the viewport
 
   @javascript @phpserver
   Scenario: Assert scroll to an element with top alignment when configured
     Given I set scroll to top alignment
-    And I am on the phpserver test page
+    And I visit "http://cli:8888/elements_relative.html"
     When I scroll to the element "#main-inner"
     Then the element "#main-inner" should be at the top of the viewport
 
   @javascript @phpserver
   Scenario: Assert selectors with quotes in attribute values work correctly
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     When I scroll to the element "button[data-action='save']"
     Then the element "button[data-action='save']" should be at the top of the viewport
     When I scroll to the element "button[data-action='delete']"
@@ -257,7 +261,7 @@ Feature: Check that ElementTrait works
 
   @api @javascript @phpserver
   Scenario: Assert step definition "Then the element :selector should be displayed" succeeds as expected
-    When I am on the phpserver test page
+    When I visit "http://cli:8888/elements_relative.html"
     Then the element "#top" should be displayed
 
   # Here and below: skipped because of Behat hanging in the child process.
@@ -266,7 +270,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      When I am on the phpserver test page
+      When I visit "http://cli:8888/elements_relative.html"
       Then the element "#hidden" should be displayed
       """
     When I run "behat --no-colors"
@@ -277,7 +281,7 @@ Feature: Check that ElementTrait works
 
   @api @javascript @phpserver
   Scenario: Assert step definition "Then the element :selector should not be displayed" succeeds as expected
-    When I am on the phpserver test page
+    When I visit "http://cli:8888/elements_relative.html"
     Then the element "#hidden" should not be displayed
 
   @trait:ElementTrait @skipped
@@ -285,7 +289,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#top" should not be displayed
       """
     When I run "behat --no-colors"
@@ -296,12 +300,12 @@ Feature: Check that ElementTrait works
 
   @api @javascript @phpserver
   Scenario: Assert step definition "Then the element :selector should not be displayed within a viewport with a top offset of :number pixels" succeeds as expected
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     Then the element "#hidden" should not be displayed within a viewport with a top offset of 10 pixels
 
   @api @javascript @phpserver
   Scenario: Assert step definition "Then the element :selector should be displayed within a viewport with a top offset of :number pixels" succeeds as expected
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     Then the element "#top" should be displayed within a viewport with a top offset of 10 pixels
 
   @api @javascript @phpserver @skipped
@@ -309,7 +313,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#top" should be displayed within a viewport with a top offset of 1000 pixels
       """
     When I run "behat --no-colors"
@@ -320,7 +324,7 @@ Feature: Check that ElementTrait works
 
   @api @javascript @phpserver
   Scenario: Assert step definition "Then the element :selector should be displayed within a viewport" and "Then the element :selector should not be displayed within a viewport" succeeds as expected
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     Then the element "#top" should be displayed within a viewport
     # Accessibility elements visible to screen readers are visible to normal
     # visibility assertion, but visually hidden.
@@ -331,10 +335,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait @skipped
   Scenario: Assert step definition "Then the element :selector should be displayed within a viewport" fails as expected
     Given some behat configuration
-    And scenario steps tagged with "@api @javascript":
+    And scenario steps tagged with "@api @javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_relative.html"
+      When I visit "http://cli:8888/elements_relative.html"
       Then the element "#sr-only" should be displayed within a viewport
       """
     When I run "behat --no-colors"
@@ -346,10 +350,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait @skipped
   Scenario: Assert step definition "Then the element :selector should not be displayed within a viewport" fails as expected
     Given some behat configuration
-    And scenario steps tagged with "@api @javascript":
+    And scenario steps tagged with "@api @javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_relative.html"
+      When I visit "http://cli:8888/elements_relative.html"
       Then the element "#top" should not be displayed within a viewport
       """
     When I run "behat --no-colors"
@@ -358,22 +362,22 @@ Feature: Check that ElementTrait works
       Element(s) defined by "#top" selector is displayed within a viewport, but should not be.
       """
 
-  @api
+  @api @phpserver
   Scenario: Text appears after another text
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the text "Copyright 2024" should appear after the text "Welcome"
 
-  @api
+  @api @phpserver
   Scenario: Assert "Then the element :selector1 should appear after the element :selector2" works as expected
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the element "body" should appear after the element "head"
 
   @trait:ElementTrait
   Scenario: Assert element order fails when first element is before second
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "head" should appear after the element "body"
       """
     When I run "behat --no-colors"
@@ -385,9 +389,9 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert text order fails when first text is before second
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the text "Welcome" should appear after the text "Copyright 2024"
       """
     When I run "behat --no-colors"
@@ -399,9 +403,9 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert element order fails when first element is not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#nonexistent" should appear after the element "body"
       """
     When I run "behat --no-colors"
@@ -413,9 +417,9 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert element order fails when second element is not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "body" should appear after the element "#nonexistent"
       """
     When I run "behat --no-colors"
@@ -427,9 +431,9 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert text order fails when first text is not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the text "NonExistentText123" should appear after the text "Welcome"
       """
     When I run "behat --no-colors"
@@ -441,9 +445,9 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert text order fails when second text is not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the text "Welcome" should appear after the text "NonExistentText123"
       """
     When I run "behat --no-colors"
@@ -452,10 +456,10 @@ Feature: Check that ElementTrait works
       Text was not found: "NonExistentText123".
       """
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "When I hover over the element :selector" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the element "#hover-reveal" should not be displayed
     When I hover over the element "#hover-target"
     Then the element "#hover-reveal" should be displayed
@@ -463,10 +467,10 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert that "When I hover over the element :selector" fails when element does not exist
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       And I hover over the element "#nonexistent-element"
       """
     When I run "behat --no-colors"
@@ -475,10 +479,10 @@ Feature: Check that ElementTrait works
       Element matching css "#nonexistent-element" not found.
       """
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "When I focus on the element :selector" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     And I focus on the element "#focus-input"
     Then the element "#focus-input" with the attribute "data-focused" and the value "true" should exist
 
@@ -488,7 +492,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       And I focus on the element "#nonexistent-element"
       """
     When I run "behat --no-colors"
@@ -497,25 +501,25 @@ Feature: Check that ElementTrait works
       Element matching css "#nonexistent-element" not found.
       """
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "Then the element :selector should have keyboard focus" and its negative form work as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     And I focus on the element "#focus-input"
     Then the element "#focus-input" should have keyboard focus
     And the element "#focus-button-outline" should not have keyboard focus
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "Then the element :selector should have a visible focus outline" passes for an element with a CSS outline
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the element "#focus-button-outline" should have a visible focus outline
     And the element "#focus-button-no-outline" should not have a visible focus outline
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "Then the element :selector should have a visible focus outline" passes for an element using box-shadow as the indicator
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the element "#focus-button-shadow" should have a visible focus outline
 
   @trait:ElementTrait
@@ -524,7 +528,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#nonexistent-element" should have keyboard focus
       """
     When I run "behat --no-colors"
@@ -539,7 +543,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       And I focus on the element "#focus-input"
       Then the element "#focus-button-outline" should have keyboard focus
       """
@@ -555,7 +559,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#focus-input" should have keyboard focus
       """
     When I run "behat --no-colors"
@@ -570,7 +574,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       And I focus on the element "#focus-input"
       Then the element "#focus-input" should not have keyboard focus
       """
@@ -586,7 +590,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#nonexistent-element" should have a visible focus outline
       """
     When I run "behat --no-colors"
@@ -601,7 +605,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#focus-button-no-outline" should have a visible focus outline
       """
     When I run "behat --no-colors"
@@ -616,7 +620,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#focus-button-outline" should not have a visible focus outline
       """
     When I run "behat --no-colors"
@@ -627,7 +631,7 @@ Feature: Check that ElementTrait works
 
   @javascript @phpserver
   Scenario: Assert click on element works
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     When I click on the element "#overlay-trigger"
     Then I should see an ".overlay-visible" element
 
@@ -636,7 +640,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       When I click on the element "#nonexistent-element"
       """
     When I run "behat --no-colors"
@@ -650,7 +654,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#bottom" should be at the top of the viewport
       """
     When I run "behat --no-colors"
@@ -664,7 +668,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#nonexistent" should be displayed
       """
     When I run "behat --no-colors"
@@ -678,7 +682,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#hidden" should be displayed
       """
     When I run "behat --no-colors"
@@ -692,7 +696,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#top" should not be displayed
       """
     When I run "behat --no-colors"
@@ -706,7 +710,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#sr-only" should be displayed within a viewport
       """
     When I run "behat --no-colors"
@@ -720,7 +724,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#top" should be displayed within a viewport with a top offset of 10000 pixels
       """
     When I run "behat --no-colors"
@@ -734,7 +738,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#top" should not be displayed within a viewport with a top offset of 0 pixels
       """
     When I run "behat --no-colors"
@@ -748,7 +752,7 @@ Feature: Check that ElementTrait works
     Given some behat configuration
     And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I am on the phpserver test page
+      Given I visit "http://cli:8888/elements_relative.html"
       Then the element "#top" should not be displayed within a viewport
       """
     When I run "behat --no-colors"
@@ -759,31 +763,33 @@ Feature: Check that ElementTrait works
 
   @javascript @phpserver
   Scenario: Assert "When I click on the element :selector with the index :index" clicks the Nth match
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     When I click on the element ".nth-btn" with the index 2
     Then I should see "Clicked 2"
 
   @javascript @phpserver
   Scenario: Assert "When I press the button :label with the index :index" presses the Nth match
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     When I press the button "Repeated action" with the index 3
     Then I should see "Clicked 3"
 
+  @phpserver
   Scenario: Assert "When I follow the link :text with the index :index" follows the Nth match
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     And I follow the link "Repeated link" with the index 2
     Then I should see "Link Testing Fixture"
 
+  @phpserver
   Scenario: Assert "Then the element :parent should contain :count element(s) matching :selector" counts matches within a parent
-    When I visit "/sites/default/files/elements.html"
+    When I visit "http://cli:8888/elements.html"
     Then the element "#nth-parent" should contain 3 elements matching ".nth-child"
 
   @trait:ElementTrait
   Scenario: Assert index-based interaction fails when the index is below 1
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       When I click on the element ".nth-child" with the index 0
       """
     When I run "behat --no-colors"
@@ -795,9 +801,9 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert index-based interaction fails when the index is out of range
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       When I click on the element ".nth-child" with the index 99
       """
     When I run "behat --no-colors"
@@ -809,9 +815,9 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert index-based interaction fails when no element matches
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       When I click on the element ".does-not-exist" with the index 1
       """
     When I run "behat --no-colors"
@@ -823,9 +829,9 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert "Then the element :parent should contain :count element(s) matching :selector" fails on a count mismatch
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#nth-parent" should contain 5 elements matching ".nth-child"
       """
     When I run "behat --no-colors"
@@ -837,9 +843,9 @@ Feature: Check that ElementTrait works
   @trait:ElementTrait
   Scenario: Assert "Then the element :parent should contain :count element(s) matching :selector" fails when the parent is missing
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/elements.html"
+      When I visit "http://cli:8888/elements.html"
       Then the element "#does-not-exist" should contain 1 element matching ".nth-child"
       """
     When I run "behat --no-colors"
@@ -848,20 +854,20 @@ Feature: Check that ElementTrait works
       Element matching css "#does-not-exist" not found.
       """
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "Then the element :selector should have the CSS property :property with the value :value" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_css.html"
+    When I visit "http://cli:8888/elements_css.html"
     Then the element "#css-box" should have the CSS property "background-color" with the value "rgb(0, 0, 255)"
     And the element "#css-box" should have the CSS property "backgroundColor" with the value "rgb(0, 0, 255)"
     And the element "#css-box" should have the CSS property "--css-brand" with the value "teal"
     And the element "#css-box" should not have the CSS property "display" with the value "none"
     And the element "#css-hidden" should have the CSS property "display" with the value "none"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "Then the element :selector should have the CSS property :property with the value containing :value" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_css.html"
+    When I visit "http://cli:8888/elements_css.html"
     Then the element "#css-box" should have the CSS property "box-shadow" with the value containing "rgb(255, 0, 0)"
     And the element "#css-box" should not have the CSS property "box-shadow" with the value containing "inset"
 
@@ -871,7 +877,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#nonexistent-element" should have the CSS property "display" with the value "block"
       """
     When I run "behat --no-colors"
@@ -886,7 +892,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#css-box" should have the CSS property "bogus-property" with the value "block"
       """
     When I run "behat --no-colors"
@@ -901,7 +907,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#css-box" should have the CSS property "background-color" with the value "rgb(255, 0, 0)"
       """
     When I run "behat --no-colors"
@@ -916,7 +922,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#css-box" should not have the CSS property "background-color" with the value "rgb(0, 0, 255)"
       """
     When I run "behat --no-colors"
@@ -931,7 +937,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#css-box" should have the CSS property "box-shadow" with the value containing "inset"
       """
     When I run "behat --no-colors"
@@ -946,7 +952,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#css-box" should not have the CSS property "box-shadow" with the value containing "rgb(255, 0, 0)"
       """
     When I run "behat --no-colors"
@@ -955,31 +961,31 @@ Feature: Check that ElementTrait works
       containing "rgb(255, 0, 0)", but it should not.
       """
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "Then the element :selector1 should stack above the element :selector2" compares the z-index of both elements
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_css.html"
+    When I visit "http://cli:8888/elements_css.html"
     Then the element "#stack-high" should stack above the element "#stack-low"
     And the element "#stack-low" should stack below the element "#stack-high"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert stacking order resolves the effective z-index across stacking contexts
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_css.html"
+    When I visit "http://cli:8888/elements_css.html"
     Then the element "#stack-sibling" should stack above the element "#stack-trap-child"
     And the element "#stack-trap-child" should stack below the element "#stack-sibling"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert stacking order falls back to document order for an equal z-index
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_css.html"
+    When I visit "http://cli:8888/elements_css.html"
     Then the element "#stack-second" should stack above the element "#stack-first"
     And the element "#stack-first" should stack below the element "#stack-second"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert stacking order of an element nested in another element
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_css.html"
+    When I visit "http://cli:8888/elements_css.html"
     Then the element "#stack-child" should stack above the element "#stack-parent"
     And the element "#stack-parent" should stack below the element "#stack-child"
     And the element "#stack-behind" should stack below the element "#stack-parent"
@@ -991,7 +997,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#nonexistent-element" should stack above the element "#stack-low"
       """
     When I run "behat --no-colors"
@@ -1006,7 +1012,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#stack-low" should stack above the element "#nonexistent-element"
       """
     When I run "behat --no-colors"
@@ -1021,7 +1027,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#stack-low" should stack above the element "#stack-low"
       """
     When I run "behat --no-colors"
@@ -1036,7 +1042,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#stack-low" should stack above the element "#stack-high"
       """
     When I run "behat --no-colors"
@@ -1051,7 +1057,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#stack-second" should stack below the element "#stack-first"
       """
     When I run "behat --no-colors"
@@ -1066,7 +1072,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#stack-behind" should stack above the element "#stack-parent"
       """
     When I run "behat --no-colors"
@@ -1081,7 +1087,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#stack-parent" should stack above the element "#stack-child"
       """
     When I run "behat --no-colors"
@@ -1090,18 +1096,18 @@ Feature: Check that ElementTrait works
       Expected element "#stack-parent" to stack above the element "#stack-child", but it stacks below it: "#stack-child" sits inside the stacking context of "#stack-parent" with an effective z-index of 0.
       """
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "Then the element :selector should be pinned to the top of the viewport" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_css.html"
+    When I visit "http://cli:8888/elements_css.html"
     Then the element "#pinned-header" should be pinned to the top of the viewport
     And the element "#not-pinned" should not be pinned to the top of the viewport
     And the element "#pinned-hidden" should not be pinned to the top of the viewport
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert "Then the element :selector should be pinned to the top of the viewport within :tolerance pixels" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_css.html"
+    When I visit "http://cli:8888/elements_css.html"
     Then the element "#pinned-offset" should be pinned to the top of the viewport within 25 pixels
     And the element "#pinned-offset" should not be pinned to the top of the viewport
 
@@ -1111,7 +1117,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#nonexistent-element" should be pinned to the top of the viewport
       """
     When I run "behat --no-colors"
@@ -1126,7 +1132,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#not-pinned" should be pinned to the top of the viewport
       """
     When I run "behat --no-colors"
@@ -1141,7 +1147,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#pinned-hidden" should be pinned to the top of the viewport
       """
     When I run "behat --no-colors"
@@ -1156,7 +1162,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#pinned-header" should not be pinned to the top of the viewport
       """
     When I run "behat --no-colors"
@@ -1171,7 +1177,7 @@ Feature: Check that ElementTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/elements_css.html"
+      When I visit "http://cli:8888/elements_css.html"
       Then the element "#pinned-header" should be pinned to the top of the viewport within -5 pixels
       """
     When I run "behat --no-colors"

--- a/tests/behat/features/field.feature
+++ b/tests/behat/features/field.feature
@@ -3,31 +3,35 @@ Feature: Check that FieldTrait works
   I want to provide tools to verify form field existence, state, values, and select options
   So that users can test form interactions reliably
 
+  @phpserver
   Scenario: Assert that a field is empty
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the field "field1" should be empty
 
+  @phpserver
   Scenario: Assert that a field is not empty
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I fill in "field1" with "Test value"
     Then the field "field1" should not be empty
 
+  @phpserver
   Scenario: Assert that a field with "0" is not empty
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I fill in "field1" with "0"
     Then the field "field1" should not be empty
 
+  @phpserver
   Scenario: Assert "When I fill in the field :selector with :value" works with CSS selector
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I fill in the field "#field1" with "CSS filled value"
     Then the field "field1" should not be empty
 
   @trait:FieldTrait
   Scenario: Assert that "When I fill in the field :selector with :value" fails when element does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       And I fill in the field "#nonexistent-field" with "some value"
       """
     When I run "behat --no-colors"
@@ -39,9 +43,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "the :field field should be empty" for field with "0"
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       And I fill in "field1" with "0"
       Then the field "field1" should be empty
       """
@@ -54,9 +58,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "the :field field should be empty" for non-empty field
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       And I fill in "field1" with "Some text"
       Then the field "field1" should be empty
       """
@@ -69,9 +73,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "the :field field should not be empty" for empty field
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the field "field1" should not be empty
       """
     When I run "behat --no-colors"
@@ -80,17 +84,20 @@ Feature: Check that FieldTrait works
       The field "field1" is empty, but should not be.
       """
 
+  @phpserver
   Scenario: Assert field exists
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the field "field1" should exist
     And the field "Field 1" should exist
 
+  @phpserver
   Scenario: Assert field does not exist
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the field "some_random_field" should not exist
 
+  @phpserver
   Scenario Outline: Assert field existence
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the field "<field>" should <existence>
     Examples:
       | field        | existence |
@@ -100,8 +107,9 @@ Feature: Check that FieldTrait works
       | Field 2      | exist     |
       | random_field | not exist |
 
+  @phpserver
   Scenario Outline: Assert if field is disabled or enabled
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the field "<field>" should have "<enabled_or_disabled>" state
     Examples:
       | field          | enabled_or_disabled |
@@ -112,16 +120,16 @@ Feature: Check that FieldTrait works
       | field3disabled | disabled            |
       | Field 3        | disabled            |
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert fills in form color field with specified id|name|label|value
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the color field "#edit-color-input" should have the value "#000000"
     When I fill in the color field "#edit-color-input" with the value "#ffffff"
     Then the color field "#edit-color-input" should have the value "#ffffff"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Assert fills in form color field with specified id|name|label|value using an alternate step definition
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the color field "#edit-color-input" should have the value "#000000"
     When I fill in the color field "#edit-color-input" with the value "#ffffff"
     Then the color field "#edit-color-input" should have the value "#ffffff"
@@ -129,9 +137,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert that negative assertion for "The field :field should exist" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the field "No existing field" should exist
       """
     When I run "behat --no-colors"
@@ -143,9 +151,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert that negative assertion for "The field :name should not exist" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the field "Field 1" should not exist
       """
     When I run "behat --no-colors"
@@ -157,9 +165,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert that negative assertion for "The field :field should not exist" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the field "field1" should not exist
       """
     When I run "behat --no-colors"
@@ -171,9 +179,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert that "the field :field should have enabled state" fails when it is disabled
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the field "field3disabled" should have "enabled" state
       """
     When I run "behat --no-colors"
@@ -185,9 +193,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert that "the field :field should have disabled state" fails when it is not disabled
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the field "field1" should have "disabled" state
       """
     When I run "behat --no-colors"
@@ -196,21 +204,23 @@ Feature: Check that FieldTrait works
       A field "field1" should be disabled, but it is not.
       """
 
+  @phpserver
   Scenario: Assert that a field with the native required attribute is required
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the field "username" should be required
     And the field "contact-email" should be required
 
+  @phpserver
   Scenario: Assert that a non-required field is not required
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the field "field1" should not be required
 
   @trait:FieldTrait
   Scenario: Assert negative "the field :field should be required" for a non-required field
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the field "field1" should be required
       """
     When I run "behat --no-colors"
@@ -222,9 +232,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "the field :field should not be required" for a required field
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the field "username" should not be required
       """
     When I run "behat --no-colors"
@@ -432,7 +442,7 @@ Feature: Check that FieldTrait works
 
   @phpserver
   Scenario: Assert that checkboxes are checked and unchecked
-    Given I am on the phpserver test page
+    Given I visit "http://cli:8888/elements_relative.html"
     Then the field "Checkbox unchecked" should exist
     And the field "Checkbox checked" should exist
 
@@ -448,22 +458,25 @@ Feature: Check that FieldTrait works
     When I check the checkbox "Checkbox checked"
     Then the checkbox "Checkbox checked" should be checked
 
+  @phpserver
   Scenario: Assert that radio buttons are selected
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     Then the field "radio1" should exist
     And the field "Option 1" should exist
     And the radio button "Option 1" should not be selected
     And the radio button "Option 2 (selected)" should be selected
     And the radio button "Option 3" should not be selected
 
+  @phpserver
   Scenario: Select radio button by label
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     When I choose the radio button "Option 1"
     Then the radio button "Option 1" should be selected
     And the radio button "Option 2 (selected)" should not be selected
 
+  @phpserver
   Scenario: Select radio button by ID
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     When I choose the radio button "radio3"
     Then the radio button "radio3" should be selected
     And the radio button "Option 2 (selected)" should not be selected
@@ -471,9 +484,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "When I choose the radio button" for non-existent radio button
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       When I choose the radio button "Non-existent radio"
       """
     When I run "behat --no-colors"
@@ -485,9 +498,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "the radio button should be selected" for non-existent radio button
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the radio button "Non-existent radio" should be selected
       """
     When I run "behat --no-colors"
@@ -499,9 +512,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "the radio button should not be selected" for non-existent radio button
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the radio button "Non-existent radio" should not be selected
       """
     When I run "behat --no-colors"
@@ -513,9 +526,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "the radio button should be selected" for unselected radio button
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the radio button "Option 1" should be selected
       """
     When I run "behat --no-colors"
@@ -527,9 +540,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "the radio button should not be selected" for selected radio button
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       Then the radio button "Option 2 (selected)" should not be selected
       """
     When I run "behat --no-colors"
@@ -538,35 +551,35 @@ Feature: Check that FieldTrait works
       The radio button "Option 2 (selected)" is selected, but should not be.
       """
 
-  @javascript
+  @javascript @phpserver
   Scenario: Disable browser validation for form after visiting page
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And browser validation for the form "#login-form" is disabled
     And I press "Submit 1"
     # Server-side validation message should appear
     Then I should see "Please fill in all required fields"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Disable browser validation as the VERY FIRST step (fixes issue #423)
     # This is the VERY FIRST step - no page visited yet - this is the core issue being fixed
     Given browser validation for the form "#login-form" is disabled
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     # Server-side validation message should appear (browser validation was disabled)
     Then I should see "Please fill in all required fields"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Disable browser validation for multiple forms
     Given browser validation for the form "#login-form" is disabled
     And browser validation for the form "#contact-form" is disabled
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     Then I should see "Please fill in all required fields"
 
-  @javascript @behat-steps-skip:FieldTrait
+  @javascript @behat-steps-skip:FieldTrait @phpserver
   Scenario: Skip FieldTrait hooks with behat-steps-skip tag
     Given browser validation for the form "#login-form" is disabled
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     # With the skip tag, validation disabling should not be applied
     # Browser validation will catch the empty fields before form submission
@@ -575,26 +588,27 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Negative test for scenario-level behat-steps-skip tag
     Given some behat configuration
-    And scenario steps tagged with "@javascript @behat-steps-skip:FieldTrait":
+    And scenario steps tagged with "@javascript @behat-steps-skip:FieldTrait @phpserver":
       """
       Given browser validation for the form "#login-form" is disabled
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       And I press "Submit 1"
       Then I should not see "Please fill in all required fields"
       """
     When I run "behat --no-colors"
     Then it should pass
 
+  @phpserver
   Scenario: Validation step works without JavaScript driver
     Given browser validation for the form "#login-form" is disabled
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     # Without JavaScript, the registry stores the selector but AfterStep returns early
     # The step should not throw an error
     Then the field "username" should exist
 
-  @javascript @disable-form-validation
+  @javascript @disable-form-validation @phpserver
   Scenario: Tag disables all forms on page automatically
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     # Try to submit login form without filling fields
     And I press "Submit 1"
     Then I should see "Please fill in all required fields"
@@ -602,9 +616,9 @@ Feature: Check that FieldTrait works
     When I press "Submit 2"
     Then I should see "Please fill in all required fields"
 
-  @javascript @disable-form-validation
+  @javascript @disable-form-validation @phpserver
   Scenario: Tag validation disabled across page navigation
-    When I visit "/sites/default/files/form1.html"
+    When I visit "http://cli:8888/form1.html"
     And I press "Submit 1"
     Then I should see "Please fill in all required fields"
     # Navigate to second page
@@ -613,40 +627,40 @@ Feature: Check that FieldTrait works
     # Validation should still be disabled on the second page
     Then I should see "Please fill in all required fields"
 
-  @javascript @disable-form-validation
+  @javascript @disable-form-validation @phpserver
   Scenario: Tag works before visiting any page
     # No page visited yet - tag should still work when we visit pages
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     Then I should see "Please fill in all required fields"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Without tag browser validation blocks submission
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     # Browser validation will block, so we won't see the error message
     Then I should not see "Please fill in all required fields"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Selector-based approach still works independently
     Given browser validation for the form "#login-form" is disabled
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     Then I should see "Login form error: Please fill in all required fields"
     # Contact form should still have browser validation
     When I press "Submit 2"
     Then I should not see "Contact form error: Please fill in all required fields"
 
-  @javascript @disable-form-validation @behat-steps-skip:FieldTrait
+  @javascript @disable-form-validation @behat-steps-skip:FieldTrait @phpserver
   Scenario: Skip tag overrides disable-form-validation tag
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     # With skip tag, validation disabling should not be applied
     Then I should not see "Please fill in all required fields"
 
-  @disable-form-validation
+  @disable-form-validation @phpserver
   Scenario: Tag works gracefully without JavaScript driver
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     # Without JavaScript, the tag should not throw an error
     Then the field "username" should exist
 
@@ -827,9 +841,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative color field value assertion when values don't match
     Given some behat configuration
-    And scenario steps tagged with "@api @javascript":
+    And scenario steps tagged with "@api @javascript @phpserver":
       """
-      Given I visit "/sites/default/files/fields.html"
+      Given I visit "http://cli:8888/fields.html"
       Then the color field "#edit-color-input" should have the value "#000000"
       When I fill in the color field "#edit-color-input" with the value "#ffffff"
       Then the color field "#edit-color-input" should have the value "#000000"
@@ -840,25 +854,25 @@ Feature: Check that FieldTrait works
       Color field "#edit-color-input" expected a value "#000000" but has a value "#ffffff".
       """
 
-  @api @javascript
+  @api @javascript @phpserver
   Scenario: Fill in WYSIWYG field with CKEditor 5
-    When I visit "/sites/default/files/wysiwyg_ckeditor5.html"
+    When I visit "http://cli:8888/wysiwyg_ckeditor5.html"
     And I fill in the WYSIWYG field "Body" with the "Updated CKEditor 5 body content"
     And I fill in the WYSIWYG field "Description" with the "Updated CKEditor 5 description"
 
   # Non-commercial version of CKEditor 4 throw an error about being insecure.
-  @api @javascript @js-errors
+  @api @javascript @js-errors @phpserver
   Scenario: Fill in WYSIWYG field with CKEditor 4
-    When I visit "/sites/default/files/wysiwyg_ckeditor4.html"
+    When I visit "http://cli:8888/wysiwyg_ckeditor4.html"
     And I fill in the WYSIWYG field "Body" with the "Updated CKEditor 4 body content"
     And I fill in the WYSIWYG field "Description" with the "Updated CKEditor 4 description"
 
   @trait:FieldTrait
   Scenario: Assert negative WYSIWYG field not found
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
-      When I visit "/sites/default/files/wysiwyg_ckeditor5.html"
+      When I visit "http://cli:8888/wysiwyg_ckeditor5.html"
       When I fill in the WYSIWYG field "Non-existent WYSIWYG" with the "test content"
       """
     When I run "behat --no-colors"
@@ -870,9 +884,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative WYSIWYG field without an ID
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
-      When I visit "/sites/default/files/wysiwyg_ckeditor5.html"
+      When I visit "http://cli:8888/wysiwyg_ckeditor5.html"
       When I fill in the WYSIWYG field "noid" with the "test content"
       """
     When I run "behat --no-colors"
@@ -881,9 +895,9 @@ Feature: Check that FieldTrait works
       WYSIWYG field must have an ID attribute.
       """
 
-  @select
+  @select @phpserver
   Scenario: Unselect option from multi-select field
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I additionally select "Option A" from "Multi-select options"
     And I additionally select "Option B" from "Multi-select options"
     And I additionally select "Option C" from "Multi-select options"
@@ -895,9 +909,9 @@ Feature: Check that FieldTrait works
     And the option "Option B" should not be selected within the select element "Multi-select options"
     And the option "Option C" should be selected within the select element "Multi-select options"
 
-  @select
+  @select @phpserver
   Scenario: Clear all selections from multi-select field
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I additionally select "Option A" from "Multi-select options"
     And I additionally select "Option B" from "Multi-select options"
     Then the option "Option A" should be selected within the select element "Multi-select options"
@@ -907,17 +921,17 @@ Feature: Check that FieldTrait works
     And the option "Option B" should not be selected within the select element "Multi-select options"
     And the option "Option C" should not be selected within the select element "Multi-select options"
 
-  @select
+  @select @phpserver
   Scenario: Clear single select field
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I select "Choice 1" from "Single select field"
     Then the option "Choice 1" should be selected within the select element "Single select field"
     When I clear the select "Single select field"
     Then the option "Choice 1" should not be selected within the select element "Single select field"
 
-  @select
+  @select @phpserver
   Scenario: Unselect option from single select field
-    When I visit "/sites/default/files/fields.html"
+    When I visit "http://cli:8888/fields.html"
     And I select "Choice 2" from "Single select field"
     Then the option "Choice 2" should be selected within the select element "Single select field"
     When I unselect "Choice 2" from "Single select field"
@@ -926,9 +940,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "When I unselect :option from :selector" for non-existent select
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       When I unselect "Option A" from "Non-existent select"
       """
     When I run "behat --no-colors"
@@ -940,9 +954,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "When I unselect :option from :selector" for non-existent option
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       When I unselect "Invalid Option" from "Multi-select options"
       """
     When I run "behat --no-colors"
@@ -954,9 +968,9 @@ Feature: Check that FieldTrait works
   @trait:FieldTrait
   Scenario: Assert negative "When I clear the select :selector" for non-existent select
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/fields.html"
+      When I visit "http://cli:8888/fields.html"
       When I clear the select "Non-existent select"
       """
     When I run "behat --no-colors"

--- a/tests/behat/features/file_download.feature
+++ b/tests/behat/features/file_download.feature
@@ -17,13 +17,13 @@ Feature: Check that FileDownloadTrait works
       | [TEST] document page | text.txt             |
       | [TEST] zip page      | archive_multiple.zip |
 
-  @api @download
+  @api @download @phpserver
   Scenario: Assert "When I download the file from the URL :url"
-    When I download the file from the URL "/sites/default/files/text.txt"
+    When I download the file from the URL "http://cli:8888/text.txt"
 
-  @api @javascript @download
+  @api @javascript @download @phpserver
   Scenario: Assert in browser "When I download the file from the URL :url"
-    When I download the file from the URL "/sites/default/files/text.txt"
+    When I download the file from the URL "http://cli:8888/text.txt"
 
   @api @download
   Scenario: Assert "When I download the file from the link :link"
@@ -41,10 +41,10 @@ Feature: Check that FileDownloadTrait works
   @api @trait:FileDownloadTrait
   Scenario: Assert that regex content match fails properly
     Given some behat configuration
-    And scenario steps tagged with "@download":
+    And scenario steps tagged with "@download @phpserver":
       """
       When I visit "/"
-      And I download the file from the URL "/sites/default/files/text.txt"
+      And I download the file from the URL "http://cli:8888/text.txt"
       Then the downloaded file should contain:
         '''
         /nonexistent.*pattern/
@@ -69,18 +69,18 @@ Feature: Check that FileDownloadTrait works
       | text.txt         |
       | not_existing.png |
 
-  @api @download
+  @api @download @phpserver
   Scenario: Assert the downloaded file name contains a specific string
-    When I download the file from the URL "/sites/default/files/text.txt"
+    When I download the file from the URL "http://cli:8888/text.txt"
     Then the downloaded file name should contain "text"
 
   @api @trait:FileDownloadTrait
   Scenario: Assert that negative assertion for "The downloaded file name should contain :name" fails with an error
     Given some behat configuration
-    And scenario steps tagged with "@download":
+    And scenario steps tagged with "@download @phpserver":
       """
       When I visit "/"
-      And I download the file from the URL "/sites/default/files/text.txt"
+      And I download the file from the URL "http://cli:8888/text.txt"
       Then the downloaded file name should contain "nonexistent"
       """
     When I run "behat --no-colors"
@@ -142,10 +142,10 @@ Feature: Check that FileDownloadTrait works
   @api @trait:FileDownloadTrait
   Scenario: Assert that file name mismatch fails with an error
     Given some behat configuration
-    And scenario steps tagged with "@download":
+    And scenario steps tagged with "@download @phpserver":
       """
       When I visit "/"
-      And I download the file from the URL "/sites/default/files/text.txt"
+      And I download the file from the URL "http://cli:8888/text.txt"
       Then the downloaded file name should be "wrong_name.txt"
       """
     When I run "behat --no-colors"
@@ -157,10 +157,10 @@ Feature: Check that FileDownloadTrait works
   @api @trait:FileDownloadTrait
   Scenario: Assert that file content not found fails with an error
     Given some behat configuration
-    And scenario steps tagged with "@download":
+    And scenario steps tagged with "@download @phpserver":
       """
       When I visit "/"
-      And I download the file from the URL "/sites/default/files/text.txt"
+      And I download the file from the URL "http://cli:8888/text.txt"
       Then the downloaded file should contain:
         '''
         nonexistent content string
@@ -278,10 +278,10 @@ Feature: Check that FileDownloadTrait works
     And the following managed files:
       | path                |
       | archive_invalid.zip |
-    And scenario steps tagged with "@download":
+    And scenario steps tagged with "@download @phpserver":
       """
       Given I am logged in as a user with the "administrator" role
-      When I download the file from the URL "/sites/default/files/archive_invalid.zip"
+      When I download the file from the URL "http://cli:8888/archive_invalid.zip"
       Then the downloaded file should be a zip archive containing the following files named:
         | test.txt |
       """
@@ -309,10 +309,10 @@ Feature: Check that FileDownloadTrait works
   @api @trait:FileDownloadTrait
   Scenario: Assert that ZIP assertion on non-ZIP file fails with an error
     Given some behat configuration
-    And scenario steps tagged with "@download":
+    And scenario steps tagged with "@download @phpserver":
       """
       When I visit "/"
-      And I download the file from the URL "/sites/default/files/text.txt"
+      And I download the file from the URL "http://cli:8888/text.txt"
       Then the downloaded file should be a zip archive containing the following files named:
         | test.txt |
       """
@@ -325,10 +325,10 @@ Feature: Check that FileDownloadTrait works
   @api @trait:FileDownloadTrait
   Scenario: Assert that downloading a URL returning an error status fails
     Given some behat configuration
-    And scenario steps tagged with "@download":
+    And scenario steps tagged with "@download @phpserver":
       """
       When I visit "/"
-      And I download the file from the URL "/sites/default/files/nonexistent-download-target.txt"
+      And I download the file from the URL "http://cli:8888/nonexistent-download-target.txt"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:

--- a/tests/behat/features/iframe.feature
+++ b/tests/behat/features/iframe.feature
@@ -6,7 +6,7 @@ Feature: Check that IframeTrait works
   @javascript @phpserver
   Scenario: Assert "When I switch to iframe with locator :locator" works for named iframe
     Given I am an anonymous user
-    When I visit "/sites/default/files/iframes.html"
+    When I visit "http://cli:8888/iframes.html"
     And I switch to iframe with locator ".named-iframe"
     Then I should see "Content inside named iframe"
     When I switch to the root document
@@ -15,7 +15,7 @@ Feature: Check that IframeTrait works
   @javascript @phpserver
   Scenario: Assert "When I switch to iframe with locator :locator" works for unnamed iframe
     Given I am an anonymous user
-    When I visit "/sites/default/files/iframes.html"
+    When I visit "http://cli:8888/iframes.html"
     And I switch to iframe with locator ".unnamed-iframe"
     Then I should see "Content inside unnamed iframe"
     When I switch to the root document
@@ -27,7 +27,7 @@ Feature: Check that IframeTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/iframes.html"
+      When I visit "http://cli:8888/iframes.html"
       And I switch to iframe with locator ".nonexistent-iframe"
       """
     When I run "behat --no-colors"

--- a/tests/behat/features/javascript.feature
+++ b/tests/behat/features/javascript.feature
@@ -3,23 +3,23 @@ Feature: Check that JavascriptTrait works
   I want to automatically detect JavaScript errors during test execution
   So that users can catch JS errors in their scenarios by default
 
-  @javascript
+  @javascript @phpserver
   Scenario: Clean page without JavaScript errors should pass
-    Given I visit "/sites/default/files/javascript_clean1.html"
+    Given I visit "http://cli:8888/javascript_clean1.html"
     Then I should see "Clean Page 1 Without JavaScript Errors"
     And I should see "Page 1 JavaScript is working correctly!"
     When I press "Click to update message"
     Then I should see "Message on page 1 updated successfully!"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Moving between pages without JavaScript errors should pass
-    Given I visit "/sites/default/files/javascript_clean1.html"
+    Given I visit "http://cli:8888/javascript_clean1.html"
     Then I should see "Clean Page 1 Without JavaScript Errors"
     And I should see "Page 1 JavaScript is working correctly!"
     When I press "Click to update message"
     Then I should see "Message on page 1 updated successfully!"
 
-    Given I visit "/sites/default/files/javascript_clean2.html"
+    Given I visit "http://cli:8888/javascript_clean2.html"
     Then I should see "Clean Page 2 Without JavaScript Errors"
     And I should see "Page 2 JavaScript is working correctly!"
     When I press "Click to update message"
@@ -28,9 +28,9 @@ Feature: Check that JavascriptTrait works
   @trait:JavascriptTrait
   Scenario: Page with JavaScript errors should fail
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
-      Given I visit "/sites/default/files/javascript_errors1.html"
+      Given I visit "http://cli:8888/javascript_errors1.html"
       Then I should see "Page 1 with JavaScript Errors"
       When I press "Click to trigger error"
       """
@@ -41,7 +41,7 @@ Feature: Check that JavascriptTrait works
       """
     And the output should contain:
       """
-      URL: http://nginx:8080/sites/default/files/javascript_errors1.html
+      URL: http://cli:8888/javascript_errors1.html
       """
     And the output should contain:
       """
@@ -51,9 +51,9 @@ Feature: Check that JavascriptTrait works
   @trait:JavascriptTrait
   Scenario: All errors collected during a step are reported together
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
-      Given I visit "/sites/default/files/javascript_errors3.html"
+      Given I visit "http://cli:8888/javascript_errors3.html"
       When I press "Click to trigger errors"
       """
     When I run "behat --no-colors"
@@ -63,7 +63,7 @@ Feature: Check that JavascriptTrait works
       """
     And the output should contain:
       """
-      URL: http://nginx:8080/sites/default/files/javascript_errors3.html
+      URL: http://cli:8888/javascript_errors3.html
       """
     And the output should contain:
       """
@@ -85,11 +85,11 @@ Feature: Check that JavascriptTrait works
   @trait:JavascriptTrait
   Scenario: Errors from different pages are tracked separately
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
-      Given I visit "/sites/default/files/javascript_errors3.html"
+      Given I visit "http://cli:8888/javascript_errors3.html"
       When I press "Click to trigger errors"
-      And I visit "/sites/default/files/javascript_errors2.html"
+      And I visit "http://cli:8888/javascript_errors2.html"
       And I press "Click to trigger error"
       """
     When I run "behat --no-colors"
@@ -99,7 +99,7 @@ Feature: Check that JavascriptTrait works
       """
     And the output should contain:
       """
-      URL: http://nginx:8080/sites/default/files/javascript_errors3.html
+      URL: http://cli:8888/javascript_errors3.html
       """
     And the output should contain:
       """
@@ -107,7 +107,7 @@ Feature: Check that JavascriptTrait works
       """
     And the output should contain:
       """
-      URL: http://nginx:8080/sites/default/files/javascript_errors2.html
+      URL: http://cli:8888/javascript_errors2.html
       """
     And the output should contain:
       """
@@ -121,12 +121,12 @@ Feature: Check that JavascriptTrait works
   @trait:JavascriptTrait
   Scenario: Errors are reported when an earlier step failed
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
-      Given I visit "/sites/default/files/javascript_errors3.html"
+      Given I visit "http://cli:8888/javascript_errors3.html"
       When I press "Click to trigger errors"
       Then I should see "text that is not on the page"
-      And I visit "/sites/default/files/javascript_clean1.html"
+      And I visit "http://cli:8888/javascript_clean1.html"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -144,18 +144,18 @@ Feature: Check that JavascriptTrait works
     And a file named "features/stub.feature" with:
       """
       Feature: Stub feature
-        @javascript
+        @javascript @phpserver
         Scenario: Passing scenario before the failure
-          Given I visit "/sites/default/files/javascript_clean1.html"
+          Given I visit "http://cli:8888/javascript_clean1.html"
 
-        @javascript
+        @javascript @phpserver
         Scenario: Scenario with a JavaScript error
-          Given I visit "/sites/default/files/javascript_errors1.html"
+          Given I visit "http://cli:8888/javascript_errors1.html"
           When I press "Click to trigger error"
 
-        @javascript
+        @javascript @phpserver
         Scenario: Passing scenario after the failure
-          Given I visit "/sites/default/files/javascript_clean2.html"
+          Given I visit "http://cli:8888/javascript_clean2.html"
       """
     When I run "behat --no-colors"
     Then it should fail with:
@@ -168,20 +168,21 @@ Feature: Check that JavascriptTrait works
       1 scenario (1 failed)
       """
 
-  @javascript @js-errors
+  @javascript @js-errors @phpserver
   Scenario: Bypass tag allows page with errors to pass
-    Given I visit "/sites/default/files/javascript_errors1.html"
+    Given I visit "http://cli:8888/javascript_errors1.html"
     Then I should see "Page 1 with JavaScript Errors"
     When I press "Click to trigger error"
     And sleep for 4 second
 
-  @javascript @trait:JavascriptTrait @behat-steps-skip:JavascriptTrait
+  @javascript @trait:JavascriptTrait @behat-steps-skip:JavascriptTrait @phpserver
   Scenario: Skip tag allows bypassing error checking
-    Given I visit "/sites/default/files/javascript_errors1.html"
+    Given I visit "http://cli:8888/javascript_errors1.html"
     Then I should see "Page 1 with JavaScript Errors"
     When I press "Click to trigger error"
     And sleep for 4 second
 
+  @phpserver
   Scenario: Non-JavaScript scenario should not check for errors
-    Given I visit "/sites/default/files/javascript_errors1.html"
+    Given I visit "http://cli:8888/javascript_errors1.html"
     Then I should see "Page 1 with JavaScript Errors"

--- a/tests/behat/features/javascript_skip.feature
+++ b/tests/behat/features/javascript_skip.feature
@@ -4,9 +4,9 @@ Feature: Check that JavascriptTrait skip at feature level works
   I want to be able to skip JavaScript error checking at feature level
   So that I can disable it for entire feature files
 
-  @javascript
+  @javascript @phpserver
   Scenario: Feature-level skip tag bypasses error checking even with @javascript
-    Given I visit "/sites/default/files/javascript_errors1.html"
+    Given I visit "http://cli:8888/javascript_errors1.html"
     Then I should see "Page 1 with JavaScript Errors"
     When I press "Click to trigger error"
     And sleep for 4 seconds

--- a/tests/behat/features/json.feature
+++ b/tests/behat/features/json.feature
@@ -3,17 +3,20 @@ Feature: Check that JsonTrait works
   I want to provide tools to assert JSON responses
   So that users can test API endpoints returning JSON
 
+  @phpserver
   Scenario: Assert "Then the response should be in JSON format" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the response should be in JSON format
 
+  @phpserver
   Scenario: Assert "Then the response should be in JSON format" honours content set from a fixture file over the page content
-    When I go to "/sites/default/files/json_invalid.json"
+    When I go to "http://cli:8888/json_invalid.json"
     And the response JSON from the file "json_valid.json"
     Then the response should be in JSON format
 
+  @phpserver
   Scenario: Assert "Then the response should be in JSON format" honours content set from a PyString over the page content
-    When I go to "/sites/default/files/json_invalid.json"
+    When I go to "http://cli:8888/json_invalid.json"
     And the response JSON content is the following:
       """
       {"name": "Blue Widget", "price": 9.99}
@@ -23,9 +26,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the response should be in JSON format" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_invalid.json"
+      When I go to "http://cli:8888/json_invalid.json"
       Then the response should be in JSON format
       """
     When I run "behat --no-colors"
@@ -34,16 +37,17 @@ Feature: Check that JsonTrait works
       The response is not valid JSON
       """
 
+  @phpserver
   Scenario: Assert "Then the response should not be in JSON format" works
-    When I go to "/sites/default/files/json_invalid.json"
+    When I go to "http://cli:8888/json_invalid.json"
     Then the response should not be in JSON format
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the response should not be in JSON format" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the response should not be in JSON format
       """
     When I run "behat --no-colors"
@@ -82,9 +86,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that path assertion fails with an exception for invalid JSON
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_invalid.json"
+      When I go to "http://cli:8888/json_invalid.json"
       Then the JSON path "$.name" should exist
       """
     When I run "behat --no-colors"
@@ -113,9 +117,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that path assertion fails with an error for an invalid JSONPath expression
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.items[?(@.x" should exist
       """
     When I run "behat --no-colors"
@@ -124,17 +128,18 @@ Feature: Check that JsonTrait works
       is invalid
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should exist" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.name" should exist
     And the JSON path "$.user.roles[0]" should exist
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should exist" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.nonexistent" should exist
       """
     When I run "behat --no-colors"
@@ -143,16 +148,17 @@ Feature: Check that JsonTrait works
       The JSON path "$.nonexistent" was not found.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should not exist" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.nonexistent" should not exist
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should not exist" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.name" should not exist
       """
     When I run "behat --no-colors"
@@ -161,8 +167,9 @@ Feature: Check that JsonTrait works
       The JSON path "$.name" was found, but it should not exist.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should be equal to :value" works with different scalar types
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.name" should be equal to "John Doe"
     And the JSON path "$.age" should be equal to "42"
     And the JSON path "$.price" should be equal to "9.99"
@@ -171,9 +178,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should be equal to :value" fails with an error for wrong value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.name" should be equal to "Wrong Name"
       """
     When I run "behat --no-colors"
@@ -185,9 +192,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that "Then the JSON path :path should be equal to :value" fails with an error for a missing path
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.nonexistent" should be equal to "test"
       """
     When I run "behat --no-colors"
@@ -199,9 +206,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that "Then the JSON path :path should be equal to :value" fails with an error for multiple matches
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.books[*].id" should be equal to "123"
       """
     When I run "behat --no-colors"
@@ -213,9 +220,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that "Then the JSON path :path should be equal to :value" fails with an error for a non-scalar value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.user" should be equal to "test"
       """
     When I run "behat --no-colors"
@@ -224,17 +231,18 @@ Feature: Check that JsonTrait works
       The JSON path "$.user" resolves to an array or object, but a scalar value is required for this assertion.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should not be equal to :value" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.name" should not be equal to "Jane Roe"
     And the JSON path "$.nickname" should not be equal to "John Doe"
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should not be equal to :value" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.name" should not be equal to "John Doe"
       """
     When I run "behat --no-colors"
@@ -243,16 +251,17 @@ Feature: Check that JsonTrait works
       The JSON path "$.name" is "John Doe", but it should not be.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should contain :value" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.name" should contain "John"
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should contain :value" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.name" should contain "Nonexistent"
       """
     When I run "behat --no-colors"
@@ -261,16 +270,17 @@ Feature: Check that JsonTrait works
       The JSON path "$.name" is "John Doe" and does not contain "Nonexistent".
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should not contain :value" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.name" should not contain "Nonexistent"
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should not contain :value" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.name" should not contain "John"
       """
     When I run "behat --no-colors"
@@ -279,16 +289,17 @@ Feature: Check that JsonTrait works
       The JSON path "$.name" is "John Doe" and contains "John", but it should not.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should match :pattern" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.email" should match "/^[^@]+@example\.com$/"
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should match :pattern" fails with an error for no match
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.email" should match "/^admin@/"
       """
     When I run "behat --no-colors"
@@ -300,9 +311,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that "Then the JSON path :path should match :pattern" fails with an error for an invalid pattern
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.email" should match "not-a-valid-regex"
       """
     When I run "behat --no-colors"
@@ -311,16 +322,17 @@ Feature: Check that JsonTrait works
       The regular expression "not-a-valid-regex" is invalid.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should not match :pattern" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.email" should not match "/^admin@/"
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should not match :pattern" fails with an error when it matches
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.email" should not match "/@example\.com$/"
       """
     When I run "behat --no-colors"
@@ -332,9 +344,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that "Then the JSON path :path should not match :pattern" fails with an error for an invalid pattern
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.email" should not match "not-a-valid-regex"
       """
     When I run "behat --no-colors"
@@ -343,16 +355,17 @@ Feature: Check that JsonTrait works
       The regular expression "not-a-valid-regex" is invalid.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should be null" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.nickname" should be null
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should be null" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.name" should be null
       """
     When I run "behat --no-colors"
@@ -361,16 +374,17 @@ Feature: Check that JsonTrait works
       The JSON path "$.name" is "John Doe", but expected null.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should be true" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.active" should be true
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should be true" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.disabled" should be true
       """
     When I run "behat --no-colors"
@@ -379,16 +393,17 @@ Feature: Check that JsonTrait works
       The JSON path "$.disabled" is not true.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should be false" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.disabled" should be false
 
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should be false" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.active" should be false
       """
     When I run "behat --no-colors"
@@ -397,8 +412,9 @@ Feature: Check that JsonTrait works
       The JSON path "$.active" is not false.
       """
 
+  @phpserver
   Scenario: Assert "Then the JSON path :path should have :count element(s)" works for arrays and objects
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.items" should have "3" elements
     And the JSON path "$.user.roles" should have "2" elements
     And the JSON path "$.user" should have "1" element
@@ -406,9 +422,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that negative assertion for "Then the JSON path :path should have :count element(s)" fails with an error for wrong count
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.items" should have "5" elements
       """
     When I run "behat --no-colors"
@@ -420,9 +436,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that "Then the JSON path :path should have :count element(s)" fails with an error for a scalar value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.name" should have "1" element
       """
     When I run "behat --no-colors"
@@ -434,9 +450,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that "Then the JSON path :path should have :count element(s)" fails with an error for a non-numeric count
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the JSON path "$.items" should have "three" elements
       """
     When I run "behat --no-colors"
@@ -445,8 +461,9 @@ Feature: Check that JsonTrait works
       The expected element count "three" is not a valid non-negative integer.
       """
 
+  @phpserver
   Scenario: Assert "Then the response should match the following JSON schema:" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the response should match the following JSON schema:
       """
       {"type": "object", "required": ["name", "age"], "properties": {"name": {"type": "string"}, "age": {"type": "integer"}}}
@@ -475,9 +492,9 @@ Feature: Check that JsonTrait works
   @trait:JsonTrait
   Scenario: Assert that "Then the response should match the following JSON schema:" fails with an error for an invalid schema
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the response should match the following JSON schema:
         '''
         {invalid schema
@@ -509,16 +526,17 @@ Feature: Check that JsonTrait works
       The response is not valid JSON
       """
 
+  @phpserver
   Scenario: Assert "Then the response should match the JSON schema in the file :filename" works
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the response should match the JSON schema in the file "json_schema.json"
 
   @trait:JsonTrait
   Scenario: Assert that "Then the response should match the JSON schema in the file :filename" fails with an exception for missing file
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/json_valid.json"
+      When I go to "http://cli:8888/json_valid.json"
       Then the response should match the JSON schema in the file "nonexistent.json"
       """
     When I run "behat --no-colors"
@@ -548,11 +566,12 @@ Feature: Check that JsonTrait works
       The response is not valid JSON
       """
 
+  @phpserver
   Scenario: Assert that JSON data is reloaded when navigating between different JSON files
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.name" should be equal to "John Doe"
-    When I go to "/sites/default/files/json_alt.json"
+    When I go to "http://cli:8888/json_alt.json"
     Then the JSON path "$.name" should be equal to "Jane Roe"
     And the JSON path "$.count" should be equal to "5"
-    When I go to "/sites/default/files/json_valid.json"
+    When I go to "http://cli:8888/json_valid.json"
     Then the JSON path "$.name" should be equal to "John Doe"

--- a/tests/behat/features/keyboard.feature
+++ b/tests/behat/features/keyboard.feature
@@ -4,18 +4,18 @@ Feature: Check that KeyboardTrait works
   I want to provide tools to interact with web elements using keyboard keys
   So that users can test keyboard navigation and input
 
-  @api @javascript
+  @api @javascript @phpserver
   Scenario: Assert step definition "When I press the keys :keys on the element :selector" succeeds as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_relative.html"
+    When I visit "http://cli:8888/elements_relative.html"
     Then the "input1" field should not contain "hello"
     When I press the keys "hello" on the element "#input1"
     Then the "input1" field should contain "hello"
 
-  @api @javascript
+  @api @javascript @phpserver
   Scenario: Assert step definition "When I press the key :char on the element :selector" succeeds as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_relative.html"
+    When I visit "http://cli:8888/elements_relative.html"
     Then the "input1" field should not contain "hello"
     When I press the key "h" on the element "#input1"
     And I press the key "e" on the element "#input1"
@@ -27,10 +27,10 @@ Feature: Check that KeyboardTrait works
   @trait:KeyboardTrait
   Scenario: Assert that negative assertion for "When I press the keys :keys on the element :selector" step throws an exception for using with a non-JavaScript driver
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      And I visit "/sites/default/files/elements_relative.html"
+      And I visit "http://cli:8888/elements_relative.html"
       When I press the key "h" on the element "#input1"
       """
     When I run "behat --no-colors"
@@ -39,27 +39,27 @@ Feature: Check that KeyboardTrait works
       Keyboard interaction is only supported by JavaScript drivers (Selenium2 or Chrome).
       """
 
-  @api @javascript
+  @api @javascript @phpserver
   Scenario: Assert step definition "When I press the key :char" succeeds as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_relative.html"
+    When I visit "http://cli:8888/elements_relative.html"
     Then the element "#sr-only-focusable" should not be displayed within a viewport
     When I press the key "tab"
     Then the element "#sr-only-focusable" should be displayed within a viewport
 
-  @api @javascript
+  @api @javascript @phpserver
   Scenario: Assert step definition "When I press the key :char on the element :selector" succeeds as expected with "tab" key
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_relative.html"
+    When I visit "http://cli:8888/elements_relative.html"
     Then the "input2" field should not contain "h"
     When I press the key "tab" on the element "#input1"
     And I press the key "h" on the element "#input2"
     Then the "input2" field should contain "h"
 
-  @api @javascript
+  @api @javascript @phpserver
   Scenario: Assert step definition "When I press the keys :keys" succeeds as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/elements_relative.html"
+    When I visit "http://cli:8888/elements_relative.html"
     And I fill in "input1" with ""
     Then the "input1" field should not contain "helloworld"
     When I press the keys "hello" on the element "#input1"
@@ -69,10 +69,10 @@ Feature: Check that KeyboardTrait works
   @trait:KeyboardTrait
   Scenario: Assert negative assertion for empty key throws an exception
     Given some behat configuration
-    And scenario steps tagged with "@api @javascript":
+    And scenario steps tagged with "@api @javascript @phpserver":
       """
       Given I am an anonymous user
-      And I visit "/sites/default/files/elements_relative.html"
+      And I visit "http://cli:8888/elements_relative.html"
       When I press the key "" on the element "#input1"
       """
     When I run "behat --no-colors"
@@ -84,10 +84,10 @@ Feature: Check that KeyboardTrait works
   @trait:KeyboardTrait
   Scenario: Assert negative assertion for unsupported key throws an exception
     Given some behat configuration
-    And scenario steps tagged with "@api @javascript":
+    And scenario steps tagged with "@api @javascript @phpserver":
       """
       Given I am an anonymous user
-      And I visit "/sites/default/files/elements_relative.html"
+      And I visit "http://cli:8888/elements_relative.html"
       When I press the key "unsupportedkey" on the element "#input1"
       """
     When I run "behat --no-colors"
@@ -99,10 +99,10 @@ Feature: Check that KeyboardTrait works
   @trait:KeyboardTrait
   Scenario: Assert negative assertion for non-existent element throws an exception
     Given some behat configuration
-    And scenario steps tagged with "@api @javascript":
+    And scenario steps tagged with "@api @javascript @phpserver":
       """
       Given I am an anonymous user
-      And I visit "/sites/default/files/elements_relative.html"
+      And I visit "http://cli:8888/elements_relative.html"
       When I press the key "h" on the element "#non-existent-element"
       """
     When I run "behat --no-colors"
@@ -114,10 +114,10 @@ Feature: Check that KeyboardTrait works
   @trait:KeyboardTrait
   Scenario: Assert negative assertion for no focused element throws an exception
     Given some behat configuration
-    And scenario steps tagged with "@api @javascript":
+    And scenario steps tagged with "@api @javascript @phpserver":
       """
       Given I am an anonymous user
-      And I visit "/sites/default/files/elements_relative.html"
+      And I visit "http://cli:8888/elements_relative.html"
       When I press the keys "abc"
       """
     When I run "behat --no-colors"

--- a/tests/behat/features/link.feature
+++ b/tests/behat/features/link.feature
@@ -3,49 +3,57 @@ Feature: Check that LinkTrait works
   I want to provide tools to verify link attributes and behaviors
   So that users can test navigation elements reliably
 
+  @phpserver
   Scenario: Assert link with href without selector
-    When I visit "/sites/default/files/links.html"
+    When I visit "http://cli:8888/links.html"
     Then the link "Absolute Link One" with the href "https://www.example.com" should exist
 
+  @phpserver
   Scenario: Assert link with href with selector
-    When I visit "/sites/default/files/links.html"
+    When I visit "http://cli:8888/links.html"
     Then the link "Link in navigation" with the href "https://www.example.com" within the element "#navigation" should exist
 
+  @phpserver
   Scenario: Assert link with wildcard in href without selector
-    When I visit "/sites/default/files/links.html"
+    When I visit "http://cli:8888/links.html"
     Then the link "Absolute Link Two" with the href "https://www.example*" should exist
 
+  @phpserver
   Scenario: Assert link with href without selector does not exist
-    When I visit "/sites/default/files/links.html"
+    When I visit "http://cli:8888/links.html"
     Then the link "RandomLinkText" with the href "https://www.example.com" should not exist
     And the link "Absolute Link One" with the href "https://www.randomhref.org" should not exist
 
+  @phpserver
   Scenario: Assert link with href with selector does not exist
-    When I visit "/sites/default/files/links.html"
+    When I visit "http://cli:8888/links.html"
     Then the link "RandomLinkText" with the href "https://www.randomhref.org" within the element "#navigation" should not exist
     And the link "Absolute Link One" with the href "https://www.randomhref.org" within the element "#navigation" should not exist
 
+  @phpserver
   Scenario: Assert link with wildcard in href without selector does not exist
-    When I visit "/sites/default/files/links.html"
+    When I visit "http://cli:8888/links.html"
     Then the link "Absolute Link One" with the href "https://www.randomhref*" should not exist
 
+  @phpserver
   Scenario: Assert link with title
-    When I visit "/sites/default/files/links.html"
+    When I visit "http://cli:8888/links.html"
     Then the link with the title "Link title one" should exist
     And the link with the title "Some non-existing title" should not exist
     And I click on the link with the title "Link title one"
 
+  @phpserver
   Scenario: Assert link is absolute or not
-    When I visit "/sites/default/files/links.html"
+    When I visit "http://cli:8888/links.html"
     Then the link "Absolute Link One" should be an absolute link
     And the link "Relative Link One" should not be an absolute link
 
   @trait:LinkTrait
   Scenario: Assert that negative assertion for "I click the link with title :title" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       When I click on the link with the title "Some non-existing title"
       """
     When I run "behat --no-colors"
@@ -57,9 +65,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that "the link with title :title exists" fails when link not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link with the title "Nonexistent title" should exist
       """
     When I run "behat --no-colors"
@@ -71,9 +79,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that negative assertion for "the link with title :title exists" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link with the title "Link title one" should not exist
       """
     When I run "behat --no-colors"
@@ -85,9 +93,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that link with href fails when selector does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link "Absolute Link One" with the href "https://www.example.com" within the element "#nonexistent-selector" should exist
       """
     When I run "behat --no-colors"
@@ -99,9 +107,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that link with href fails when link text not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link "NonexistentLinkText" with the href "https://www.example.com" should exist
       """
     When I run "behat --no-colors"
@@ -113,9 +121,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that negative link assertion fails when selector does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link "Absolute Link One" with the href "https://www.example.com" within the element "#nonexistent-selector" should not exist
       """
     When I run "behat --no-colors"
@@ -127,9 +135,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that link with href fails when href does not match
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link "Absolute Link One" with the href "https://wrong.url" should exist
       """
     When I run "behat --no-colors"
@@ -141,9 +149,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that negative assertion fails when link href matches but should not
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link "Absolute Link One" with the href "https://www.example.com" should not exist
       """
     When I run "behat --no-colors"
@@ -155,9 +163,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that absolute link check fails when link not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link "NonexistentLink" should be an absolute link
       """
     When I run "behat --no-colors"
@@ -169,9 +177,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that absolute link check fails when link is not absolute
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link "Relative Link One" should be an absolute link
       """
     When I run "behat --no-colors"
@@ -183,9 +191,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that not absolute link check fails when link not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link "NonexistentLink" should not be an absolute link
       """
     When I run "behat --no-colors"
@@ -197,9 +205,9 @@ Feature: Check that LinkTrait works
   @trait:LinkTrait
   Scenario: Assert that not absolute link check fails when link is absolute
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/links.html"
+      When I visit "http://cli:8888/links.html"
       Then the link "Absolute Link One" should not be an absolute link
       """
     When I run "behat --no-colors"

--- a/tests/behat/features/metatag.feature
+++ b/tests/behat/features/metatag.feature
@@ -49,22 +49,24 @@ Feature: Check that MetatagTrait works
       Meta tag with specified attributes should not exist: {"name":"MobileOptimized","content":"width"}
       """
 
+  @phpserver
   Scenario: Assert "Then the :metaName meta tag should not contain any HTML tags" works for clean meta tag
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags.html"
+    When I visit "http://cli:8888/metatags.html"
     Then the "description" meta tag should not contain any HTML tags
 
+  @phpserver
   Scenario: Assert "Then the :metaName meta tag should not contain any HTML tags" works for clean OG meta tag
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags.html"
+    When I visit "http://cli:8888/metatags.html"
     Then the "og:title" meta tag should not contain any HTML tags
 
   @trait:MetatagTrait
   Scenario: Assert that "Then the :metaName meta tag should not contain any HTML tags" fails when meta tag contains HTML
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the "og:description" meta tag should not contain any HTML tags
       """
     When I run "behat --no-colors"
@@ -76,9 +78,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the :metaName meta tag should not contain any HTML tags" fails when meta tag does not exist
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the "nonexistent" meta tag should not contain any HTML tags
       """
     When I run "behat --no-colors"
@@ -87,27 +89,31 @@ Feature: Check that MetatagTrait works
       Meta tag with name or property "nonexistent" not found.
       """
 
+  @phpserver
   Scenario: Assert canonical URL presence and value
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags_seo.html"
+    When I visit "http://cli:8888/metatags_seo.html"
     Then the canonical URL should exist
-    And the canonical URL should be "/sites/default/files/metatags_seo.html"
+    And the canonical URL should be "http://cli:8888/metatags_seo.html"
 
+  @phpserver
   Scenario: Assert canonical URL absence
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags.html"
+    When I visit "http://cli:8888/metatags.html"
     Then the canonical URL should not exist
 
+  @phpserver
   Scenario: Assert indexability and robots directives via the robots meta tag
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags_seo.html"
+    When I visit "http://cli:8888/metatags_seo.html"
     Then the page should be indexable
     And the meta robots should include "index"
     And the meta robots should not include "noindex"
 
+  @phpserver
   Scenario: Assert a non-indexable page via the robots meta tag
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags_noindex.html"
+    When I visit "http://cli:8888/metatags_noindex.html"
     Then the page should not be indexable
     And the meta robots should include "noindex"
 
@@ -121,28 +127,32 @@ Feature: Check that MetatagTrait works
     When I visit "/mysite_core/test-robots-header?value=all"
     Then the page should be indexable
 
+  @phpserver
   Scenario: Assert hreflang alternates are valid
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags_seo.html"
+    When I visit "http://cli:8888/metatags_seo.html"
     Then the hreflang alternates should be valid
 
+  @phpserver
   Scenario: Assert hreflang alternates have reciprocal return links
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags_hreflang_en.html"
+    When I visit "http://cli:8888/metatags_hreflang_en.html"
     Then the hreflang alternates should be valid
     And the hreflang alternates should have reciprocal return links
 
+  @phpserver
   Scenario: Assert Open Graph tags are valid and present
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags_seo.html"
+    When I visit "http://cli:8888/metatags_seo.html"
     Then the Open Graph tags should be valid
     And the following Open Graph tags should exist:
       | og:title       |
       | og:description |
 
+  @phpserver
   Scenario: Assert Twitter Card tags are valid and present
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags_seo.html"
+    When I visit "http://cli:8888/metatags_seo.html"
     Then the Twitter Card tags should be valid
     And the following Twitter Card tags should exist:
       | twitter:image |
@@ -150,23 +160,23 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the canonical URL should be" fails on mismatch
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_seo.html"
+      When I visit "http://cli:8888/metatags_seo.html"
       Then the canonical URL should be "/wrong-url"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      The canonical URL is "/sites/default/files/metatags_seo.html", but expected "/wrong-url".
+      The canonical URL is "http://cli:8888/metatags_seo.html", but expected "/wrong-url".
       """
 
   @trait:MetatagTrait
   Scenario: Assert that "Then the canonical URL should be" fails when absent
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the canonical URL should be "/some-url"
       """
     When I run "behat --no-colors"
@@ -178,9 +188,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the canonical URL should exist" fails when absent
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the canonical URL should exist
       """
     When I run "behat --no-colors"
@@ -192,28 +202,29 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the canonical URL should not exist" fails when present
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_seo.html"
+      When I visit "http://cli:8888/metatags_seo.html"
       Then the canonical URL should not exist
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
       """
-      The canonical URL should not be set, but found "/sites/default/files/metatags_seo.html".
+      The canonical URL should not be set, but found "http://cli:8888/metatags_seo.html".
       """
 
+  @phpserver
   Scenario: Assert canonical URL absence for an empty canonical link
     Given I am an anonymous user
-    When I visit "/sites/default/files/metatags_canonical_empty.html"
+    When I visit "http://cli:8888/metatags_canonical_empty.html"
     Then the canonical URL should not exist
 
   @trait:MetatagTrait
   Scenario: Assert that "Then the page should be indexable" fails on a noindex page
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_noindex.html"
+      When I visit "http://cli:8888/metatags_noindex.html"
       Then the page should be indexable
       """
     When I run "behat --no-colors"
@@ -225,9 +236,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the page should not be indexable" fails on an indexable page
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_seo.html"
+      When I visit "http://cli:8888/metatags_seo.html"
       Then the page should not be indexable
       """
     When I run "behat --no-colors"
@@ -239,9 +250,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the meta robots should include" fails when the directive is missing
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_seo.html"
+      When I visit "http://cli:8888/metatags_seo.html"
       Then the meta robots should include "noindex"
       """
     When I run "behat --no-colors"
@@ -253,9 +264,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the meta robots should not include" fails when the directive is present
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_noindex.html"
+      When I visit "http://cli:8888/metatags_noindex.html"
       Then the meta robots should not include "noindex"
       """
     When I run "behat --no-colors"
@@ -267,9 +278,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the hreflang alternates should be valid" fails with no alternates
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the hreflang alternates should be valid
       """
     When I run "behat --no-colors"
@@ -281,9 +292,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the hreflang alternates should be valid" fails on an invalid language code
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_hreflang_invalid.html"
+      When I visit "http://cli:8888/metatags_hreflang_invalid.html"
       Then the hreflang alternates should be valid
       """
     When I run "behat --no-colors"
@@ -295,9 +306,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the hreflang alternates should be valid" fails on an empty href
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_hreflang_emptyhref.html"
+      When I visit "http://cli:8888/metatags_hreflang_emptyhref.html"
       Then the hreflang alternates should be valid
       """
     When I run "behat --no-colors"
@@ -309,9 +320,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the hreflang alternates should be valid" fails without a self-reference
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_hreflang_noself.html"
+      When I visit "http://cli:8888/metatags_hreflang_noself.html"
       Then the hreflang alternates should be valid
       """
     When I run "behat --no-colors"
@@ -323,9 +334,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the hreflang alternates should have reciprocal return links" fails without a return link
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_hreflang_noreturn.html"
+      When I visit "http://cli:8888/metatags_hreflang_noreturn.html"
       Then the hreflang alternates should have reciprocal return links
       """
     When I run "behat --no-colors"
@@ -337,9 +348,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the hreflang alternates should have reciprocal return links" fails when an alternate is missing
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags_hreflang_404.html"
+      When I visit "http://cli:8888/metatags_hreflang_404.html"
       Then the hreflang alternates should have reciprocal return links
       """
     When I run "behat --no-colors"
@@ -351,9 +362,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the hreflang alternates should have reciprocal return links" fails with no alternates
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the hreflang alternates should have reciprocal return links
       """
     When I run "behat --no-colors"
@@ -365,9 +376,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the Open Graph tags should be valid" fails when tags are missing
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the Open Graph tags should be valid
       """
     When I run "behat --no-colors"
@@ -379,9 +390,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the Twitter Card tags should be valid" fails when tags are missing
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the Twitter Card tags should be valid
       """
     When I run "behat --no-colors"
@@ -393,9 +404,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the following Open Graph tags should exist" fails when a listed tag is missing
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the following Open Graph tags should exist:
         | og:title |
         | og:image |
@@ -409,9 +420,9 @@ Feature: Check that MetatagTrait works
   @trait:MetatagTrait
   Scenario: Assert that "Then the following Twitter Card tags should exist" fails when a listed tag is missing
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I visit "/sites/default/files/metatags.html"
+      When I visit "http://cli:8888/metatags.html"
       Then the following Twitter Card tags should exist:
         | twitter:card |
       """

--- a/tests/behat/features/modal.feature
+++ b/tests/behat/features/modal.feature
@@ -8,7 +8,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert jQuery UI modal full lifecycle
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_jquery_ui.html"
+    When I visit "http://cli:8888/modal_jquery_ui.html"
     Then I should not see the modal
     When I click on the element "#open-settings"
     And I wait for the modal to appear
@@ -21,7 +21,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert jQuery UI modal click with CSS selector
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_jquery_ui.html"
+    When I visit "http://cli:8888/modal_jquery_ui.html"
     And I click on the element "#open-settings"
     And I wait for the modal to appear
     Then I should see the modal
@@ -30,7 +30,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert jQuery UI modal click with button text
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_jquery_ui.html"
+    When I visit "http://cli:8888/modal_jquery_ui.html"
     And I click on the element "#open-settings"
     And I wait for the modal to appear
     When I click on "Save" in the modal
@@ -38,7 +38,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert jQuery UI modal click with link text
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_jquery_ui.html"
+    When I visit "http://cli:8888/modal_jquery_ui.html"
     And I click on the element "#open-settings"
     And I wait for the modal to appear
     When I click on "Cancel" in the modal
@@ -46,7 +46,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert jQuery UI second modal has different content
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_jquery_ui.html"
+    When I visit "http://cli:8888/modal_jquery_ui.html"
     And I click on the element "#open-confirm"
     And I wait for the modal to appear
     Then I should see the modal
@@ -58,7 +58,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert native dialog full lifecycle
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_native.html"
+    When I visit "http://cli:8888/modal_native.html"
     Then I should not see the modal
     When I click on the element "#open-info"
     And I wait for the modal to appear
@@ -71,7 +71,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert native dialog click with button text
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_native.html"
+    When I visit "http://cli:8888/modal_native.html"
     And I click on the element "#open-info"
     And I wait for the modal to appear
     When I click on "OK" in the modal
@@ -79,7 +79,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert native dialog click with link text
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_native.html"
+    When I visit "http://cli:8888/modal_native.html"
     And I click on the element "#open-info"
     And I wait for the modal to appear
     When I click on "View details" in the modal
@@ -87,7 +87,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert native dialog second modal has different content
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_native.html"
+    When I visit "http://cli:8888/modal_native.html"
     And I click on the element "#open-delete"
     And I wait for the modal to appear
     Then the modal should contain "Delete modal content"
@@ -98,7 +98,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert custom modal full lifecycle
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_custom.html"
+    When I visit "http://cli:8888/modal_custom.html"
     Then I should not see the modal
     When I click on the element "#open-profile"
     And I wait for the modal to appear
@@ -111,7 +111,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert custom modal click with CSS selector
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_custom.html"
+    When I visit "http://cli:8888/modal_custom.html"
     And I click on the element "#open-profile"
     And I wait for the modal to appear
     When I click on ".btn-update" in the modal
@@ -119,7 +119,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert custom modal click with link text
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_custom.html"
+    When I visit "http://cli:8888/modal_custom.html"
     And I click on the element "#open-profile"
     And I wait for the modal to appear
     When I click on "Reset" in the modal
@@ -127,7 +127,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert custom modal second modal has different content
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_custom.html"
+    When I visit "http://cli:8888/modal_custom.html"
     And I click on the element "#open-export"
     And I wait for the modal to appear
     Then the modal should contain "Export modal content"
@@ -136,7 +136,7 @@ Feature: Check that ModalTrait works
   @javascript @phpserver
   Scenario: Assert a visible modal is found when an earlier selector matches a hidden one
     Given I am an anonymous user
-    When I visit "/sites/default/files/modal_mixed.html"
+    When I visit "http://cli:8888/modal_mixed.html"
     Then I should not see the modal
     When I click on the element "#open-native"
     And I wait for the modal to appear
@@ -149,10 +149,10 @@ Feature: Check that ModalTrait works
   @trait:ModalTrait
   Scenario: Assert "Then I should see the modal" fails when no modal is visible
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/modal_jquery_ui.html"
+      When I visit "http://cli:8888/modal_jquery_ui.html"
       Then I should see the modal
       """
     When I run "behat --no-colors"
@@ -164,10 +164,10 @@ Feature: Check that ModalTrait works
   @trait:ModalTrait
   Scenario: Assert "When I close the modal" fails when modal is hidden
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/modal_jquery_ui.html"
+      When I visit "http://cli:8888/modal_jquery_ui.html"
       When I close the modal
       """
     When I run "behat --no-colors"
@@ -179,10 +179,10 @@ Feature: Check that ModalTrait works
   @trait:ModalTrait
   Scenario: Assert "When I click :selector in the modal" fails when modal is hidden
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/modal_jquery_ui.html"
+      When I visit "http://cli:8888/modal_jquery_ui.html"
       When I click on "Save" in the modal
       """
     When I run "behat --no-colors"
@@ -194,10 +194,10 @@ Feature: Check that ModalTrait works
   @trait:ModalTrait
   Scenario: Assert "Then the modal should contain :text" fails when modal is hidden
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/modal_jquery_ui.html"
+      When I visit "http://cli:8888/modal_jquery_ui.html"
       Then the modal should contain "some text"
       """
     When I run "behat --no-colors"
@@ -209,10 +209,10 @@ Feature: Check that ModalTrait works
   @trait:ModalTrait
   Scenario: Assert "When I click :selector in the modal" fails when element not found
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/modal_jquery_ui.html"
+      When I visit "http://cli:8888/modal_jquery_ui.html"
       When I press "Open Settings"
       When I click on ".nonexistent-element" in the modal
       """
@@ -225,10 +225,10 @@ Feature: Check that ModalTrait works
   @trait:ModalTrait
   Scenario: Assert "When I wait for the modal to appear" fails when modal does not appear within timeout
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/modal_delayed.html"
+      When I visit "http://cli:8888/modal_delayed.html"
       When I press "Open Delayed Modal"
       When I wait for the modal to appear
       """
@@ -241,10 +241,10 @@ Feature: Check that ModalTrait works
   @trait:ModalTrait
   Scenario: Assert "Then I should not see the modal" passes when no modal is visible
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/modal_jquery_ui.html"
+      When I visit "http://cli:8888/modal_jquery_ui.html"
       Then I should not see the modal
       """
     When I run "behat --no-colors"

--- a/tests/behat/features/response.feature
+++ b/tests/behat/features/response.feature
@@ -3,16 +3,17 @@ Feature: Check that ResponseTrait works
   I want to provide tools to verify HTTP response headers
   So that users can test server configuration and content delivery
 
+  @phpserver
   Scenario: Assert "Then the response should contain the header :header_name" works
-    When I go to "/sites/default/files/elements.html"
+    When I go to "http://cli:8888/elements.html"
     Then the response should contain the header "Content-Type"
 
   @trait:ResponseTrait
   Scenario: Assert that negative assertion for "Then the response should contain the header :header_name" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/elements.html"
+      When I go to "http://cli:8888/elements.html"
       Then the response should contain the header "NonExistingHeader"
       """
     When I run "behat --no-colors"
@@ -21,8 +22,9 @@ Feature: Check that ResponseTrait works
       The response does not contain the header "NonExistingHeader".
       """
 
+  @phpserver
   Scenario: Assert "Then the response should not contain the header :header_name" works
-    When I go to "/sites/default/files/elements.html"
+    When I go to "http://cli:8888/elements.html"
     Then the response should not contain the header "NonExistingHeader"
 
   @trait:ResponseTrait
@@ -39,8 +41,9 @@ Feature: Check that ResponseTrait works
       The response contains the header "Content-Type", but should not.
       """
 
+  @phpserver
   Scenario: Assert "Then the response header :header_name should contain the value :header_value" works
-    When I go to "/sites/default/files/elements.html"
+    When I go to "http://cli:8888/elements.html"
     Then the response header "Content-Type" should contain the value "text/html"
 
   @trait:ResponseTrait
@@ -71,8 +74,9 @@ Feature: Check that ResponseTrait works
       The text "nonexistingvalue" was not found anywhere in the "Content-Type" response header.
       """
 
+  @phpserver
   Scenario: Assert "Then the response header :header_name should not contain the value :header_value" works
-    When I go to "/sites/default/files/elements.html"
+    When I go to "http://cli:8888/elements.html"
     Then the response header "Content-Type" should not contain the value "nonexistingvalue"
 
   @trait:ResponseTrait

--- a/tests/behat/features/responsive.feature
+++ b/tests/behat/features/responsive.feature
@@ -60,9 +60,9 @@ Feature: Check that ResponsiveTrait works
   @trait:ResponsiveTrait
   Scenario: Invalid breakpoint should throw exception
     Given some behat configuration
-    And scenario steps tagged with "@phpserver":
+    And scenario steps:
       """
-      @javascript
+      @javascript @phpserver
       Scenario: Test invalid breakpoint
         When I am on "http://cli:8888/javascript_clean1.html"
         And I set the viewport to the "non_existent_breakpoint" breakpoint
@@ -76,9 +76,9 @@ Feature: Check that ResponsiveTrait works
   @trait:ResponsiveTrait
   Scenario: Invalid breakpoint tag should throw exception
     Given some behat configuration
-    And scenario steps tagged with "@phpserver":
+    And scenario steps:
       """
-      @javascript @breakpoint:invalid_breakpoint_tag
+      @javascript @breakpoint:invalid_breakpoint_tag @phpserver
       Scenario: Test invalid breakpoint tag
         When I am on "http://cli:8888/javascript_clean1.html"
       """
@@ -91,9 +91,9 @@ Feature: Check that ResponsiveTrait works
   @trait:ResponsiveTrait
   Scenario: Missing @javascript tag with @breakpoint should throw exception
     Given some behat configuration
-    And scenario steps tagged with "@phpserver":
+    And scenario steps:
       """
-      @breakpoint:mobile_portrait
+      @breakpoint:mobile_portrait @phpserver
       Scenario: Test missing javascript tag
         When I am on "http://cli:8888/javascript_clean1.html"
       """
@@ -106,9 +106,9 @@ Feature: Check that ResponsiveTrait works
   @trait:ResponsiveTrait
   Scenario: Multiple @breakpoint tags should throw exception
     Given some behat configuration
-    And scenario steps tagged with "@phpserver":
+    And scenario steps:
       """
-      @javascript @breakpoint:mobile_portrait @breakpoint:desktop
+      @javascript @breakpoint:mobile_portrait @breakpoint:desktop @phpserver
       Scenario: Test multiple breakpoint tags
         When I am on "http://cli:8888/javascript_clean1.html"
       """

--- a/tests/behat/features/responsive.feature
+++ b/tests/behat/features/responsive.feature
@@ -3,9 +3,9 @@ Feature: Check that ResponsiveTrait works
   I want to provide tools to test responsive layouts with viewport control
   So that users can verify their responsive designs at various breakpoints
 
-  @javascript
+  @javascript @phpserver
   Scenario: Resize viewport to default breakpoints
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
     And I set the viewport to the "mobile_portrait" breakpoint
     And I set the viewport to the "mobile_landscape" breakpoint
     And I set the viewport to the "tablet_portrait" breakpoint
@@ -13,46 +13,46 @@ Feature: Check that ResponsiveTrait works
     And I set the viewport to the "laptop" breakpoint
     And I set the viewport to the "desktop" breakpoint
 
-  @javascript
+  @javascript @phpserver
   Scenario: Set custom viewport dimensions
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
     And I set the viewport to "1920" by "1080"
     And I set the viewport to "800" by "600"
     And I set the viewport to "1366" by "768"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Set individual viewport width and height
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
     And I set the viewport to "1024" by "768"
     And I set the viewport width to "1280"
     And I set the viewport height to "1024"
 
-  @javascript @breakpoint:tablet_landscape
+  @javascript @breakpoint:tablet_landscape @phpserver
   Scenario: Tag-based breakpoint control
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
 
-  @javascript @breakpoint:mobile_portrait
+  @javascript @breakpoint:mobile_portrait @phpserver
   Scenario: Tag-based mobile breakpoint
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
 
-  @javascript @breakpoint:desktop
+  @javascript @breakpoint:desktop @phpserver
   Scenario: Tag-based desktop breakpoint
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
 
-  @javascript @breakpoint:tablet_landscape
+  @javascript @breakpoint:tablet_landscape @phpserver
   Scenario: Tag-based breakpoint should actually resize viewport
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
     Then the viewport should have the width of "1024"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Step-based breakpoint should resize viewport
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
     And I set the viewport to the "tablet_landscape" breakpoint
     Then the viewport should have the width of "1024"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Test multiple breakpoints in sequence
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
     And I set the viewport to the "mobile_portrait" breakpoint
     And I set the viewport to the "tablet_portrait" breakpoint
     And I set the viewport to the "desktop" breakpoint
@@ -60,11 +60,11 @@ Feature: Check that ResponsiveTrait works
   @trait:ResponsiveTrait
   Scenario: Invalid breakpoint should throw exception
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       @javascript
       Scenario: Test invalid breakpoint
-        When I am on "/sites/default/files/javascript_clean1.html"
+        When I am on "http://cli:8888/javascript_clean1.html"
         And I set the viewport to the "non_existent_breakpoint" breakpoint
       """
     When I run "behat --no-colors"
@@ -76,11 +76,11 @@ Feature: Check that ResponsiveTrait works
   @trait:ResponsiveTrait
   Scenario: Invalid breakpoint tag should throw exception
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       @javascript @breakpoint:invalid_breakpoint_tag
       Scenario: Test invalid breakpoint tag
-        When I am on "/sites/default/files/javascript_clean1.html"
+        When I am on "http://cli:8888/javascript_clean1.html"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -91,11 +91,11 @@ Feature: Check that ResponsiveTrait works
   @trait:ResponsiveTrait
   Scenario: Missing @javascript tag with @breakpoint should throw exception
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       @breakpoint:mobile_portrait
       Scenario: Test missing javascript tag
-        When I am on "/sites/default/files/javascript_clean1.html"
+        When I am on "http://cli:8888/javascript_clean1.html"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -106,11 +106,11 @@ Feature: Check that ResponsiveTrait works
   @trait:ResponsiveTrait
   Scenario: Multiple @breakpoint tags should throw exception
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       @javascript @breakpoint:mobile_portrait @breakpoint:desktop
       Scenario: Test multiple breakpoint tags
-        When I am on "/sites/default/files/javascript_clean1.html"
+        When I am on "http://cli:8888/javascript_clean1.html"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -118,25 +118,25 @@ Feature: Check that ResponsiveTrait works
       Only one @breakpoint tag is allowed per scenario. Found: @breakpoint:mobile_portrait, @breakpoint:desktop
       """
 
-  @javascript
+  @javascript @phpserver
   Scenario: Custom breakpoints can be registered and used
     Given the following responsive breakpoints:
       | name       | dimensions |
       | iphone_12  | 390x844    |
       | 4k_display | 3840x2160  |
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
     And I set the viewport to the "iphone_12" breakpoint
     And I set the viewport to the "4k_display" breakpoint
 
   @trait:ResponsiveTrait
   Scenario: Invalid custom breakpoint format should throw exception
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given the following responsive breakpoints:
         | name     | dimensions |
         | invalid  | 1920-1080  |
-      When I am on "/sites/default/files/javascript_clean1.html"
+      When I am on "http://cli:8888/javascript_clean1.html"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -147,12 +147,12 @@ Feature: Check that ResponsiveTrait works
   @trait:ResponsiveTrait
   Scenario: Invalid custom breakpoint format with letters should throw exception
     Given some behat configuration
-    And scenario steps tagged with "@javascript":
+    And scenario steps tagged with "@javascript @phpserver":
       """
       Given the following responsive breakpoints:
         | name     | dimensions |
         | invalid  | 1920xABC   |
-      When I am on "/sites/default/files/javascript_clean1.html"
+      When I am on "http://cli:8888/javascript_clean1.html"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:
@@ -160,22 +160,23 @@ Feature: Check that ResponsiveTrait works
       Invalid breakpoint format for 'invalid': '1920xABC'. Expected format: WIDTHxHEIGHT
       """
 
-  @javascript
+  @javascript @phpserver
   Scenario: Custom breakpoint overrides default breakpoint
     Given the following responsive breakpoints:
       | name            | dimensions |
       | mobile_portrait | 375x812    |
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
     And I set the viewport to the "mobile_portrait" breakpoint
 
+  @phpserver
   Scenario: Viewport steps without JavaScript driver should not throw exceptions
-    When I am on "/sites/default/files/javascript_clean1.html"
+    When I am on "http://cli:8888/javascript_clean1.html"
     And I set the viewport to the "mobile_portrait" breakpoint
     And I set the viewport to "1920" by "1080"
     And I set the viewport width to "1280"
     And I set the viewport height to "1024"
 
-  @javascript
+  @javascript @phpserver
   Scenario: Resize before visiting any page should start session
     When I set the viewport to "1920" by "1080"
-    And I am on "/sites/default/files/javascript_clean1.html"
+    And I am on "http://cli:8888/javascript_clean1.html"

--- a/tests/behat/features/table.feature
+++ b/tests/behat/features/table.feature
@@ -5,23 +5,25 @@ Feature: Check that TableTrait works
 
   # Row count.
 
+  @phpserver
   Scenario: Assert "Then the table :selector should have :count row(s)" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-asc" should have 3 rows
 
+  @phpserver
   Scenario: Assert "Then the table :selector should have :count row(s)" works with single row
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-single" should have 1 row
 
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should have :count row(s)" fails when table not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".nonexistent" should have 1 rows
       """
     When I run "behat --no-colors"
@@ -33,10 +35,10 @@ Feature: Check that TableTrait works
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should have :count row(s)" fails when row count does not match
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".table-asc" should have 99 rows
       """
     When I run "behat --no-colors"
@@ -47,23 +49,25 @@ Feature: Check that TableTrait works
 
   # Column count.
 
+  @phpserver
   Scenario: Assert "Then the table :selector should have :count column(s)" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-asc" should have 3 columns
 
+  @phpserver
   Scenario: Assert "Then the table :selector should have :count column(s)" works with different table
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-desc" should have 2 columns
 
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should have :count column(s)" fails when column count does not match
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".table-asc" should have 99 columns
       """
     When I run "behat --no-colors"
@@ -74,9 +78,10 @@ Feature: Check that TableTrait works
 
   # Column headers.
 
+  @phpserver
   Scenario: Assert "Then the table :selector should contain the following columns:" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-asc" should contain the following columns:
       | Name     |
       | Category |
@@ -85,10 +90,10 @@ Feature: Check that TableTrait works
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should contain the following columns:" fails when column not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".table-asc" should contain the following columns:
         | NonExistent |
       """
@@ -100,18 +105,19 @@ Feature: Check that TableTrait works
 
   # Empty and not empty.
 
+  @phpserver
   Scenario: Assert "Then the table :selector should be empty" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-empty" should be empty
 
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should be empty" fails when table has rows
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".table-asc" should be empty
       """
     When I run "behat --no-colors"
@@ -120,18 +126,19 @@ Feature: Check that TableTrait works
       Expected table ".table-asc" to be empty, but found 3 row(s).
       """
 
+  @phpserver
   Scenario: Assert "Then the table :selector should not be empty" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-asc" should not be empty
 
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should not be empty" fails when table is empty
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".table-empty" should not be empty
       """
     When I run "behat --no-colors"
@@ -142,23 +149,25 @@ Feature: Check that TableTrait works
 
   # Sort order.
 
+  @phpserver
   Scenario: Assert "Then the table :selector should be sorted by :column in :direction order" works with ascending order
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-asc" should be sorted by "Name" in "ascending" order
 
+  @phpserver
   Scenario: Assert "Then the table :selector should be sorted by :column in :direction order" works with descending order
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-desc" should be sorted by "Name" in "descending" order
 
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should be sorted by :column in :direction order" fails with invalid direction
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".table-asc" should be sorted by "Name" in "invalid" order
       """
     When I run "behat --no-colors"
@@ -170,10 +179,10 @@ Feature: Check that TableTrait works
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should be sorted by :column in :direction order" fails when not sorted
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".table-desc" should be sorted by "Name" in "ascending" order
       """
     When I run "behat --no-colors"
@@ -185,10 +194,10 @@ Feature: Check that TableTrait works
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should be sorted by :column in :direction order" fails when column not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".table-asc" should be sorted by "NonExistent" in "ascending" order
       """
     When I run "behat --no-colors"
@@ -199,9 +208,10 @@ Feature: Check that TableTrait works
 
   # Row content.
 
+  @phpserver
   Scenario: Assert "Then the table :selector should contain the following rows:" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the table ".table-asc" should contain the following rows:
       | Name       | Status   |
       | Alpha item | Active   |
@@ -210,10 +220,10 @@ Feature: Check that TableTrait works
   @trait:TableTrait
   Scenario: Assert "Then the table :selector should contain the following rows:" fails when row not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the table ".table-asc" should contain the following rows:
         | Name         |
         | Non Existent |
@@ -226,9 +236,10 @@ Feature: Check that TableTrait works
 
   # Row text.
 
+  @phpserver
   Scenario: Assert "Then the :rowText row should contain the following:" works as expected
     Given I am an anonymous user
-    When I visit "/sites/default/files/table.html"
+    When I visit "http://cli:8888/table.html"
     Then the "Alpha item" row should contain the following:
       | Type A  |
       | Active  |
@@ -236,10 +247,10 @@ Feature: Check that TableTrait works
   @trait:TableTrait
   Scenario: Assert "Then the :rowText row should contain the following:" fails when row not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the "NonExistent" row should contain the following:
         | some text |
       """
@@ -252,10 +263,10 @@ Feature: Check that TableTrait works
   @trait:TableTrait
   Scenario: Assert "Then the :rowText row should contain the following:" fails when text not found in row
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
       Given I am an anonymous user
-      When I visit "/sites/default/files/table.html"
+      When I visit "http://cli:8888/table.html"
       Then the "Alpha item" row should contain the following:
         | NonExistent |
       """

--- a/tests/behat/features/wait.feature
+++ b/tests/behat/features/wait.feature
@@ -26,9 +26,9 @@ Feature: Check that WaitTrait works
   @trait:WaitTrait
   Scenario: Assert that "When I wait for :seconds second(s) for AJAX to finish" fails when AJAX does not complete in time
     Given some behat configuration
-    And scenario steps tagged with "@api @javascript":
+    And scenario steps tagged with "@api @javascript @phpserver":
       """
-      When I visit "/sites/default/files/ajax_timeout.html"
+      When I visit "http://cli:8888/ajax_timeout.html"
       And I wait for "2" seconds for AJAX to finish
       """
     When I run "behat --no-colors"

--- a/tests/behat/features/xml.feature
+++ b/tests/behat/features/xml.feature
@@ -3,21 +3,25 @@ Feature: Check that XmlTrait works
   I want to provide tools to assert XML responses
   So that users can test API endpoints returning XML
 
+  @phpserver
   Scenario: Assert "Then the response should be in XML format" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the response should be in XML format
 
+  @phpserver
   Scenario: Assert "Then the response should be in XML format" works with XML that has warnings
-    When I go to "/sites/default/files/xml_with_warnings.xml"
+    When I go to "http://cli:8888/xml_with_warnings.xml"
     Then the response should be in XML format
 
+  @phpserver
   Scenario: Assert "Then the response should be in XML format" honours content set from a fixture file over the page content
-    When I go to "/sites/default/files/xml_invalid.xml"
+    When I go to "http://cli:8888/xml_invalid.xml"
     And the response content from the file "xml_valid.xml"
     Then the response should be in XML format
 
+  @phpserver
   Scenario: Assert "Then the response should be in XML format" honours content set from a PyString over the page content
-    When I go to "/sites/default/files/xml_invalid.xml"
+    When I go to "http://cli:8888/xml_invalid.xml"
     And the response content is the following:
       """
       <?xml version="1.0" encoding="UTF-8"?>
@@ -30,9 +34,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be in XML format" fails with an exception
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_invalid.xml"
+      When I go to "http://cli:8888/xml_invalid.xml"
       Then the response should be in XML format
       """
     When I run "behat --no-colors"
@@ -41,21 +45,23 @@ Feature: Check that XmlTrait works
       Failed to load XML
       """
 
+  @phpserver
   Scenario: Assert "Then the response should not be in XML format" works
-    When I go to "/sites/default/files/xml_invalid.xml"
+    When I go to "http://cli:8888/xml_invalid.xml"
     Then the response should not be in XML format
 
+  @phpserver
   Scenario: Assert "Then the response should not be in XML format" honours content set from a fixture file over the page content
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     And the response content from the file "xml_invalid.xml"
     Then the response should not be in XML format
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should not be in XML format" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the response should not be in XML format
       """
     When I run "behat --no-colors"
@@ -64,24 +70,27 @@ Feature: Check that XmlTrait works
       The response is valid XML, but it should not be.
       """
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should exist" works with absolute path
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "/library/book" should exist
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should exist" works with relative path
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book" should exist
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should exist" works with predicate
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']" should exist
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should exist" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//nonexistent" should exist
       """
     When I run "behat --no-colors"
@@ -90,16 +99,17 @@ Feature: Check that XmlTrait works
       The XML element "//nonexistent" was not found.
       """
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should not exist" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//nonexistent" should not exist
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should not exist" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//book" should not exist
       """
     When I run "behat --no-colors"
@@ -108,16 +118,17 @@ Feature: Check that XmlTrait works
       The XML element "//book" was found, but it should not exist.
       """
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should be equal to :text" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/title" should be equal to "The Great Adventure"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should be equal to :text" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//nonexistent" should be equal to "test"
       """
     When I run "behat --no-colors"
@@ -129,9 +140,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should be equal to :text" fails with an error for wrong content
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//book[@id='123']/title" should be equal to "Wrong Title"
       """
     When I run "behat --no-colors"
@@ -140,16 +151,17 @@ Feature: Check that XmlTrait works
       The XML element "//book[@id='123']/title" content is "The Great Adventure", but expected "Wrong Title".
       """
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should not be equal to :text" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/title" should not be equal to "Wrong Title"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should not be equal to :text" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//book[@id='123']/title" should not be equal to "The Great Adventure"
       """
     When I run "behat --no-colors"
@@ -158,16 +170,17 @@ Feature: Check that XmlTrait works
       The XML element "//book[@id='123']/title" content is "The Great Adventure", but it should not be.
       """
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should contain :text" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/description" should contain "sample book"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should contain :text" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//nonexistent" should contain "test"
       """
     When I run "behat --no-colors"
@@ -179,9 +192,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should contain :text" fails with an error for missing text
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//book[@id='123']/title" should contain "nonexistent"
       """
     When I run "behat --no-colors"
@@ -190,16 +203,17 @@ Feature: Check that XmlTrait works
       The XML element "//book[@id='123']/title" does not contain "nonexistent".
       """
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should not contain :text" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/title" should not contain "nonexistent"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should not contain :text" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//book[@id='123']/description" should not contain "sample book"
       """
     When I run "behat --no-colors"
@@ -208,16 +222,17 @@ Feature: Check that XmlTrait works
       The XML element "//book[@id='123']/description" contains "sample book", but it should not.
       """
 
+  @phpserver
   Scenario: Assert "Then the XML attribute :attribute on element :element should exist" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "id" on element "//book[@id='123']" should exist
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should exist" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "id" on element "//nonexistent" should exist
       """
     When I run "behat --no-colors"
@@ -229,9 +244,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should exist" fails with an error for missing attribute
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "nonexistent" on element "//book[@id='123']" should exist
       """
     When I run "behat --no-colors"
@@ -240,16 +255,17 @@ Feature: Check that XmlTrait works
       The XML attribute "nonexistent" on element "//book[@id='123']" was not found.
       """
 
+  @phpserver
   Scenario: Assert "Then the XML attribute :attribute on element :element should not exist" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "nonexistent" on element "//book[@id='123']" should not exist
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should not exist" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "id" on element "//book[@id='123']" should not exist
       """
     When I run "behat --no-colors"
@@ -258,20 +274,22 @@ Feature: Check that XmlTrait works
       The XML attribute "id" on element "//book[@id='123']" was found, but it should not exist.
       """
 
+  @phpserver
   Scenario: Assert "Then the XML attribute :attribute on element :element should be equal to :text" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "id" on element "//book[@id='123']" should be equal to "123"
 
+  @phpserver
   Scenario: Assert "Then the XML attribute :attribute on element :element should be equal to :text" works with category
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "category" on element "//book[@id='123']" should be equal to "fiction"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should be equal to :text" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "id" on element "//nonexistent" should be equal to "123"
       """
     When I run "behat --no-colors"
@@ -283,9 +301,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should be equal to :text" fails with an error for missing attribute
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "nonexistent" on element "//book[@id='123']" should be equal to "test"
       """
     When I run "behat --no-colors"
@@ -297,9 +315,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should be equal to :text" fails with an error for wrong value
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "id" on element "//book[@id='123']" should be equal to "999"
       """
     When I run "behat --no-colors"
@@ -308,16 +326,17 @@ Feature: Check that XmlTrait works
       The XML attribute "id" on element "//book[@id='123']" is "123", but expected "999".
       """
 
+  @phpserver
   Scenario: Assert "Then the XML attribute :attribute on element :element should not be equal to :text" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "id" on element "//book[@id='123']" should not be equal to "999"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should not be equal to :text" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "id" on element "//book[@id='123']" should not be equal to "123"
       """
     When I run "behat --no-colors"
@@ -326,20 +345,22 @@ Feature: Check that XmlTrait works
       The XML attribute "id" on element "//book[@id='123']" is "123", but it should not be.
       """
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should have :count element(s)" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//library" should have "3" elements
 
+  @phpserver
   Scenario: Assert "Then the XML element :element should have :count element(s)" works with simple.xml
-    When I go to "/sites/default/files/xml_simple.xml"
+    When I go to "http://cli:8888/xml_simple.xml"
     Then the XML element "//root" should have "5" elements
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should have :count element(s)" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//nonexistent" should have "3" elements
       """
     When I run "behat --no-colors"
@@ -351,9 +372,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML element :element should have :count element(s)" fails with an error for wrong count
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//library" should have "5" elements
       """
     When I run "behat --no-colors"
@@ -362,20 +383,22 @@ Feature: Check that XmlTrait works
       The XML element "//library" has 3 child element(s), but expected 5.
       """
 
+  @phpserver
   Scenario: Assert "Then the XML should use the namespace :namespace" works
-    When I go to "/sites/default/files/xml_namespaced.xml"
+    When I go to "http://cli:8888/xml_namespaced.xml"
     Then the XML should use the namespace "http://example.com/custom"
 
+  @phpserver
   Scenario: Assert "Then the XML should use the namespace :namespace" works with test namespace
-    When I go to "/sites/default/files/xml_namespaced.xml"
+    When I go to "http://cli:8888/xml_namespaced.xml"
     Then the XML should use the namespace "http://example.com/test"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML should use the namespace :namespace" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_namespaced.xml"
+      When I go to "http://cli:8888/xml_namespaced.xml"
       Then the XML should use the namespace "http://example.com/nonexistent"
       """
     When I run "behat --no-colors"
@@ -384,16 +407,17 @@ Feature: Check that XmlTrait works
       The XML does not use the namespace "http://example.com/nonexistent".
       """
 
+  @phpserver
   Scenario: Assert "Then the XML should not use the namespace :namespace" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML should not use the namespace "http://example.com/nonexistent"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML should not use the namespace :namespace" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_namespaced.xml"
+      When I go to "http://cli:8888/xml_namespaced.xml"
       Then the XML should not use the namespace "http://example.com/custom"
       """
     When I run "behat --no-colors"
@@ -402,21 +426,22 @@ Feature: Check that XmlTrait works
       The XML uses the namespace "http://example.com/custom", but it should not.
       """
 
+  @phpserver
   Scenario: Assert that XML document is reloaded when navigating between different XML files
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/title" should be equal to "The Great Adventure"
-    When I go to "/sites/default/files/xml_simple.xml"
+    When I go to "http://cli:8888/xml_simple.xml"
     Then the XML element "//root" should have "5" elements
     And the XML element "//count" should be equal to "3"
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/title" should be equal to "The Great Adventure"
 
   @trait:XmlTrait
   Scenario: Assert that "Then the XML element :element should not be equal to :text" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//nonexistent" should not be equal to "test"
       """
     When I run "behat --no-colors"
@@ -428,9 +453,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that "Then the XML element :element should not contain :text" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML element "//nonexistent" should not contain "test"
       """
     When I run "behat --no-colors"
@@ -442,9 +467,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that "Then the XML attribute :attribute on element :element should not exist" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "id" on element "//nonexistent" should not exist
       """
     When I run "behat --no-colors"
@@ -456,9 +481,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that "Then the XML attribute :attribute on element :element should not be equal to :text" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "id" on element "//nonexistent" should not be equal to "123"
       """
     When I run "behat --no-colors"
@@ -470,9 +495,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that "Then the XML attribute :attribute on element :element should not be equal to :text" fails with an error for missing attribute
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "nonexistent" on element "//book[@id='123']" should not be equal to "test"
       """
     When I run "behat --no-colors"
@@ -535,20 +560,22 @@ Feature: Check that XmlTrait works
       Failed to load XML
       """
 
+  @phpserver
   Scenario: Assert "Then the XML attribute :attribute_name on element :element should contain :text" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "category" on element "//book[@id='123']" should contain "fic"
 
+  @phpserver
   Scenario: Assert "Then the XML attribute :attribute_name on element :element should contain :text" works with id attribute
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "id" on element "//book[@id='123']" should contain "12"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should contain :text" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "id" on element "//nonexistent" should contain "123"
       """
     When I run "behat --no-colors"
@@ -560,9 +587,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should contain :text" fails with an error for missing attribute
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "nonexistent" on element "//book[@id='123']" should contain "test"
       """
     When I run "behat --no-colors"
@@ -574,9 +601,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should contain :text" fails with an error for text not found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "category" on element "//book[@id='123']" should contain "science"
       """
     When I run "behat --no-colors"
@@ -585,16 +612,17 @@ Feature: Check that XmlTrait works
       The XML attribute "category" on element "//book[@id='123']" does not contain "science".
       """
 
+  @phpserver
   Scenario: Assert "Then the XML attribute :attribute_name on element :element should not contain :text" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "category" on element "//book[@id='123']" should not contain "science"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should not contain :text" fails with an error for missing element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "id" on element "//nonexistent" should not contain "123"
       """
     When I run "behat --no-colors"
@@ -606,9 +634,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should not contain :text" fails with an error for missing attribute
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "nonexistent" on element "//book[@id='123']" should not contain "test"
       """
     When I run "behat --no-colors"
@@ -620,9 +648,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should not contain :text" fails with an error when text is found
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the XML attribute "category" on element "//book[@id='123']" should not contain "fic"
       """
     When I run "behat --no-colors"
@@ -667,16 +695,17 @@ Feature: Check that XmlTrait works
       </xs:schema>
       """
 
+  @phpserver
   Scenario: Assert "Then the response should match the XSD schema in the file :filename" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the response should match the XSD schema in the file "xml_schema.xsd"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should match the XSD schema in the file :filename" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_simple.xml"
+      When I go to "http://cli:8888/xml_simple.xml"
       Then the response should match the XSD schema in the file "xml_schema.xsd"
       """
     When I run "behat --no-colors"
@@ -688,9 +717,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that "Then the response should match the XSD schema in the file :filename" fails with an exception for missing file
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       Then the response should match the XSD schema in the file "nonexistent.xsd"
       """
     When I run "behat --no-colors"
@@ -709,16 +738,17 @@ Feature: Check that XmlTrait works
       <!ELEMENT note (#PCDATA)>
       """
 
+  @phpserver
   Scenario: Assert "Then the response should match the DTD in the file :filename" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the response should match the DTD in the file "xml_schema.dtd"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should match the DTD in the file :filename" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_simple.xml"
+      When I go to "http://cli:8888/xml_simple.xml"
       Then the response should match the DTD in the file "xml_schema.dtd"
       """
     When I run "behat --no-colors"
@@ -739,16 +769,17 @@ Feature: Check that XmlTrait works
       </element>
       """
 
+  @phpserver
   Scenario: Assert "Then the response should match the RelaxNG schema in the file :filename" works
-    When I go to "/sites/default/files/xml_valid.xml"
+    When I go to "http://cli:8888/xml_valid.xml"
     Then the response should match the RelaxNG schema in the file "xml_schema.rng"
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should match the RelaxNG schema in the file :filename" fails with an error
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_simple.xml"
+      When I go to "http://cli:8888/xml_simple.xml"
       Then the response should match the RelaxNG schema in the file "xml_schema.rng"
       """
     When I run "behat --no-colors"
@@ -757,16 +788,17 @@ Feature: Check that XmlTrait works
       The response does not match the RelaxNG schema
       """
 
+  @phpserver
   Scenario: Assert "Then the response should be a valid RSS feed" works
-    When I go to "/sites/default/files/rss_valid.xml"
+    When I go to "http://cli:8888/rss_valid.xml"
     Then the response should be a valid RSS feed
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for a non-rss root
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       And the response content is the following:
         '''
         <?xml version="1.0"?><catalog></catalog>
@@ -782,9 +814,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for a wrong version
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       And the response content is the following:
         '''
         <?xml version="1.0"?><rss version="1.0"><channel><title>t</title><link>l</link><description>d</description></channel></rss>
@@ -800,9 +832,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for a missing channel
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       And the response content is the following:
         '''
         <?xml version="1.0"?><rss version="2.0"></rss>
@@ -818,9 +850,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for a missing required channel element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       And the response content is the following:
         '''
         <?xml version="1.0"?><rss version="2.0"><channel><title>t</title><link>l</link></channel></rss>
@@ -836,9 +868,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be a valid RSS feed" fails with an error for an item without a title or description
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       And the response content is the following:
         '''
         <?xml version="1.0"?><rss version="2.0"><channel><title>t</title><link>l</link><description>d</description><item><link>x</link></item></channel></rss>
@@ -851,16 +883,17 @@ Feature: Check that XmlTrait works
       each "item" element must contain a "title" or a "description"
       """
 
+  @phpserver
   Scenario: Assert "Then the response should be a valid Atom feed" works
-    When I go to "/sites/default/files/atom_valid.xml"
+    When I go to "http://cli:8888/atom_valid.xml"
     Then the response should be a valid Atom feed
 
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be a valid Atom feed" fails with an error for a non-atom root
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       And the response content is the following:
         '''
         <?xml version="1.0"?><feed><id>x</id><title>t</title><updated>u</updated></feed>
@@ -876,9 +909,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be a valid Atom feed" fails with an error for a missing required feed element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       And the response content is the following:
         '''
         <?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><id>x</id><title>t</title></feed>
@@ -894,9 +927,9 @@ Feature: Check that XmlTrait works
   @trait:XmlTrait
   Scenario: Assert that negative assertion for "Then the response should be a valid Atom feed" fails with an error for an entry missing a required element
     Given some behat configuration
-    And scenario steps:
+    And scenario steps tagged with "@phpserver":
       """
-      When I go to "/sites/default/files/xml_valid.xml"
+      When I go to "http://cli:8888/xml_valid.xml"
       And the response content is the following:
         '''
         <?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom" xmlns:other="http://example.com/other"><id>x</id><title>t</title><updated>u</updated><entry><id>e</id><title>et</title><other:updated>2024</other:updated></entry></feed>

--- a/tests/behat/fixtures/accessibility_clean.html
+++ b/tests/behat/fixtures/accessibility_clean.html
@@ -24,8 +24,8 @@ It should pass axe-core WCAG 2.0/2.1 A and AA checks.
   <main>
     <h1>Clean Accessibility Page</h1>
     <p>This page contains content with sufficient color contrast and a proper document structure.</p>
-    <p><a href="/sites/default/files/accessibility_clean2.html">Go to second clean page</a></p>
-    <img src="/sites/default/files/image.png" alt="An accessible image with proper alt text" width="200" height="100">
+    <p><a href="/accessibility_clean2.html">Go to second clean page</a></p>
+    <img src="/image.png" alt="An accessible image with proper alt text" width="200" height="100">
   </main>
 </body>
 </html>

--- a/tests/behat/fixtures/accessibility_violations.html
+++ b/tests/behat/fixtures/accessibility_violations.html
@@ -23,7 +23,7 @@ It deliberately contains multiple accessibility violations:
 </head>
 <body>
   <h1>Inaccessible Page</h1>
-  <img src="/sites/default/files/image.png" width="200" height="100">
+  <img src="/image.png" width="200" height="100">
   <button></button>
   <a href="#"></a>
 </body>

--- a/tests/behat/fixtures/elements.html
+++ b/tests/behat/fixtures/elements.html
@@ -74,9 +74,9 @@
       <span class="nth-child">Child two</span>
       <span class="nth-child">Child three</span>
     </div>
-    <p><a href="/sites/default/files/table.html" class="nth-link">Repeated link</a></p>
-    <p><a href="/sites/default/files/links.html" class="nth-link">Repeated link</a></p>
-    <p><a href="/sites/default/files/metatags.html" class="nth-link">Repeated link</a></p>
+    <p><a href="/table.html" class="nth-link">Repeated link</a></p>
+    <p><a href="/links.html" class="nth-link">Repeated link</a></p>
+    <p><a href="/metatags.html" class="nth-link">Repeated link</a></p>
   </div>
 
   <!-- Section: Focus Testing -->

--- a/tests/behat/fixtures/elements_css.html
+++ b/tests/behat/fixtures/elements_css.html
@@ -5,9 +5,6 @@ viewport pinning assertions in ElementTrait.
 It is kept apart from `elements.html` because the pinning tests need
 `position: fixed` elements, which would overlay content that other fixtures
 rely on being reachable.
-
-Any changes to this document should be copied over manually:
-cp /app/tests/behat/fixtures/elements_css.html /app/build/web/sites/default/files/elements_css.html
 -->
 <!DOCTYPE html>
 <html lang="en" dir="ltr">

--- a/tests/behat/fixtures/elements_relative.html
+++ b/tests/behat/fixtures/elements_relative.html
@@ -7,9 +7,6 @@ JS-based assertions.
 It also has a JS code used in VisibilityTrait to test visibility of an element.
 And it also has tests for this JS code.
 Scroll to the bottom of the document to `isElemVisible()` function.
-
-Any changes to this document should be copied over manually:
-cp /app/tests/behat/fixtures/elements_relative.html /app/build/web/sites/default/files/elements_relative.html
 -->
 <!DOCTYPE html>
 <html>

--- a/tests/behat/fixtures/metatags_hreflang_404.html
+++ b/tests/behat/fixtures/metatags_hreflang_404.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>Hreflang broken link</title>
-  <link rel="alternate" hreflang="en" href="/sites/default/files/metatags_hreflang_404.html">
-  <link rel="alternate" hreflang="de" href="/sites/default/files/metatags_hreflang_missing.html">
+  <link rel="alternate" hreflang="en" href="http://cli:8888/metatags_hreflang_404.html">
+  <link rel="alternate" hreflang="de" href="http://cli:8888/metatags_hreflang_missing.html">
 </head>
 <body>
   <h1>Hreflang broken link</h1>

--- a/tests/behat/fixtures/metatags_hreflang_de.html
+++ b/tests/behat/fixtures/metatags_hreflang_de.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <title>Hreflang DE</title>
-  <link rel="alternate" hreflang="en" href="/sites/default/files/metatags_hreflang_en.html">
-  <link rel="alternate" hreflang="de" href="/sites/default/files/metatags_hreflang_de.html">
-  <link rel="alternate" hreflang="x-default" href="/sites/default/files/metatags_hreflang_en.html">
+  <link rel="alternate" hreflang="en" href="http://cli:8888/metatags_hreflang_en.html">
+  <link rel="alternate" hreflang="de" href="http://cli:8888/metatags_hreflang_de.html">
+  <link rel="alternate" hreflang="x-default" href="http://cli:8888/metatags_hreflang_en.html">
 </head>
 <body>
   <h1>Hreflang DE</h1>

--- a/tests/behat/fixtures/metatags_hreflang_en.html
+++ b/tests/behat/fixtures/metatags_hreflang_en.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <title>Hreflang EN</title>
-  <link rel="alternate" hreflang="en" href="/sites/default/files/metatags_hreflang_en.html">
-  <link rel="alternate" hreflang="de" href="/sites/default/files/metatags_hreflang_de.html">
-  <link rel="alternate" hreflang="x-default" href="/sites/default/files/metatags_hreflang_en.html">
+  <link rel="alternate" hreflang="en" href="http://cli:8888/metatags_hreflang_en.html">
+  <link rel="alternate" hreflang="de" href="http://cli:8888/metatags_hreflang_de.html">
+  <link rel="alternate" hreflang="x-default" href="http://cli:8888/metatags_hreflang_en.html">
 </head>
 <body>
   <h1>Hreflang EN</h1>

--- a/tests/behat/fixtures/metatags_hreflang_invalid.html
+++ b/tests/behat/fixtures/metatags_hreflang_invalid.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Hreflang invalid</title>
-  <link rel="alternate" hreflang="english" href="/sites/default/files/metatags_hreflang_invalid.html">
+  <link rel="alternate" hreflang="english" href="http://cli:8888/metatags_hreflang_invalid.html">
 </head>
 <body>
   <h1>Hreflang invalid</h1>

--- a/tests/behat/fixtures/metatags_hreflang_noreturn.html
+++ b/tests/behat/fixtures/metatags_hreflang_noreturn.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>Hreflang no return</title>
-  <link rel="alternate" hreflang="en" href="/sites/default/files/metatags_hreflang_noreturn.html">
-  <link rel="alternate" hreflang="de" href="/sites/default/files/metatags_hreflang_de.html">
+  <link rel="alternate" hreflang="en" href="http://cli:8888/metatags_hreflang_noreturn.html">
+  <link rel="alternate" hreflang="de" href="http://cli:8888/metatags_hreflang_de.html">
 </head>
 <body>
   <h1>Hreflang no return</h1>

--- a/tests/behat/fixtures/metatags_hreflang_noself.html
+++ b/tests/behat/fixtures/metatags_hreflang_noself.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>Hreflang no self</title>
-  <link rel="alternate" hreflang="en" href="/sites/default/files/metatags_hreflang_en.html">
-  <link rel="alternate" hreflang="de" href="/sites/default/files/metatags_hreflang_de.html">
+  <link rel="alternate" hreflang="en" href="http://cli:8888/metatags_hreflang_en.html">
+  <link rel="alternate" hreflang="de" href="http://cli:8888/metatags_hreflang_de.html">
 </head>
 <body>
   <h1>Hreflang no self</h1>

--- a/tests/behat/fixtures/metatags_seo.html
+++ b/tests/behat/fixtures/metatags_seo.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="UTF-8">
   <title>SEO Meta Tag Testing Page</title>
-  <link rel="canonical" href="/sites/default/files/metatags_seo.html">
+  <link rel="canonical" href="http://cli:8888/metatags_seo.html">
   <meta name="description" content="A page with a full set of SEO head tags.">
   <meta name="robots" content="index, follow">
-  <link rel="alternate" hreflang="en" href="/sites/default/files/metatags_seo.html">
-  <link rel="alternate" hreflang="x-default" href="/sites/default/files/metatags_seo.html">
+  <link rel="alternate" hreflang="en" href="http://cli:8888/metatags_seo.html">
+  <link rel="alternate" hreflang="x-default" href="http://cli:8888/metatags_seo.html">
   <meta property="og:title" content="SEO Meta Tag Testing Page">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="/sites/default/files/og-image.png">
-  <meta property="og:url" content="/sites/default/files/metatags_seo.html">
+  <meta property="og:image" content="http://cli:8888/og-image.png">
+  <meta property="og:url" content="http://cli:8888/metatags_seo.html">
   <meta property="og:description" content="A page with a full set of SEO head tags.">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="SEO Meta Tag Testing Page">
   <meta name="twitter:description" content="A page with a full set of SEO head tags.">
-  <meta name="twitter:image" content="/sites/default/files/og-image.png">
+  <meta name="twitter:image" content="http://cli:8888/og-image.png">
 </head>
 <body>
   <h1>SEO Meta Tag Testing Page</h1>


### PR DESCRIPTION
Closes #746

## Summary

Feature tests for traits without a Drupal dependency reached their static fixtures through the fixture Drupal site at `/sites/default/files/<file>`, which coupled them to a provisioned Drupal build and to Drupal's public files directory. They now address the fixtures directly on the PHP built-in server that already serves `tests/behat/fixtures` (provided by `drevops/behat-phpserver`, already wired into `behat.yml` and into the generated child config in `tests/behat/bootstrap/BehatCliTrait.php`), at `http://cli:8888/<file>`, with each scenario carrying the `@phpserver` tag that starts the server. No new services, dependencies, or containers were introduced; the change reuses infrastructure that was already in the stack. Verified against the full local BDD suite: 1048 of 1052 scenarios passed, and the remaining failures (`drupal_content.feature:280`, `drupal_content.feature:290`, `drupal_override.feature:18`) are pre-existing and unrelated: `drupal_override.feature:18` was reproduced failing identically against the pre-change harness and feature file.

## Changes

- Converted 20 feature files (~490 URL references) from `/sites/default/files/<file>` to `http://cli:8888/<file>`, and added the `@phpserver` tag to every scenario that needs the server, including inside nested `scenario steps tagged with "..."` blocks that spawn a child Behat process via `BehatCliContext`.
- Placed `@phpserver` directly on nested blocks that declare their own `Scenario:` line with its own tags (4 scenarios in `responsive.feature`, 3 inner scenarios in `javascript.feature`) instead of on the generated stub scenario, so the server keeps running while the visiting scenario executes.
- Made fixture markup that the traits resolve against an origin fully qualified to `http://cli:8888/...`: the canonical, hreflang, and `og:url` tags in `metatags_seo.html` and the `metatags_hreflang_*.html` files, because `MetatagTrait::metatagResolveUrl()` resolves root-relative hrefs against Mink's `base_url` and compares them with the current page URL.
- Changed plain in-page links and images in `elements.html`, `accessibility_clean.html`, and `accessibility_violations.html` to root-relative paths (`/table.html`, `/image.png`).
- Updated expected-output assertions where the reported URL changed: `javascript.feature` now expects `URL: http://cli:8888/...`, and `accessibility.feature` keeps one page URL absolute, matching `AccessibilityTrait::accessibilityFormatUrl()`'s deliberate behavior of not rewriting a cross-origin URL.
- Removed the test-only step `I am on the phpserver test page` from `tests/behat/bootstrap/FeatureContextTrait.php`; its 28 call sites now visit `http://cli:8888/elements_relative.html` explicitly, so every fixture visit reads the same way.
- Removed stale "copy this file into build/web/sites/default/files" comments from `elements_css.html` and `elements_relative.html`.
- Updated the documented example in `src/FileDownloadTrait.php` (the only `src/` change) from `/sites/default/files/document.pdf` to `/files/document.pdf`, and regenerated `STEPS.md` to match.
- Added a "Static fixtures" section to `CONTRIBUTING.md` and rewrote the fixture rule in `CLAUDE.md` to describe both serving paths.
- Left `drupal_big_pipe.feature` (a Drupal trait) on `/sites/default/files/`, so `scripts/provision.sh` and `ahoy copy-files` still copy fixtures into the Drupal docroot.

## Before / After

```
Before: non-Drupal trait test reaching its fixture

┌────────────────────────────────┐
│         Behat scenario         │
└────────────────────────────────┘
                 │  GET /sites/default/files/elements.html
                 ▼
┌────────────────────────────────┐
│          Drupal nginx          │
└────────────────────────────────┘
                 │  (fixture site; must be built & provisioned)
                 ▼
┌────────────────────────────────┐
│ build/web/sites/default/files/ │
└────────────────────────────────┘
  (a provisioned copy of tests/behat/fixtures/)

After: non-Drupal trait test reaching its fixture

┌────────────────────────────────┐
│         Behat scenario         │
└────────────────────────────────┘
                 │  GET http://cli:8888/elements.html
                 ▼
┌────────────────────────────────┐
│      PHP built-in server       │
└────────────────────────────────┘
                 │  (drevops/behat-phpserver, started by @phpserver)
                 ▼
┌────────────────────────────────┐
│     tests/behat/fixtures/      │
└────────────────────────────────┘
  (served directly, no Drupal build required)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Migrates non-Drupal feature tests to serve static fixtures from `http://cli:8888/<file>`.
- Adds `@phpserver` tags, including for nested scenarios that run in child Behat processes.
- Updates fixture markup, URL assertions, documentation, and generated `STEPS.md`.
- Sets test cookies on the page origin.
- Removes the test-only PHP server navigation step.
- Keeps Drupal-specific fixtures unchanged.
- Reports 1048 of 1052 scenarios passing locally. The remaining failures are pre-existing and unrelated.

## Critical

- No step-definition rule violations were identified in the provided changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->