### PR TITLE
[#774] Documented the supported version matrix and the v3 LTS window.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ guidelines](CONTRIBUTING.md#steps-format) to keep the step language consistent.
 We actively maintain this package and welcome [contributions](CONTRIBUTING.md)
 from the community.
 
+## Supported versions
+
+| Version | Behat | Drupal | PHP | Support |
+| --- | --- | --- | --- | --- |
+| 4.x | 3.32+, 4 | 11 | 8.3, 8.4, 8.5 | Active development |
+| 3.x | 3 | 10, 11 | 8.2, 8.3, 8.4, 8.5 | The current minor is LTS until 1 July 2027 and receives bugfixes and security updates only. |
+| 2.x | 3 | 9, 10 | 8.2+ | Unsupported |
+
+See [MIGRATION.md](MIGRATION.md) for migration guides.
+
 ## Available steps
 
 ### Index of Generic steps


### PR DESCRIPTION
Part of #774

## Summary

Added a "Supported versions" table to `README.md` documenting the version support matrix for this package. The `4.x` line requires Behat `3.32+` or `4`, Drupal `11`, and PHP `8.3-8.5`, and is under active development. The `3.x` line supports Behat `3`, Drupal `10` and `11`, and PHP `8.2-8.5`, with its current minor designated LTS until 1 July 2027, receiving bugfixes and security updates only. The `2.x` line is marked unsupported. The table links to `MIGRATION.md` for migration guidance between versions.

## Changes

- `README.md`: Added a "Supported versions" section with a table of Behat, Drupal, and PHP compatibility plus support status for the `4.x`, `3.x`, and `2.x` lines, and a link to `MIGRATION.md`.

## Before / After

```
BEFORE                                     AFTER
┌─────────────────────────────┐           ┌─────────────────────────────┐
│ README.md                   │           │ README.md                   │
├─────────────────────────────┤           ├─────────────────────────────┤
│ ...                         │           │ ...                         │
│ We actively maintain this   │           │ We actively maintain this   │
│ package and welcome         │           │ package and welcome         │
│ contributions.              │           │ contributions.              │
│                             │           │                             │
│                             │           │ ## Supported versions       │
│                             │           │ | Version | Behat | Drupal  │
│                             │           │ | 4.x | 3.32+, 4 | 11 | ... │
│                             │           │ | 3.x | 3 | 10, 11 | ...    │
│                             │           │ | 2.x | 3 | 9, 10 | ...     │
│                             │           │ See MIGRATION.md            │
│                             │           │                             │
│ ## Available steps          │           │ ## Available steps          │
│ ...                         │           │ ...                         │
└─────────────────────────────┘           └─────────────────────────────┘
  No version or support info                Explicit support matrix with
  in the README                             LTS window and migration link
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Added a **Supported versions** section to `README.md`.

- Documents compatibility for `4.x`, `3.x`, and `2.x`.
- Defines support status for each package version.
- Links to `MIGRATION.md` for migration guidance.

No step definition rule violations were found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->