### PR TITLE
Stopped Renovate pinning a digest on the templated CLI base image.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
     "branchPrefix": "deps/",
     "packageRules": [
         {
+            "description": "The image name in this file is assembled from a build argument, so a pinned digest would only ever resolve for one of the PHP versions in the test matrix.",
+            "matchFileNames": [".docker/cli.dockerfile"],
+            "pinDigests": false
+        },
+        {
             "matchDepNames": ["php"],
             "matchManagers": ["composer"],
             "enabled": false


### PR DESCRIPTION
## Summary

Renovate's `pinDigests: true` setting was pinning a manifest digest onto the templated `FROM` line in `.docker/cli.dockerfile`, which builds the CLI image from a `PHP_VERSION` build argument to produce three different images (8.2, 8.3, 8.4) for the CI test matrix. Renovate resolved the digest against only the `ARG` default (8.3), so the PHP 8.2 and PHP 8.4 matrix jobs tried to pull that same 8.3 digest from their own image repositories, where it does not exist, and failed the "Build stack" step. This adds a `packageRules` entry that disables digest pinning specifically for `.docker/cli.dockerfile`, while leaving digest pinning enabled everywhere else (GitHub Actions and the non-templated images in `docker-compose.yml`). The tag itself stays version-pinned and Renovate-managed.

## Changes

- Added a `packageRules` entry to `renovate.json` matching `.docker/cli.dockerfile` via `matchFileNames` and setting `pinDigests: false` for that file, with a `description` explaining why the templated image name cannot carry a single pinned digest.

## Before / After

```
Before (pinDigests: true applied to the templated Dockerfile):

  .docker/cli.dockerfile
  ARG PHP_VERSION=8.3
  FROM uselagoon/php-${PHP_VERSION}-cli-drupal:26.8.0@sha256:dedcb03e...   <- digest for the 8.3 variant only

  CI matrix build:
    PHP_VERSION=8.2  ->  uselagoon/php-8.2-cli-drupal:26.8.0@sha256:dedcb03e...  -> NOT FOUND -> FAIL
    PHP_VERSION=8.3  ->  uselagoon/php-8.3-cli-drupal:26.8.0@sha256:dedcb03e...  -> matches    -> PASS
    PHP_VERSION=8.4  ->  uselagoon/php-8.4-cli-drupal:26.8.0@sha256:dedcb03e...  -> NOT FOUND -> FAIL

After (pinDigests: false scoped to .docker/cli.dockerfile):

  .docker/cli.dockerfile
  ARG PHP_VERSION=8.3
  FROM uselagoon/php-${PHP_VERSION}-cli-drupal:26.8.0                     <- no digest, tag stays Renovate-managed

  CI matrix build:
    PHP_VERSION=8.2  ->  uselagoon/php-8.2-cli-drupal:26.8.0  -> resolves per-repository -> PASS
    PHP_VERSION=8.3  ->  uselagoon/php-8.3-cli-drupal:26.8.0  -> resolves per-repository -> PASS
    PHP_VERSION=8.4  ->  uselagoon/php-8.4-cli-drupal:26.8.0  -> resolves per-repository -> PASS

  Digest pinning is unaffected everywhere else (GitHub Actions, docker-compose.yml images).
```
