### PR TITLE
Deleted comments restating code and added a security policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ from the community.
 
 [//]: # (END)
 
-## Installation
+## 📦 Installation
 
 ```bash
 composer require --dev drevops/behat-steps:^3
@@ -122,7 +122,7 @@ To keep installs lean, packages needed by only some traits are declared as `sugg
 - **`JsonTrait`** needs `softcreatr/jsonpath` for JSON path steps and `justinrainbow/json-schema` for JSON schema steps.
 - **`@javascript` scenarios** need a Mink driver - see [JavaScript drivers](#javascript-drivers) below.
 
-## Usage
+## 🚀 Usage
 
 Add required traits to your
 `FeatureContext.php` ([example](tests/behat/bootstrap/FeatureContext.php)):
@@ -220,7 +220,7 @@ To keep only entities of a **named type**, add
 `@behat-steps-entity-cleanup-skip:ENTITY_TYPE_ID` (for example
 `@behat-steps-entity-cleanup-skip:media`). Repeat the tag to keep several types.
 
-## Writing tests with AI assistants
+## 🤖 Writing tests with AI assistants
 
 Copy and paste below into your project's `CLAUDE.md` or `AGENTS.md` file.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released for the `3.x` series only. Earlier series are available on the `1.x` and `2.x` branches but receive no security updates, so upgrade to `3.x` to stay supported. [MIGRATION.md](MIGRATION.md) documents the step changes between `2.x` and `3.x`.
+
+| Version | Supported |
+| --- | --- |
+| 3.x | Yes |
+| 2.x | No |
+| 1.x | No |
+
+## Reporting a vulnerability
+
+Report vulnerabilities privately. Do not open a public issue, because an issue discloses the problem before a fix is available.
+
+Use either channel:
+
+- [Report a vulnerability](https://github.com/drevops/behat-steps/security/advisories/new) through GitHub Security Advisories.
+- Email the maintainer at alex@drevops.com.
+
+Include the affected version, the steps or configuration needed to reproduce the problem, and the impact you expect. A minimal Behat scenario that demonstrates the issue is the most useful reproduction.
+
+You will receive an acknowledgement of the report. If the report is accepted, the fix and the advisory are published together, and the release notes credit the reporter unless anonymity is requested. If the report is declined, you will be told why.
+
+## Scope
+
+This package is a test-only library: consumers install it under `require-dev` and run it against their own test environments, never in production. Reports are most relevant where a step definition could expose data outside the test environment, execute unintended commands on the machine running the suite, or write outside the paths a test controls.
+
+Findings in the fixture Drupal site under `build/`, in the test suite, or in development dependencies are not vulnerabilities in this library. Report those as ordinary issues.

--- a/src/CookieTrait.php
+++ b/src/CookieTrait.php
@@ -180,6 +180,7 @@ trait CookieTrait {
           if ($is_partial_name) {
             throw new ExpectationException(sprintf('The cookie with name containing "%s" was set with value "%s", but it should contain "%s".', $name, $cookie['value'], $value), $this->getSession()->getDriver());
           }
+
           throw new ExpectationException(sprintf('The cookie with name "%s" was set with value "%s", but it should contain "%s".', $name, $cookie['value'], $value), $this->getSession()->getDriver());
         }
       }
@@ -187,6 +188,7 @@ trait CookieTrait {
         if ($is_partial_name) {
           throw new ExpectationException(sprintf('The cookie with name containing "%s" was set with value "%s", but it should be "%s".', $name, $cookie['value'], $value), $this->getSession()->getDriver());
         }
+
         throw new ExpectationException(sprintf('The cookie with name "%s" was set with value "%s", but it should be "%s".', $name, $cookie['value'], $value), $this->getSession()->getDriver());
       }
     }
@@ -208,6 +210,7 @@ trait CookieTrait {
           if ($is_partial_name) {
             throw new ExpectationException(sprintf('The cookie with name containing "%s" was set with value containing "%s", but it should not contain "%s".', $name, $cookie['value'], $value), $this->getSession()->getDriver());
           }
+
           throw new ExpectationException(sprintf('The cookie with name "%s" was set with value containing "%s", but it should not contain "%s".', $name, $cookie['value'], $value), $this->getSession()->getDriver());
         }
       }
