### PR TITLE
[#756] Made accessibility console summary opt-in via 'BEHAT_ACCESSIBILITY_PRINT'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -91,6 +91,11 @@
 >  file is written per run, so a run never overwrites a previous one. The
 >  aggregate accumulates in process-global state, so under parallel Behat each
 >  process writes its own report.
+>  <br/><br/>
+>  Console output. A one-line per-page summary can be printed to the console
+>  as pages are assessed. Printing is off by default; set the
+>  `BEHAT_ACCESSIBILITY_PRINT` environment variable to a non-empty value other
+>  than `0`, or override `accessibilityGetPrintCli()`, to enable it.
 
 
 <details>

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -41,6 +41,11 @@ use Behat\Step\Then;
  * file is written per run, so a run never overwrites a previous one. The
  * aggregate accumulates in process-global state, so under parallel Behat each
  * process writes its own report.
+ *
+ * Console output. A one-line per-page summary can be printed to the console
+ * as pages are assessed. Printing is off by default; set the
+ * `BEHAT_ACCESSIBILITY_PRINT` environment variable to a non-empty value other
+ * than `0`, or override `accessibilityGetPrintCli()`, to enable it.
  */
 trait AccessibilityTrait {
 
@@ -460,6 +465,19 @@ trait AccessibilityTrait {
   }
 
   /**
+   * Return TRUE to print a one-line per-page summary to the console.
+   *
+   * Default: enabled only when the `BEHAT_ACCESSIBILITY_PRINT` environment
+   * variable is set to a non-empty value other than `0`. Override to
+   * hardcode either behaviour.
+   */
+  protected function accessibilityGetPrintCli(): bool {
+    $value = getenv('BEHAT_ACCESSIBILITY_PRINT');
+
+    return !in_array($value, [FALSE, '', '0'], TRUE);
+  }
+
+  /**
    * Return the canonical impact levels in descending severity order.
    *
    * Default: the four `IMPACT_*` constants on this trait. Engines with a
@@ -709,13 +727,15 @@ trait AccessibilityTrait {
     $this->accessibilityResults[] = ['url' => $url, 'rules' => $rules, 'result' => $normalized];
     $this->accessibilityLastCheckedUrl = $url;
 
-    fwrite(STDOUT, sprintf("\n[accessibility] %s: %d violations, %d passes, %d incomplete (rules: %s)\n",
-      $this->accessibilityFormatUrl($url),
-      count($normalized['violations'] ?? []),
-      count($normalized['passes'] ?? []),
-      count($normalized['incomplete'] ?? []),
-      $rules
-    ));
+    if ($this->accessibilityGetPrintCli()) {
+      fwrite(STDOUT, sprintf("\n[accessibility] %s: %d violations, %d passes, %d incomplete (rules: %s)\n",
+        $this->accessibilityFormatUrl($url),
+        count($normalized['violations'] ?? []),
+        count($normalized['passes'] ?? []),
+        count($normalized['incomplete'] ?? []),
+        $rules
+      ));
+    }
 
     return $normalized;
   }

--- a/tests/behat/features/accessibility.feature
+++ b/tests/behat/features/accessibility.feature
@@ -123,3 +123,34 @@ Feature: Check that AccessibilityTrait works
       """
       <system-out>
       """
+
+  @trait:AccessibilityTrait
+  Scenario: Console summary is not printed by default
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I visit "http://cli:8888/accessibility_clean.html"
+      Then the current page should pass accessibility checks
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+    And the output should not contain:
+      """
+      [accessibility]
+      """
+
+  @trait:AccessibilityTrait
+  Scenario: Console summary is printed when the environment variable is set
+    Given some behat configuration
+    And scenario steps tagged with "@javascript @phpserver":
+      """
+      Given I visit "http://cli:8888/accessibility_clean.html"
+      Then the current page should pass accessibility checks
+      """
+    When the "BEHAT_ACCESSIBILITY_PRINT" environment variable is set to "1"
+    And I run "behat --no-colors"
+    Then it should pass
+    And the output should contain:
+      """
+      [accessibility] http://cli:8888/accessibility_clean.html: 0 violations,
+      """


### PR DESCRIPTION
Closes #756

## Summary

`AccessibilityTrait` used to unconditionally `fwrite(STDOUT, ...)` a one-line per-page summary every time a page was assessed, so any consumer's console output was cluttered with `[accessibility] <url>: N violations, ...` lines it never asked for. Console printing is now opt-in: a new protected getter, `accessibilityGetPrintCli()`, guards the `fwrite` call, and its default implementation returns TRUE only when the `BEHAT_ACCESSIBILITY_PRINT` environment variable is set to a non-empty value other than `0`. Consumers can also override the getter to hardcode either behaviour. HTML, JUnit, and aggregate reports are unaffected; only the STDOUT line is gated.

## Changes

- `src/AccessibilityTrait.php`: Added the protected `accessibilityGetPrintCli()` getter, wrapped the existing `fwrite(STDOUT, ...)` summary in a call to it, and extended the trait docblock with a new "Console output" section documenting the opt-in behaviour and the `BEHAT_ACCESSIBILITY_PRINT` environment variable.
- `tests/behat/features/accessibility.feature`: Added two Behat-in-Behat `@trait:AccessibilityTrait` scenarios covering the default-silent path and the `BEHAT_ACCESSIBILITY_PRINT`-enabled path.
- `STEPS.md`: Regenerated from the updated trait docblock so the new "Console output" section is reflected in the published documentation.

## Before / After

```
BEFORE                                    AFTER
──────                                    ─────
Page assessed                             Page assessed
      │                                         │
      ▼                                         ▼
fwrite(STDOUT, ...)                       accessibilityGetPrintCli()
      │                                         │
      ▼                                   ┌─────┴─────┐
"[accessibility] <url>:                   │           │
 N violations, N passes,                FALSE        TRUE
 N incomplete (rules: ...)"          (default:    (BEHAT_ACCESSIBILITY_PRINT
                                     env unset      set to a non-empty,
Printed on every run,                or "0")        non-"0" value)
regardless of consumer need              │           │
                                          ▼           ▼
                                    No STDOUT    fwrite(STDOUT, ...)
                                     output      "[accessibility] <url>:
                                                   N violations, ..."
```
