### PR TITLE
[#760] Expanded fixture paths for file and image fields in subdirectories.

### DIFF
--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -338,10 +338,10 @@ trait ContentTrait {
   /**
    * Expand fixture file paths for file/image fields on nodes.
    *
-   * Rewrites bare fixture filenames (e.g. 'document.pdf') on 'file' and
-   * 'image' field types to absolute paths under the Mink 'files_path'.
-   * drupal-driver's FileHandler can then read and upload them during node
-   * creation.
+   * Rewrites fixture paths (e.g. 'document.pdf', 'images/photo.png') on
+   * 'file' and 'image' field types to absolute paths under the Mink
+   * 'files_path'. drupal-driver's FileHandler can then read and upload them
+   * during node creation.
    *
    * Without this, scenarios with file fields on nodes have to pre-create
    * managed files explicitly via FileTrait.

--- a/src/Drupal/HelperTrait.php
+++ b/src/Drupal/HelperTrait.php
@@ -162,10 +162,11 @@ trait HelperTrait {
   /**
    * Expand fixture file paths for file/image fields on an entity stub.
    *
-   * Rewrites bare fixture filenames (e.g. 'document.pdf') on 'file' and
-   * 'image' field types to absolute paths under the Mink 'files_path' so
-   * drupal-driver's FileHandler can read and upload them during entity
-   * creation. Skips expansion when a managed file with the same basename
+   * Rewrites fixture paths on 'file' and 'image' field types to absolute
+   * paths under the Mink 'files_path' so drupal-driver's FileHandler can read
+   * and upload them during entity creation. A path is taken relative to the
+   * fixtures directory, so both 'document.pdf' and 'images/photo.png'
+   * resolve. Skips expansion when a managed file with the same basename
    * already exists in public:// or private://, so existing files take
    * precedence.
    *
@@ -235,34 +236,32 @@ trait HelperTrait {
       $mutated = FALSE;
 
       foreach ($records as $index => $record) {
-        $basename = is_array($record) ? $record['target_id'] ?? $record[0] ?? NULL : $record;
+        $path = is_array($record) ? $record['target_id'] ?? $record[0] ?? NULL : $record;
 
-        if (!is_string($basename) || $basename === '') {
+        if (!is_string($path) || $path === '') {
           continue;
         }
 
-        if (str_contains($basename, '/') || str_contains($basename, '\\') || $basename !== basename($basename)) {
+        if ($this->helperManagedFileExists($path)) {
           continue;
         }
 
-        if ($this->helperManagedFileExists($basename)) {
-          continue;
-        }
+        $resolved = $this->helperResolveFixtureFile($path, $fixture_path);
 
-        if (!is_file($fixture_path . $basename)) {
+        if ($resolved === NULL) {
           continue;
         }
 
         if (is_array($record)) {
           if (array_key_exists('target_id', $record)) {
-            $records[$index]['target_id'] = $fixture_path . $basename;
+            $records[$index]['target_id'] = $resolved;
           }
           else {
-            $records[$index][0] = $fixture_path . $basename;
+            $records[$index][0] = $resolved;
           }
         }
         else {
-          $records[$index] = $fixture_path . $basename;
+          $records[$index] = $resolved;
         }
 
         $mutated = TRUE;
@@ -287,38 +286,65 @@ trait HelperTrait {
   }
 
   /**
-   * Rewrite each 'target_id:"basename"' segment to embed the fixture path.
+   * Rewrite each 'target_id:"path"' segment to embed the fixture path.
    *
-   * Only the 'target_id' key is touched and only when the quoted value is a
-   * pure basename (no separators), is not backed by an existing managed file
-   * and resolves to a real file under the fixtures dir. Other compound
-   * columns (e.g. 'alt', 'description') are left untouched so the parser can
-   * still process them.
+   * Only the 'target_id' key is touched and only when the quoted value is not
+   * backed by an existing managed file and resolves to a real file under the
+   * fixtures dir. Other compound columns (e.g. 'alt', 'description') are left
+   * untouched so the parser can still process them.
    */
   protected function helperExpandCompoundCellFixtures(string $value, string $fixture_path): string {
     $callback = function (array $matches) use ($fixture_path): string {
-      $basename = $matches[2];
+      $path = $matches[2];
 
-      if ($basename === '' || str_contains($basename, '/') || str_contains($basename, '\\')) {
+      if ($this->helperManagedFileExists($path)) {
         return $matches[0];
       }
 
-      if ($basename !== basename($basename)) {
-        return $matches[0];
-      }
+      $resolved = $this->helperResolveFixtureFile($path, $fixture_path);
 
-      if ($this->helperManagedFileExists($basename)) {
-        return $matches[0];
-      }
-
-      if (!is_file($fixture_path . $basename)) {
-        return $matches[0];
-      }
-
-      return $matches[1] . $fixture_path . $basename . $matches[3];
+      return $resolved === NULL ? $matches[0] : $matches[1] . $resolved . $matches[3];
     };
 
     return (string) preg_replace_callback('/(target_id\s*:\s*")([^"\\\\]+)(")/i', $callback, $value);
+  }
+
+  /**
+   * Resolve a field value against the fixtures directory.
+   *
+   * @param string $value
+   *   The raw field value: a path relative to the fixtures directory, a
+   *   stream URI or an absolute filesystem path.
+   * @param string $fixture_path
+   *   The resolved fixtures directory, with a trailing separator.
+   *
+   * @return string|null
+   *   The absolute path to the fixture file, or NULL when the value does not
+   *   resolve to a file inside the fixtures directory.
+   */
+  protected function helperResolveFixtureFile(string $value, string $fixture_path): ?string {
+    // drupal-driver resolves stream URIs and absolute paths itself.
+    if (str_contains($value, '://')) {
+      return NULL;
+    }
+
+    if (str_starts_with($value, '/') || str_starts_with($value, '\\') || preg_match('#^[a-z]:[\\\\/]#i', $value) === 1) {
+      return NULL;
+    }
+
+    if (!is_file($fixture_path . $value)) {
+      return NULL;
+    }
+
+    $resolved = realpath($fixture_path . $value);
+
+    // is_file() also succeeds for a '..' path that lands outside the
+    // fixtures directory.
+    if ($resolved === FALSE || !str_starts_with($resolved, $fixture_path)) {
+      return NULL;
+    }
+
+    return $resolved;
   }
 
   /**

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -392,6 +392,26 @@ Feature: Check that ContentTrait works
     Then I should see "[TEST] Compound fixture image"
 
   @api
+  Scenario: Assert file field on node resolves fixture path in a subdirectory
+    Given the following article content:
+      | title                          | field_file          |
+      | [TEST] Subdirectory file       | subdir/document.pdf |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "article" content edit page with the title "[TEST] Subdirectory file"
+    Then I should see "[TEST] Subdirectory file"
+    And the response should contain ".pdf"
+
+  @api
+  Scenario: Assert file field on node resolves compound fixture path in a subdirectory
+    Given the following article content:
+      | title                            | field_file                                              |
+      | [TEST] Compound subdirectory file | target_id:"subdir/document.pdf", description:"My doc"  |
+    And I am logged in as a user with the "administrator" role
+    When I visit the "article" content edit page with the title "[TEST] Compound subdirectory file"
+    Then I should see "[TEST] Compound subdirectory file"
+    And the response should contain ".pdf"
+
+  @api
   Scenario: Assert "When I set the path alias of the :content_type content with the title :title to :alias" works as expected
     Given the following page content:
       | title                   |

--- a/tests/behat/features/drupal_media.feature
+++ b/tests/behat/features/drupal_media.feature
@@ -44,6 +44,16 @@ Feature: Check that MediaTrait works
     When I edit the media "document" with the name "Test media document"
     Then I should see "Edit Document Test media document"
 
+  @api
+  Scenario: Assert media file field resolves a fixture path in a subdirectory
+    Given the following media "document" exist:
+      | name                      | field_media_document |
+      | Test subdirectory media   | subdir/document.pdf  |
+    And I am logged in as a user with the "administrator" role
+    When I edit the media "document" with the name "Test subdirectory media"
+    Then I should see "Edit Document Test subdirectory media"
+    And the response should contain ".pdf"
+
   @api @javascript
   Scenario: Assert remove media type
     Given I am logged in as a user with the "administrator" role

--- a/tests/phpunit/src/Drupal/HelperTraitTest.php
+++ b/tests/phpunit/src/Drupal/HelperTraitTest.php
@@ -42,12 +42,20 @@ class HelperTraitTest extends UnitTestCase {
   /**
    * Create fixture files with placeholder content in the fixtures directory.
    *
-   * @param array<int, string> $basenames
-   *   Basenames to create under the per-test fixtures directory.
+   * @param array<int, string> $paths
+   *   Paths to create, relative to the per-test fixtures directory. Missing
+   *   parent directories are created.
    */
-  protected function createFixtureFiles(array $basenames): void {
-    foreach ($basenames as $basename) {
-      file_put_contents($this->fixturesPath . $basename, 'fixture content');
+  protected function createFixtureFiles(array $paths): void {
+    foreach ($paths as $path) {
+      $full_path = $this->fixturesPath . $path;
+      $directory = dirname($full_path);
+
+      if (!is_dir($directory)) {
+        mkdir($directory, 0777, TRUE);
+      }
+
+      file_put_contents($full_path, 'fixture content');
     }
   }
 
@@ -171,11 +179,35 @@ class HelperTraitTest extends UnitTestCase {
         ['text.txt'],
         'target_id:"text.txt", description:"My file"',
       ],
-      'leaves target_id unchanged when value contains a separator' => [
+      'rewrites target_id for a fixture in a subdirectory' => [
         'target_id:"sub/text.txt", description:"My file"',
+        ['sub/text.txt'],
+        [],
+        'target_id:"{FIXTURES}sub/text.txt", description:"My file"',
+      ],
+      'leaves target_id unchanged when the subdirectory fixture is missing' => [
+        'target_id:"sub/missing.txt", description:"My file"',
         [],
         [],
-        'target_id:"sub/text.txt", description:"My file"',
+        'target_id:"sub/missing.txt", description:"My file"',
+      ],
+      'leaves target_id unchanged for a stream wrapper uri' => [
+        'target_id:"public://text.txt", description:"My file"',
+        ['text.txt'],
+        [],
+        'target_id:"public://text.txt", description:"My file"',
+      ],
+      'leaves target_id unchanged for an absolute path' => [
+        'target_id:"/var/www/text.txt", description:"My file"',
+        ['text.txt'],
+        [],
+        'target_id:"/var/www/text.txt", description:"My file"',
+      ],
+      'leaves target_id unchanged when traversal escapes the fixtures directory' => [
+        'target_id:"../outside.txt", description:"My file"',
+        ['../outside.txt'],
+        [],
+        'target_id:"../outside.txt", description:"My file"',
       ],
       'leaves cell unchanged when no target_id key present' => [
         'alt:"description only", description:"No file"',
@@ -286,6 +318,55 @@ class HelperTraitTest extends UnitTestCase {
         ['field_file' => 'file'],
         ['field_file' => 'target_id:"document.pdf", description:"A"'],
         fn(string $f): array => ['field_file' => 'target_id:"' . $f . 'document.pdf", description:"A"'],
+      ],
+      'rewrites a fixture in a subdirectory' => [
+        ['sub/document.pdf'],
+        [],
+        ['field_file' => 'file'],
+        ['field_file' => 'sub/document.pdf'],
+        fn(string $f): array => ['field_file' => $f . 'sub/document.pdf'],
+      ],
+      'rewrites a fixture nested several directories deep' => [
+        ['sub/nested/image.png'],
+        [],
+        ['field_image' => 'image'],
+        ['field_image' => 'sub/nested/image.png'],
+        fn(string $f): array => ['field_image' => $f . 'sub/nested/image.png'],
+      ],
+      'rewrites every entry in a multi-value list of subdirectory fixtures' => [
+        ['sub/document.pdf', 'sub/image.png'],
+        [],
+        ['field_files' => 'file'],
+        ['field_files' => ['sub/document.pdf', 'sub/image.png']],
+        fn(string $f): array => ['field_files' => [$f . 'sub/document.pdf', $f . 'sub/image.png']],
+      ],
+      'leaves missing subdirectory fixture unchanged' => [
+        [],
+        [],
+        ['field_file' => 'file'],
+        ['field_file' => 'sub/missing.pdf'],
+        fn(string $f): array => ['field_file' => 'sub/missing.pdf'],
+      ],
+      'leaves stream wrapper uri unchanged' => [
+        ['document.pdf'],
+        [],
+        ['field_file' => 'file'],
+        ['field_file' => 'public://document.pdf'],
+        fn(string $f): array => ['field_file' => 'public://document.pdf'],
+      ],
+      'leaves absolute path unchanged' => [
+        ['document.pdf'],
+        [],
+        ['field_file' => 'file'],
+        ['field_file' => '/var/www/document.pdf'],
+        fn(string $f): array => ['field_file' => '/var/www/document.pdf'],
+      ],
+      'leaves traversal escaping the fixtures directory unchanged' => [
+        ['../outside.pdf'],
+        [],
+        ['field_file' => 'file'],
+        ['field_file' => '../outside.pdf'],
+        fn(string $f): array => ['field_file' => '../outside.pdf'],
       ],
     ];
   }


### PR DESCRIPTION
Closes #760

## Summary

Fixture file paths for `file` and `image` fields on entity stubs stopped expanding as soon as the value contained a path separator, so a value like `images/500x200.png` was passed straight through to drupal-driver and failed with `file_get_contents(images/500x200.png): Failed to open stream` instead of being rewritten to an absolute path under the Mink `files_path`. Only bare filenames such as `500x200.png` worked. `HelperTrait::helperExpandFixtureFiles()` and `helperExpandCompoundCellFixtures()` now resolve the value relative to the fixtures directory through a new `helperResolveFixtureFile()` method instead of rejecting anything containing a separator. `ContentTrait` is updated to describe the same behaviour for node file/image fields.

## Changes

- `src/Drupal/HelperTrait.php`: replaced the separator-rejection check in `helperExpandFixtureFiles()` and `helperExpandCompoundCellFixtures()` with a call to the new `helperResolveFixtureFile()`, which treats the value as relative to the fixtures directory, leaves stream URIs (`public://...`) and absolute paths for drupal-driver to resolve, and confirms the resolved realpath stays inside the fixtures directory so a `../` value cannot escape it.
- `src/Drupal/ContentTrait.php`: updated the docblock on the node file/image expansion method to describe subdirectory paths alongside bare filenames.
- `tests/phpunit/src/Drupal/HelperTraitTest.php`: extended `createFixtureFiles()` to create parent directories as needed, and added cases covering a subdirectory fixture, a nested multi-level fixture, a multi-value list of subdirectory fixtures, a missing subdirectory fixture, a stream URI, an absolute path, and a `../` traversal attempt.
- `tests/behat/features/drupal_content.feature` and `tests/behat/features/drupal_media.feature`: added scenarios that create a node and a media entity with a `file`/`image` field value pointing at a fixture in a subdirectory.

## Before / After

```
Before:
  field_file: "images/500x200.png"
        │
        ▼
  contains "/" ──► rejected, value passed through unchanged
        │
        ▼
  drupal-driver: file_get_contents(images/500x200.png)
        │
        ▼
  Failed to open stream (fixture never resolved)

After:
  field_file: "images/500x200.png"
        │
        ▼
  helperResolveFixtureFile(value, fixture_path)
        │
        ├─ contains "://"            ──► NULL (left for drupal-driver)
        ├─ starts with "/", "\", "C:\" ──► NULL (left for drupal-driver)
        ├─ not a file under fixture_path ──► NULL (left unchanged)
        ├─ realpath escapes fixture_path ──► NULL (left unchanged)
        └─ otherwise                  ──► absolute path under files_path
        │
        ▼
  drupal-driver reads the resolved absolute path and uploads it
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restore nested fixture path support for `file` and `image` fields.
- Resolve valid relative paths under Mink’s fixtures directory.
- Preserve stream URIs and absolute paths.
- Reject missing files and paths that escape the fixtures directory.
- Apply the resolver to regular field values and compound `target_id` values.
- Update documentation, PHPUnit tests, and Behat scenarios for nested, multiple, missing, absolute, stream, and traversal paths.

## Critical

- Step-definition compliance could not be assessed because `CONTRIBUTING.md` content was not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->