@@ -215,6 +218,7 @@ trait CookieTrait {
         if ($is_partial_name) {
           throw new ExpectationException(sprintf('The cookie with name containing "%s" was set with value "%s", but it should not be "%s".', $name, $cookie['value'], $value), $this->getSession()->getDriver());
         }
+
         throw new ExpectationException(sprintf('The cookie with name "%s" was set with value "%s", but it should not be "%s".', $name, $cookie['value'], $value), $this->getSession()->getDriver());
       }
     }
@@ -222,6 +226,7 @@ trait CookieTrait {
       if ($is_partial_name) {
         throw new ExpectationException(sprintf('The cookie with name containing "%s" was set but it should not be.', $name), $this->getSession()->getDriver());
       }
+
       throw new ExpectationException(sprintf('The cookie with name "%s" was set but it should not be.', $name), $this->getSession()->getDriver());
     }
   }

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -406,12 +406,10 @@ trait FieldTrait {
    * inside any associated label.
    */
   protected function fieldIsMarkedRequired(NodeElement $field_element): bool {
-    // Native required attribute.
     if ($field_element->hasAttribute('required')) {
       return TRUE;
     }
 
-    // `form-required` class on the element itself.
     $classes = (string) $field_element->getAttribute('class');
     if (str_contains($classes, 'form-required')) {
       return TRUE;
@@ -419,14 +417,12 @@ trait FieldTrait {
 
     $page = $this->getSession()->getPage();
 
-    // Find the label associated with the field by id.
     $field_id = $field_element->getAttribute('id');
     $label = NULL;
     if ($field_id !== NULL && $field_id !== '') {
       $label = $page->find('xpath', sprintf('//label[@for=%s]', $this->fieldXpathLiteral($field_id)));
     }
 
-    // Fall back to the nearest ancestor label.
     if ($label === NULL) {
       $label = $field_element->find('xpath', 'ancestor::label[1]');
     }
@@ -439,7 +435,6 @@ trait FieldTrait {
       if (str_contains($label->getText(), '*')) {
         return TRUE;
       }
-      // Check for a nested element with the form-required class.
       if ($label->find('css', '.form-required') !== NULL) {
         return TRUE;
       }
@@ -536,7 +531,6 @@ JS;
       throw new ElementNotFoundException($this->getSession()->getDriver(), 'form field', 'id|name|label|value|placeholder', $field);
     }
 
-    // For non-JS drivers process field in a standard way.
     if (!$this->helperIsJavascriptSupported()) {
       $element->setValue($value);
       return;
@@ -704,10 +698,8 @@ JS;
       throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
     }
 
-    // Check if it's a multi-select field.
     $is_multiple = $select_field->hasAttribute('multiple');
 
-    // Find the option element to get its value.
     $option_element = $select_field->find('named', ['option', $option]);
     if (!$option_element) {
       throw new ExpectationException(sprintf('The option "%s" was not found in the select "%s".', $option, $selector), $this->getSession()->getDriver());
@@ -723,26 +715,21 @@ JS;
     $option_value = (string) $option_value;
 
     if ($is_multiple) {
-      // For multi-select, remove the specific option from current selections.
       $current_values = $select_field->getValue();
 
-      // Ensure we have an array.
       // @codeCoverageIgnoreStart
       if (!is_array($current_values)) {
         $current_values = $current_values ? [$current_values] : [];
       }
       // @codeCoverageIgnoreEnd
-      // Remove the option value from current selections and filter out non-string values.
       $new_values = array_values(array_filter(
         array_diff($current_values, [$option_value]),
         is_string(...)
       ));
 
-      // Set the new values.
       $select_field->setValue($new_values);
     }
     else {
-      // For single select, just clear it by setting empty string.
       $select_field->setValue('');
     }
   }
@@ -769,15 +756,12 @@ JS;
       throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
     }
 
-    // Check if it's a multi-select field.
     $is_multiple = $select_field->hasAttribute('multiple');
 
     if ($is_multiple) {
-      // For multi-select, set to empty array.
       $select_field->setValue([]);
     }
     else {
-      // For single select, set to empty string.
       $select_field->setValue('');
     }
   }
@@ -935,12 +919,10 @@ JS;
    */
   #[Given('browser validation for the form :selector is disabled')]
   public function fieldDisableFormBrowserValidation(string $selector): void {
-    // Add selector to registry for deferred execution.
     if (!in_array($selector, $this->fieldFormValidationRegistry, TRUE)) {
       $this->fieldFormValidationRegistry[] = $selector;
     }
 
-    // Try to apply immediately if we're already on a page with JS support.
     if ($this->helperIsJavascriptSupported()) {
       $this->fieldDisableFormValidation($selector);
     }
@@ -1066,7 +1048,6 @@ JS;
    *   If the datetime field part cannot be located.
    */
   protected function fieldFillDatetimeHelper(string $label, string $part, string $field, string $value): void {
-    // Try to find by label element first.
     $xpath = sprintf(
       '//label[contains(text(), "%s")]/..//input[contains(@name, "[%s][%s]")]',
       $label,
@@ -1088,7 +1069,6 @@ JS;
       $element = $page->find('xpath', $xpath);
     }
 
-    // If still not found, try a more generic approach.
     if ($element === NULL) {
       $xpath = sprintf(
         '//*[contains(text(), "%s")]/ancestor::div[contains(@class, "field--")]//input[contains(@name, "[%s][%s]")]',

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -724,7 +724,6 @@ JS;
         $current_values = $current_values ? [$current_values] : [];
       }
       // @codeCoverageIgnoreEnd
-
       $new_values = array_values(array_filter(
         array_diff($current_values, [$option_value]),
         is_string(...)

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -432,9 +432,11 @@ trait FieldTrait {
       if (str_contains($label_classes, 'form-required')) {
         return TRUE;
       }
+
       if (str_contains($label->getText(), '*')) {
         return TRUE;
       }
+
       if ($label->find('css', '.form-required') !== NULL) {
         return TRUE;
       }
@@ -722,6 +724,7 @@ JS;
         $current_values = $current_values ? [$current_values] : [];
       }
       // @codeCoverageIgnoreEnd
+
       $new_values = array_values(array_filter(
         array_diff($current_values, [$option_value]),
         is_string(...)

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -301,7 +301,6 @@ JS;
       $errors = $this->getSession()->evaluateScript('return typeof window.jsErrors !== "undefined" ? window.jsErrors : [];');
 
       if (!empty($errors)) {
-        // Store errors in registry under this URL.
         if (!isset($this->javascriptErrorRegistry[$url])) {
           $this->javascriptErrorRegistry[$url] = [];
         }
@@ -310,7 +309,6 @@ JS;
           $this->javascriptErrorRegistry[$url][] = $error;
         }
 
-        // Clear errors from browser.
         $this->getSession()->executeScript('window.jsErrors = [];');
       }
     }

--- a/src/JsonTrait.php
+++ b/src/JsonTrait.php
@@ -617,6 +617,7 @@ trait JsonTrait {
       foreach ($validator->getErrors() as $error) {
         $messages[] = sprintf('[%s] %s', $error['property'], $error['message']);
       }
+
       throw new ExpectationException(sprintf('The response does not match the JSON schema: %s.', implode('; ', $messages)), $this->getSession()->getDriver());
     }
   }

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -314,6 +314,7 @@ trait ResponsiveTrait {
       if ($name) {
         throw new \RuntimeException(sprintf("Invalid breakpoint format for '%s': '%s'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)", $name, $dimensions));
       }
+
       throw new \RuntimeException(sprintf("Invalid breakpoint format: '%s'. Expected format: WIDTHxHEIGHT (e.g., 1920x1080)", $dimensions));
     }
 


### PR DESCRIPTION
## Summary

This is a documentation and code-hygiene polish pass with no behavioural changes. It removes 22 inline comments that only restate the line of code beneath them, adds a blank line before 7 fallback `throw` statements to match the spacing convention already dominant in the codebase, and adds `SECURITY.md` so the repository has a documented vulnerability-reporting process. The README also gains an emoji on three action-oriented headings for scannability. PHP token streams (ignoring comments and whitespace) for all five changed source files are identical to `main`, and `ahoy lint`, `ahoy test-unit` (395 tests, 682 assertions) and `ahoy lint-docs` all pass, with `STEPS.md` unchanged.

## Changes

- **Comment cleanup** - deleted 22 inline `//` comments that merely restate the code they sit above, 20 in `src/FieldTrait.php` and 2 in `src/JavascriptTrait.php`. Docblocks, `@code` blocks, `@param`/`@return` lines and `@codeCoverageIgnore` annotations were left untouched, since `docs.php` publishes docblocks into `STEPS.md` and Drupal phpcs mandates them.
- **Vertical rhythm** - added a blank line before a fallback `throw` that directly follows a closing brace, at 7 sites: 5 in `src/CookieTrait.php`, 1 in `src/JsonTrait.php`, 1 in `src/ResponsiveTrait.php`. This converges on the form already dominant in the codebase (12 sites vs 7 before this change).
- **`SECURITY.md` added** - documents supported versions (`3.x` only, with `1.x`/`2.x` unsupported), private vulnerability reporting through GitHub Security Advisories or the maintainer email, and a scope note that this is a `require-dev` test-only library.
- **README polish** - added an emoji to three action-oriented headings: `## 📦 Installation`, `## 🚀 Usage`, `## 🤖 Writing tests with AI assistants`. The `## Available steps` heading is deliberately left bare because `docs.php` matches it as a literal string marker, and an emoji there would break the `ahoy lint-docs` CI gate.

## Before / After

```
┌─ src/FieldTrait.php ── fieldClearSelectOption() multi-select branch
│
│ BEFORE
│   if ($is_multiple) {
│     // Remove the option value from current selections and filter
│     // out non-string values.
│     $new_values = array_values(array_filter(
│       array_diff($current_values, [$option_value]),
│       is_string(...)
│     ));
│
│     // Set the new values.
│     $select_field->setValue($new_values);
│   }
│
│ AFTER
│   if ($is_multiple) {
│     $new_values = array_values(array_filter(
│       array_diff($current_values, [$option_value]),
│       is_string(...)
│     ));
│
│     $select_field->setValue($new_values);
│   }
└──────────────────────────────────────────────────────────────────

┌─ src/CookieTrait.php ── fallback throw after a closing brace
│
│ BEFORE
│   if ($is_partial_name) {
│     throw new ExpectationException(...);
│   }
│   throw new ExpectationException(...);
│
│ AFTER
│   if ($is_partial_name) {
│     throw new ExpectationException(...);
│   }
│
│   throw new ExpectationException(...);
└──────────────────────────────────────────────────────────────────

┌─ repository root ── OSS file set
│
│ BEFORE
│   behat-steps/
│   ├── LICENSE
│   ├── README.md
│   ├── CONTRIBUTING.md
│   ├── MIGRATION.md
│   └── STEPS.md
│
│ AFTER
│   behat-steps/
│   ├── LICENSE
│   ├── README.md
│   ├── CONTRIBUTING.md
│   ├── MIGRATION.md
│   ├── SECURITY.md   (new)
│   └── STEPS.md
└──────────────────────────────────────────────────────────────────
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `SECURITY.md` with supported versions and vulnerability-reporting guidance.
- Added emojis to three README headings.
- Removed redundant inline comments from source traits.
- Added spacing before fallback `throw` statements.
- Preserved documentation blocks and the `Available steps` heading required by `docs.php`.
- Confirmed unchanged PHP token streams for five modified source files.

## Validation

- `ahoy lint` passed.
- `ahoy test-unit` passed: 395 tests and 682 assertions.
- `ahoy lint-docs` passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->