### PR TITLE
Documented the GitHub account requirement for vulnerability reporting.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,8 +16,8 @@ Report vulnerabilities privately. Do not open a public issue, because an issue d
 
 Use either channel:
 
-- [Report a vulnerability](https://github.com/drevops/behat-steps/security/advisories/new) through GitHub Security Advisories.
-- Email the maintainer at alex@drevops.com.
+- [Report a vulnerability](https://github.com/drevops/behat-steps/security/advisories/new) through GitHub Security Advisories. This requires a signed-in GitHub account, because the link redirects to sign-in otherwise.
+- Email the maintainer at alex@drevops.com. Use this channel if you do not have a GitHub account or prefer not to use one.
 
 Include the affected version, the steps or configuration needed to reproduce the problem, and the impact you expect. A minimal Behat scenario that demonstrates the issue is the most useful reproduction.
 


### PR DESCRIPTION
## Summary

`SECURITY.md` lists two channels for reporting a vulnerability: GitHub Security Advisories and the maintainer email. The GitHub Advisories link redirects to a sign-in page for anyone who is not already authenticated, which was not previously called out, so a reporter without a GitHub account could hit the link and be left unsure how to proceed. This change makes that requirement explicit and points reporters without a GitHub account to the email channel instead.

## Changes

- Documented that the GitHub Security Advisories link requires a signed-in GitHub account.
- Documented that the maintainer email is the channel to use for reporters without a GitHub account or who prefer not to use one.

## Before / After

```
┌ Before ────────────────────────────────────────────────────────────
│ - Report a vulnerability through GitHub Security Advisories.
│ - Email the maintainer at alex@drevops.com.
└────────────────────────────────────────────────────────────────────

┌ After ─────────────────────────────────────────────────────────────
│ - Report a vulnerability through GitHub Security Advisories.
│   Requires a signed-in GitHub account, because the link
│   redirects to sign-in otherwise.
│ - Email the maintainer at alex@drevops.com. Use this channel
│   if you do not have a GitHub account or prefer not to use one.
└────────────────────────────────────────────────────────────────────
```
