### PR TITLE
[#712] Unified Gherkin placeholder names, articles and Given verbs across steps.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,34 @@ ahoy copy-files
   - Omit unnecessary suffixes like `on the page`
   - Method names should begin with the trait name: `userAssertHasRoles()`
 
+- **Placeholder Names**: one concept gets one name across every trait. Reusing a
+  name that already exists is always preferred over inventing a synonym.
+  - Placeholder names are `snake_case` and match the method parameter name
+    exactly - Behat binds the argument by name, so a mismatch only surfaces at
+    run time
+  - A step that names its target (`:element`, `:path`, `:key`, `:field`)
+    compares against `:value`; `:text` is only for steps asserting on a whole
+    body with no named target, such as `the modal should contain :text`
+  - A bundle placeholder is named after its entity type - `:content_type`,
+    `:media_type`, `:content_block_type`, `:vocabulary` - unless the step is
+    deliberately entity-agnostic, where `:bundle` is correct
+  - A partial match reads `:partial_<thing>`, as in `:partial_name`
+
+- **Articles and Word Order**:
+  - Every noun takes an article, and `URL` is uppercase
+  - A named value reads `the value :value`, never `the :value value` or a bare
+    `:value`
+  - A bundle placeholder qualifying an entity noun comes before it
+    (`the :media_type media`); one that is itself the subject follows its noun
+    (`the media type :media_type`)
+
 - **Given Steps**:
   - Define test prerequisites
-  - Use words like `exists` or `have`
+  - State a fact in the present tense: `<subject> <verb> <complement>`. A
+    verbless step, a bare noun phrase, or the perfect tense (`has been cleared`)
+    is not a Given
+  - Use words like `exists` or `have`; `is`/`are` plus an adjective is also
+    correct where it mirrors the matching `should be ...` assertion
   - Avoid using `should` or `should not`
   - Avoid using `Given I`
 
@@ -89,7 +114,7 @@ ahoy copy-files
 - Email testing:
   - `I enable the test email system`
   - `I clear the test email system queue`
-  - `an email should be sent to the "..."`
+  - `an email should be sent to the address "..."`
 
 ## Skipping Before Scenario Hooks
 Some traits provide `beforeScenario` hook implementations that can be disabled by adding `behat-steps-skip:METHOD_NAME` tag to your test.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,213 @@
 # Migration guide
 
+## Unified step text
+
+Placeholder names, articles and `Given` verbs drifted as traits were added, so the same idea ended up written several different ways: an XML attribute was `:attribute` in 4 steps and `:attribute_name` in 2, a taxonomy vocabulary answered to 3 different names, and a handful of `Given` steps had no verb at all. 73 steps now follow one set of conventions.
+
+- A step that names its target (`:element`, `:path`, `:key`, `:field`) compares against `:value`. `:text` is now reserved for steps that assert on a whole body with no named target, such as `the modal should contain :text`.
+- A bundle placeholder is named after its entity type - `:content_type`, `:media_type`, `:content_block_type`, `:vocabulary`. Steps that are deliberately entity-agnostic keep `:bundle` (`EckTrait`, and the parent lookup in `ParagraphsTrait`).
+- A bundle placeholder that qualifies an entity noun comes before it, as in `the :media_type media`. One that is itself the subject follows its noun, as in `the media type :media_type`.
+- Every noun takes an article, `URL` is uppercase, and a named value reads `the value :value` rather than `the :value value`.
+- Placeholder names are `snake_case`.
+- A `Given` states a fact in the present tense. Verbless steps gained `exist`, bare noun phrases gained a verb, and the `has been cleared` family became `is empty`. Steps that already read `is empty`, `is enabled` or `is disabled` were left alone: they mirror the `should be ...` assertion they pair with, and forcing them into an `exists` form would say something different.
+
+Placeholder names are part of the contract even when the surrounding words are identical. Behat binds a step argument to the method parameter of the same name, so a rename reaches any context that overrides the step method or calls it directly.
+
+Three steps were relying on Behat's positional fallback because their parameter never matched their placeholder. Their step text is unchanged, but the method signatures are not: `MediaTrait::mediaRemoveType()` now takes `$media_type`, and `SearchApiTrait::searchApiIndexContent()` and `searchApiDoIndex()` now take `$content_type` and `$count`.
+
+### CacheTrait
+
+| Before | After |
+| --- | --- |
+| `Given the page cache for the path :path has been cleared` | `Given the page cache for the path :path is empty` |
+| `Given the page cache for the paths matching :path_pattern has been cleared` | `Given the page cache for the paths matching :path_pattern is empty` |
+| `Given the render cache has been cleared` | `Given the render cache is empty` |
+
+### ConfigTrait
+
+| Before | After |
+| --- | --- |
+| `Given the following config values:` | `Given the following config values exist:` |
+
+### ContentBlockTrait
+
+| Before | After |
+| --- | --- |
+| `When I edit the :type content block with the description :description` | `When I edit the :content_block_type content block with the description :description` |
+| `Then the content block type :type should exist` | `Then the content block type :content_block_type should exist` |
+| `Given the following :type content blocks do not exist:` | `Given the following :content_block_type content blocks do not exist:` |
+| `Given the following :type content blocks exist:` | `Given the following :content_block_type content blocks exist:` |
+| `Given the following :type content blocks with fields:` | `Given the following :content_block_type content blocks with fields exist:` |
+
+### ContentTrait
+
+| Before | After |
+| --- | --- |
+| `Given the following :type content with fields:` | `Given the following :content_type content with fields exist:` |
+
+### DraggableviewsTrait
+
+| Before | After |
+| --- | --- |
+| `When I save the draggable views items of the view :view_id and the display :view_display_id for the :bundle content in the following order:` | `When I save the draggable views items of the view :view_id and the display :view_display_id for the :content_type content in the following order:` |
+
+### EmailTrait
+
+| Before | After |
+| --- | --- |
+| `Then an email should be sent to the :address` | `Then an email should be sent to the address :address` |
+| `Then no emails should have been sent to the :address` | `Then no emails should have been sent to the address :address` |
+
+### FieldTrait
+
+| Before | After |
+| --- | --- |
+| `When I fill in the WYSIWYG field :field with the :value` | `When I fill in the WYSIWYG field :field with the value :value` |
+| `When I fill in the field :selector with :value` | `When I fill in the field :selector with the value :value` |
+| `Given browser validation for the form :selector is disabled` | `Given the browser validation for the form :selector is disabled` |
+| `Then the field :name should exist` | `Then the field :field should exist` |
+| `Then the field :name should have :enabled_or_disabled state` | `Then the field :field should have the :enabled_or_disabled state` |
+| `Then the field :name should not exist` | `Then the field :field should not exist` |
+
+### FileDownloadTrait
+
+| Before | After |
+| --- | --- |
+| `Then the downloaded file name should contain :file_name_part` | `Then the downloaded file name should contain :partial_name` |
+
+### FileTrait
+
+| Before | After |
+| --- | --- |
+| `Given the following managed files:` | `Given the following managed files exist:` |
+| `Given the unmanaged file at the URI :uri exists with :content` | `Given the unmanaged file at the URI :uri exists with the content :content` |
+
+### IframeTrait
+
+| Before | After |
+| --- | --- |
+| `When I switch to iframe with locator :locator` | `When I switch to the iframe with the selector :selector` |
+
+### JsonTrait
+
+| Before | After |
+| --- | --- |
+| `Given the response JSON content is the following:` | `Given the response JSON is the following:` |
+| `Given the response JSON from the file :filename` | `Given the response JSON is loaded from the file :filename` |
+
+### MediaTrait
+
+| Before | After |
+| --- | --- |
+| `Given :media_type media type does not exist` | `Given the media type :media_type does not exist` |
+| `When I edit the media :media_type with the name :name` | `When I edit the :media_type media with the name :name` |
+| `When I visit the media :media_type delete page with the name :name` | `When I visit the :media_type media delete page with the name :name` |
+| `When I visit the media :media_type revisions page with the name :name` | `When I visit the :media_type media revisions page with the name :name` |
+| `When I visit the media :media_type with the name :name` | `When I visit the :media_type media with the name :name` |
+| `Then the :media_type media type should exist` | `Then the media type :media_type should exist` |
+| `Then the :media_type media type should not exist` | `Then the media type :media_type should not exist` |
+| `Given the following :bundle media with fields:` | `Given the following :media_type media with fields exist:` |
+| `Given the following media :media_type do not exist:` | `Given the following :media_type media do not exist:` |
+| `Given the following media :media_type exist:` | `Given the following :media_type media exist:` |
+
+### MenuTrait
+
+| Before | After |
+| --- | --- |
+| `Given the following menus:` | `Given the following menus exist:` |
+
+### MetatagTrait
+
+| Before | After |
+| --- | --- |
+| `Then the :metaName meta tag should not contain any HTML tags` | `Then the :meta_name meta tag should not contain any HTML tags` |
+
+### PathTrait
+
+| Before | After |
+| --- | --- |
+| `Then current url should have the :param parameter` | `Then the current URL should have the :param parameter` |
+| `Then current url should have the :param parameter with the :value value` | `Then the current URL should have the :param parameter with the value :value` |
+| `Then current url should not have the :param parameter` | `Then the current URL should not have the :param parameter` |
+| `Then current url should not have the :param parameter with the :value value` | `Then the current URL should not have the :param parameter with the value :value` |
+| `Given the basic authentication with the username :username and the password :password` | `Given the basic authentication has the username :username and the password :password` |
+
+### ResponseTrait
+
+| Before | After |
+| --- | --- |
+| `Then the response header :header_name should contain the value :header_value` | `Then the response header :name should contain the value :value` |
+| `Then the response header :header_name should not contain the value :header_value` | `Then the response header :name should not contain the value :value` |
+| `Then the response should contain the header :header_name` | `Then the response should contain the header :name` |
+| `Then the response should not contain the header :header_name` | `Then the response should not contain the header :name` |
+
+### ResponsiveTrait
+
+| Before | After |
+| --- | --- |
+| `Given the following responsive breakpoints:` | `Given the following responsive breakpoints exist:` |
+
+### RestTrait
+
+| Before | After |
+| --- | --- |
+| `Given a REST header :name with value :value` | `Given the REST header :name has the value :value` |
+
+### StateTrait
+
+| Before | After |
+| --- | --- |
+| `Given the following state values:` | `Given the following state values exist:` |
+
+### TableTrait
+
+| Before | After |
+| --- | --- |
+| `Then the :rowText row should contain the following:` | `Then the :row_text row should contain the following:` |
+
+### TaxonomyTrait
+
+| Before | After |
+| --- | --- |
+| `When I visit the :vocabulary_machine_name term delete page with the name :term_name` | `When I visit the :vocabulary term delete page with the name :term_name` |
+| `When I visit the :vocabulary_machine_name term edit page with the name :term_name` | `When I visit the :vocabulary term edit page with the name :term_name` |
+| `When I visit the :vocabulary_machine_name term page with the name :term_name` | `When I visit the :vocabulary term page with the name :term_name` |
+| `Given the following :vocabulary terms with fields:` | `Given the following :vocabulary terms with fields exist:` |
+| `Given the following :vocabulary_machine_name vocabulary terms do not exist:` | `Given the following :vocabulary terms do not exist:` |
+| `Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should exist` | `Then the taxonomy term :term_name from the vocabulary :vocabulary should exist` |
+| `Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should not exist` | `Then the taxonomy term :term_name from the vocabulary :vocabulary should not exist` |
+| `Then the vocabulary :machine_name should not exist` | `Then the vocabulary :vocabulary should not exist` |
+| `Then the vocabulary :machine_name with the name :name should exist` | `Then the vocabulary :vocabulary with the name :name should exist` |
+
+### UserTrait
+
+| Before | After |
+| --- | --- |
+| `Given the following roles:` | `Given the following roles exist:` |
+| `Given the following users with fields:` | `Given the following users with fields exist:` |
+| `Given the role :role_name with the permissions :permissions` | `Given the role :role_name has the permissions :permissions` |
+
+### WebformTrait
+
+| Before | After |
+| --- | --- |
+| `Given a webform :title from template :template` | `Given the webform :title exists from the template :template` |
+
+### XmlTrait
+
+| Before | After |
+| --- | --- |
+| `Then the XML attribute :attribute on element :element should be equal to :text` | `Then the XML attribute :attribute on element :element should be equal to :value` |
+| `Then the XML attribute :attribute on element :element should not be equal to :text` | `Then the XML attribute :attribute on element :element should not be equal to :value` |
+| `Then the XML attribute :attribute_name on element :element should contain :text` | `Then the XML attribute :attribute on element :element should contain :value` |
+| `Then the XML attribute :attribute_name on element :element should not contain :text` | `Then the XML attribute :attribute on element :element should not contain :value` |
+| `Then the XML element :element should be equal to :text` | `Then the XML element :element should be equal to :value` |
+| `Then the XML element :element should contain :text` | `Then the XML element :element should contain :value` |
+| `Then the XML element :element should not be equal to :text` | `Then the XML element :element should not be equal to :value` |
+| `Then the XML element :element should not contain :text` | `Then the XML element :element should not contain :value` |
+| `Given the response content from the file :filename` | `Given the response XML is loaded from the file :filename` |
+| `Given the response content is the following:` | `Given the response XML is the following:` |
+
 ## Optional dependencies moved to `require-dev` and `suggest`
 
 Trait-specific packages are no longer hard `require` dependencies. They now live in `require-dev` (so this library's own test suite still runs) and `suggest`, matching the existing treatment of `justinrainbow/json-schema`. Projects that relied on transitive installation must add the packages they use to their own `composer.json`.

--- a/STEPS.md
+++ b/STEPS.md
@@ -1140,14 +1140,14 @@ Then the element "#main-nav" should contain 3 elements matching ".menu-item"
 
 
 <details>
-  <summary><code>@Given browser validation for the form :selector is disabled</code></summary>
+  <summary><code>@Given the browser validation for the form :selector is disabled</code></summary>
 
 <br/>
 Disable browser validation for the form for validating errors
 <br/><br/>
 
 ```gherkin
-Given browser validation for the form "#node-article-form" is disabled
+Given the browser validation for the form "#node-article-form" is disabled
 When I go to "node/add/article"
 And I press "Save"
 Then I should see "Title field is required"
@@ -1189,14 +1189,14 @@ When I fill in the color field "#edit-text-color" with the value "#3366FF"
 </details>
 
 <details>
-  <summary><code>@When I fill in the WYSIWYG field :field with the :value</code></summary>
+  <summary><code>@When I fill in the WYSIWYG field :field with the value :value</code></summary>
 
 <br/>
 Set value for WYSIWYG field
 <br/><br/>
 
 ```gherkin
-When I fill in the WYSIWYG field "edit-body-0-value" with the "<p>This is a <strong>formatted</strong> paragraph.</p>"
+When I fill in the WYSIWYG field "edit-body-0-value" with the value "<p>This is a <strong>formatted</strong> paragraph.</p>"
 
 ```
 
@@ -1278,15 +1278,15 @@ When I choose the radio button "edit-field-choice-option-a"
 </details>
 
 <details>
-  <summary><code>@When I fill in the field :selector with :value</code></summary>
+  <summary><code>@When I fill in the field :selector with the value :value</code></summary>
 
 <br/>
 Fill in a field identified by CSS selector
 <br/><br/>
 
 ```gherkin
-When I fill in the field ".field--name-body textarea" with "Hello world"
-When I fill in the field "#edit-field-custom-0-value" with "Test value"
+When I fill in the field ".field--name-body textarea" with the value "Hello world"
+When I fill in the field "#edit-field-custom-0-value" with the value "Test value"
 
 ```
 
@@ -1394,7 +1394,7 @@ Then the field "Name" should not be empty
 </details>
 
 <details>
-  <summary><code>@Then the field :name should exist</code></summary>
+  <summary><code>@Then the field :field should exist</code></summary>
 
 <br/>
 Assert that field exists on the page using id,name,label or value
@@ -1409,7 +1409,7 @@ Then the field "field_body" should exist
 </details>
 
 <details>
-  <summary><code>@Then the field :name should not exist</code></summary>
+  <summary><code>@Then the field :field should not exist</code></summary>
 
 <br/>
 Assert that field does not exist on the page using id,name,label or value
@@ -1424,17 +1424,17 @@ Then the field "field_body" should not exist
 </details>
 
 <details>
-  <summary><code>@Then the field :name should have :enabled_or_disabled state</code></summary>
+  <summary><code>@Then the field :field should have the :enabled_or_disabled state</code></summary>
 
 <br/>
 Assert whether the field has a state
 <br/><br/>
 
 ```gherkin
-Then the field "Body" should have "disabled" state
-Then the field "field_body" should have "disabled" state
-Then the field "Tags" should have "enabled" state
-Then the field "field_tags" should have "not enabled" state
+Then the field "Body" should have the "disabled" state
+Then the field "field_body" should have the "disabled" state
+Then the field "Tags" should have the "enabled" state
+Then the field "field_tags" should have the "not enabled" state
 
 ```
 
@@ -1646,7 +1646,7 @@ Then the downloaded file name should be "report.pdf"
 </details>
 
 <details>
-  <summary><code>@Then the downloaded file name should contain :file_name_part</code></summary>
+  <summary><code>@Then the downloaded file name should contain :partial_name</code></summary>
 
 <br/>
 Assert the downloaded file name contains a specific string
@@ -1720,15 +1720,15 @@ Then the downloaded file should be a zip archive not containing the following fi
 
 
 <details>
-  <summary><code>@When I switch to iframe with locator :locator</code></summary>
+  <summary><code>@When I switch to the iframe with the selector :selector</code></summary>
 
 <br/>
 Switch to an iframe identified by CSS selector
 <br/><br/>
 
 ```gherkin
-When I switch to iframe with locator "iframe.payment-form"
-When I switch to iframe with locator "#recaptcha iframe"
+When I switch to the iframe with the selector "iframe.payment-form"
+When I switch to the iframe with the selector "#recaptcha iframe"
 
 ```
 
@@ -1797,28 +1797,28 @@ When I switch to the root document
 
 
 <details>
-  <summary><code>@Given the response JSON from the file :filename</code></summary>
+  <summary><code>@Given the response JSON is loaded from the file :filename</code></summary>
 
 <br/>
 Set the response JSON content from a fixture file
 <br/><br/>
 
 ```gherkin
-Given the response JSON from the file "json_valid.json"
+Given the response JSON is loaded from the file "json_valid.json"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Given the response JSON content is the following:</code></summary>
+  <summary><code>@Given the response JSON is the following:</code></summary>
 
 <br/>
 Set the response JSON content directly from a PyString
 <br/><br/>
 
 ```gherkin
-Given the response JSON content is the following:
+Given the response JSON is the following:
   """
   {"name": "John Doe", "roles": ["admin", "editor"]}
   """
@@ -1852,7 +1852,7 @@ Assert that a response is valid JSON
 Then the response should be in JSON format
 
 # Content set by a fixture step is validated instead of the page content.
-Given the response JSON from the file "json_valid.json"
+Given the response JSON is loaded from the file "json_valid.json"
 Then the response should be in JSON format
 
 ```
@@ -2328,7 +2328,7 @@ Then the meta tag should not exist with the following attributes:
 </details>
 
 <details>
-  <summary><code>@Then the :metaName meta tag should not contain any HTML tags</code></summary>
+  <summary><code>@Then the :meta_name meta tag should not contain any HTML tags</code></summary>
 
 <br/>
 Assert a meta tag does not contain HTML tags
@@ -2657,14 +2657,14 @@ Then the modal should not contain "Error message"
 
 
 <details>
-  <summary><code>@Given the basic authentication with the username :username and the password :password</code></summary>
+  <summary><code>@Given the basic authentication has the username :username and the password :password</code></summary>
 
 <br/>
 Set basic authentication for the current session
 <br/><br/>
 
 ```gherkin
-Given the basic authentication with the username "myusername" and the password "mypassword"
+Given the basic authentication has the username "myusername" and the password "mypassword"
 
 ```
 
@@ -2717,56 +2717,56 @@ Then the path should not be "<front>"
 </details>
 
 <details>
-  <summary><code>@Then current url should have the :param parameter</code></summary>
+  <summary><code>@Then the current URL should have the :param parameter</code></summary>
 
 <br/>
 Assert that current URL has a query parameter with a non-empty value
 <br/><br/>
 
 ```gherkin
-Then current url should have the "filter" parameter
+Then the current URL should have the "filter" parameter
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Then current url should have the :param parameter with the :value value</code></summary>
+  <summary><code>@Then the current URL should have the :param parameter with the value :value</code></summary>
 
 <br/>
 Assert that current URL has a query parameter with a specific value
 <br/><br/>
 
 ```gherkin
-Then current url should have the "filter" parameter with the "recent" value
+Then the current URL should have the "filter" parameter with the value "recent"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Then current url should not have the :param parameter</code></summary>
+  <summary><code>@Then the current URL should not have the :param parameter</code></summary>
 
 <br/>
 Assert that current URL has no query parameter with a non-empty value
 <br/><br/>
 
 ```gherkin
-Then current url should not have the "filter" parameter
+Then the current URL should not have the "filter" parameter
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Then current url should not have the :param parameter with the :value value</code></summary>
+  <summary><code>@Then the current URL should not have the :param parameter with the value :value</code></summary>
 
 <br/>
 Assert that current URL does not have a query parameter with a value
 <br/><br/>
 
 ```gherkin
-Then current url should not have the "filter" parameter with the "recent" value
+Then the current URL should not have the "filter" parameter with the value "recent"
 
 ```
 
@@ -2781,7 +2781,7 @@ Then current url should not have the "filter" parameter with the "recent" value
 
 
 <details>
-  <summary><code>@Then the response should contain the header :header_name</code></summary>
+  <summary><code>@Then the response should contain the header :name</code></summary>
 
 <br/>
 Assert that a response contains a header with specified name
@@ -2795,7 +2795,7 @@ Then the response should contain the header "Connection"
 </details>
 
 <details>
-  <summary><code>@Then the response should not contain the header :header_name</code></summary>
+  <summary><code>@Then the response should not contain the header :name</code></summary>
 
 <br/>
 Assert that a response does not contain a header with a specified name
@@ -2809,7 +2809,7 @@ Then the response should not contain the header "Connection"
 </details>
 
 <details>
-  <summary><code>@Then the response header :header_name should contain the value :header_value</code></summary>
+  <summary><code>@Then the response header :name should contain the value :value</code></summary>
 
 <br/>
 Assert that a response contains a header with a specified name and value
@@ -2823,7 +2823,7 @@ Then the response header "Connection" should contain the value "Keep-Alive"
 </details>
 
 <details>
-  <summary><code>@Then the response header :header_name should not contain the value :header_value</code></summary>
+  <summary><code>@Then the response header :name should not contain the value :value</code></summary>
 
 <br/>
 Assert a response does not contain a header with a specified name and value
@@ -2883,14 +2883,14 @@ Then the response header "Connection" should not contain the value "Keep-Alive"
 
 
 <details>
-  <summary><code>@Given the following responsive breakpoints:</code></summary>
+  <summary><code>@Given the following responsive breakpoints exist:</code></summary>
 
 <br/>
 Set custom responsive breakpoints from a table
 <br/><br/>
 
 ```gherkin
-Given the following responsive breakpoints:
+Given the following responsive breakpoints exist:
   | name       | dimensions |
   | iphone_12  | 390x844    |
   | 4k_display | 3840x2160  |
@@ -2972,15 +2972,15 @@ When I set the viewport to "375" by "667"
 
 
 <details>
-  <summary><code>@Given a REST header :name with value :value</code></summary>
+  <summary><code>@Given the REST header :name has the value :value</code></summary>
 
 <br/>
 Set a REST header for subsequent requests
 <br/><br/>
 
 ```gherkin
-Given a REST header "Accept" with value "application/json"
-Given a REST header "Authorization" with value "Bearer abc123"
+Given the REST header "Accept" has the value "application/json"
+Given the REST header "Authorization" has the value "Bearer abc123"
 
 ```
 
@@ -3166,7 +3166,7 @@ Then the table ".mytable" should contain the following rows:
 </details>
 
 <details>
-  <summary><code>@Then the :rowText row should contain the following:</code></summary>
+  <summary><code>@Then the :row_text row should contain the following:</code></summary>
 
 <br/>
 Assert that a table row containing a text has the expected values
@@ -3230,28 +3230,28 @@ When I wait for 1 second for AJAX to finish
 
 
 <details>
-  <summary><code>@Given the response content from the file :filename</code></summary>
+  <summary><code>@Given the response XML is loaded from the file :filename</code></summary>
 
 <br/>
 Set the response XML content from a fixture file
 <br/><br/>
 
 ```gherkin
-Given the response content from the file "xml_valid.xml"
+Given the response XML is loaded from the file "xml_valid.xml"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Given the response content is the following:</code></summary>
+  <summary><code>@Given the response XML is the following:</code></summary>
 
 <br/>
 Set the response XML content directly from a PyString
 <br/><br/>
 
 ```gherkin
-Given the response content is the following:
+Given the response XML is the following:
   """
   <?xml version="1.0"?><root><item>value</item></root>
   """
@@ -3285,7 +3285,7 @@ Assert that a response is valid XML
 Then the response should be in XML format
 
 # Content set by a fixture step is validated instead of the page content.
-Given the response content from the file "xml_valid.xml"
+Given the response XML is loaded from the file "xml_valid.xml"
 Then the response should be in XML format
 
 ```
@@ -3303,7 +3303,7 @@ Assert that a response is not valid XML
 Then the response should not be in XML format
 
 # Content set by a fixture step is validated instead of the page content.
-Given the response content from the file "xml_invalid.xml"
+Given the response XML is loaded from the file "xml_invalid.xml"
 Then the response should not be in XML format
 
 ```
@@ -3341,7 +3341,7 @@ Then the XML element "/library/book[@id='999']" should not exist
 </details>
 
 <details>
-  <summary><code>@Then the XML element :element should be equal to :text</code></summary>
+  <summary><code>@Then the XML element :element should be equal to :value</code></summary>
 
 <br/>
 Assert that an XML element content equals specified text
@@ -3356,7 +3356,7 @@ Then the XML element "/library/book[1]/author" should be equal to "John Doe"
 </details>
 
 <details>
-  <summary><code>@Then the XML element :element should not be equal to :text</code></summary>
+  <summary><code>@Then the XML element :element should not be equal to :value</code></summary>
 
 <br/>
 Assert that an XML element content does not equal specified text
@@ -3371,7 +3371,7 @@ Then the XML element "/library/book[1]/author" should not be equal to "Wrong Aut
 </details>
 
 <details>
-  <summary><code>@Then the XML element :element should contain :text</code></summary>
+  <summary><code>@Then the XML element :element should contain :value</code></summary>
 
 <br/>
 Assert that an XML element contains specified text
@@ -3386,7 +3386,7 @@ Then the XML element "/library/book[1]/description" should contain "detailed"
 </details>
 
 <details>
-  <summary><code>@Then the XML element :element should not contain :text</code></summary>
+  <summary><code>@Then the XML element :element should not contain :value</code></summary>
 
 <br/>
 Assert that an XML element does not contain specified text
@@ -3431,7 +3431,7 @@ Then the XML attribute "missing" on element "/library/book[1]" should not exist
 </details>
 
 <details>
-  <summary><code>@Then the XML attribute :attribute on element :element should be equal to :text</code></summary>
+  <summary><code>@Then the XML attribute :attribute on element :element should be equal to :value</code></summary>
 
 <br/>
 Assert that an XML attribute value equals specified text
@@ -3446,7 +3446,7 @@ Then the XML attribute "category" on element "/library/book[1]" should be equal 
 </details>
 
 <details>
-  <summary><code>@Then the XML attribute :attribute on element :element should not be equal to :text</code></summary>
+  <summary><code>@Then the XML attribute :attribute on element :element should not be equal to :value</code></summary>
 
 <br/>
 Assert that an XML attribute value does not equal specified text
@@ -3461,7 +3461,7 @@ Then the XML attribute "category" on element "/library/book[1]" should not be eq
 </details>
 
 <details>
-  <summary><code>@Then the XML attribute :attribute_name on element :element should contain :text</code></summary>
+  <summary><code>@Then the XML attribute :attribute on element :element should contain :value</code></summary>
 
 <br/>
 Assert that an XML attribute value contains specified text
@@ -3476,7 +3476,7 @@ Then the XML attribute "id" on element "/library/book[1]" should contain "12"
 </details>
 
 <details>
-  <summary><code>@Then the XML attribute :attribute_name on element :element should not contain :text</code></summary>
+  <summary><code>@Then the XML attribute :attribute on element :element should not contain :value</code></summary>
 
 <br/>
 Assert that an XML attribute value does not contain specified text
@@ -3871,42 +3871,42 @@ Then the block "My block" should not exist in the "content" region
 
 
 <details>
-  <summary><code>@Given the page cache for the path :path has been cleared</code></summary>
+  <summary><code>@Given the page cache for the path :path is empty</code></summary>
 
 <br/>
 Clear the page cache for a single path
 <br/><br/>
 
 ```gherkin
-Given the page cache for the path "/about" has been cleared
+Given the page cache for the path "/about" is empty
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Given the page cache for the paths matching :path_pattern has been cleared</code></summary>
+  <summary><code>@Given the page cache for the paths matching :path_pattern is empty</code></summary>
 
 <br/>
 Clear the page cache for all paths matching a glob-style pattern
 <br/><br/>
 
 ```gherkin
-Given the page cache for the paths matching "/news*" has been cleared
+Given the page cache for the paths matching "/news*" is empty
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Given the render cache has been cleared</code></summary>
+  <summary><code>@Given the render cache is empty</code></summary>
 
 <br/>
 Clear the render cache
 <br/><br/>
 
 ```gherkin
-Given the render cache has been cleared
+Given the render cache is empty
 
 ```
 
@@ -4018,14 +4018,14 @@ Given the config "system.site" key "page.front" has the value "/node"
 </details>
 
 <details>
-  <summary><code>@Given the following config values:</code></summary>
+  <summary><code>@Given the following config values exist:</code></summary>
 
 <br/>
 Set multiple stored Drupal configuration values from a table
 <br/><br/>
 
 ```gherkin
-Given the following config values:
+Given the following config values exist:
   | name              | key          | value                   |
   | system.site       | name         | My site                 |
   | mymodule.settings | api.endpoint | https://api.example.com |
@@ -4158,7 +4158,7 @@ Then the config "system.site" key "name" should not contain the effective value 
 
 
 <details>
-  <summary><code>@Given the following :type content blocks do not exist:</code></summary>
+  <summary><code>@Given the following :content_block_type content blocks do not exist:</code></summary>
 
 <br/>
 Remove content blocks of a specified type with the given descriptions
@@ -4174,7 +4174,7 @@ Given the following "basic" content blocks do not exist:
 </details>
 
 <details>
-  <summary><code>@Given the following :type content blocks exist:</code></summary>
+  <summary><code>@Given the following :content_block_type content blocks exist:</code></summary>
 
 <br/>
 Create content blocks of the specified type with the given field values
@@ -4191,14 +4191,14 @@ Given the following "basic" content blocks exist:
 </details>
 
 <details>
-  <summary><code>@Given the following :type content blocks with fields:</code></summary>
+  <summary><code>@Given the following :content_block_type content blocks with fields exist:</code></summary>
 
 <br/>
 Create content blocks with vertical field format
 <br/><br/>
 
 ```gherkin
-Given the following basic content blocks with fields:
+Given the following basic content blocks with fields exist:
   | info   | [TEST] Block 1        | [TEST] Block 2        |
   | body   | First block content   | Second block content  |
   | status | 1                     | 1                     |
@@ -4208,7 +4208,7 @@ Given the following basic content blocks with fields:
 </details>
 
 <details>
-  <summary><code>@When I edit the :type content block with the description :description</code></summary>
+  <summary><code>@When I edit the :content_block_type content block with the description :description</code></summary>
 
 <br/>
 Navigate to the edit page for a specified content block
@@ -4222,7 +4222,7 @@ When I edit the "basic" content block with the description "[TEST] Footer Block"
 </details>
 
 <details>
-  <summary><code>@Then the content block type :type should exist</code></summary>
+  <summary><code>@Then the content block type :content_block_type should exist</code></summary>
 
 <br/>
 Assert that a content block type exists
@@ -4285,14 +4285,14 @@ Given the following "article" content does not exist:
 </details>
 
 <details>
-  <summary><code>@Given the following :type content with fields:</code></summary>
+  <summary><code>@Given the following :content_type content with fields exist:</code></summary>
 
 <br/>
 Create content with vertical field format
 <br/><br/>
 
 ```gherkin
-Given the following page content with fields:
+Given the following page content with fields exist:
   | title  | [TEST] Page 1        | [TEST] Page 2        |
   | body   | First page content   | Second page content  |
   | status | 1                    | 1                    |
@@ -4478,7 +4478,7 @@ Then "page" content with the title "Test page" should not be published
 
 
 <details>
-  <summary><code>@When I save the draggable views items of the view :view_id and the display :view_display_id for the :bundle content in the following order:</code></summary>
+  <summary><code>@When I save the draggable views items of the view :view_id and the display :view_display_id for the :content_type content in the following order:</code></summary>
 
 <br/>
 Save order of the Draggable Order items
@@ -4654,14 +4654,14 @@ When I disable the test email system
 </details>
 
 <details>
-  <summary><code>@Then an email should be sent to the :address</code></summary>
+  <summary><code>@Then an email should be sent to the address :address</code></summary>
 
 <br/>
 Assert that an email should be sent to an address
 <br/><br/>
 
 ```gherkin
-Then an email should be sent to the "user@example.com"
+Then an email should be sent to the address "user@example.com"
 
 ```
 
@@ -4682,14 +4682,14 @@ Then no emails should have been sent
 </details>
 
 <details>
-  <summary><code>@Then no emails should have been sent to the :address</code></summary>
+  <summary><code>@Then no emails should have been sent to the address :address</code></summary>
 
 <br/>
 Assert that no email messages should be sent to a specified address
 <br/><br/>
 
 ```gherkin
-Then no emails should have been sent to the "user@example.com"
+Then no emails should have been sent to the address "user@example.com"
 
 ```
 
@@ -4925,14 +4925,14 @@ Then the file "report.xlsx" should be attached to the email with the subject con
 
 
 <details>
-  <summary><code>@Given the following managed files:</code></summary>
+  <summary><code>@Given the following managed files exist:</code></summary>
 
 <br/>
 Create managed files with properties provided in the table
 <br/><br/>
 
 ```gherkin
-Given the following managed files:
+Given the following managed files exist:
   | path         | uri                    | status |
   | document.pdf | public://document.pdf  | 1      |
   | image.jpg    | public://images/pic.jpg| 1      |
@@ -4977,14 +4977,14 @@ Given the unmanaged file at the URI "public://sample.txt" exists
 </details>
 
 <details>
-  <summary><code>@Given the unmanaged file at the URI :uri exists with :content</code></summary>
+  <summary><code>@Given the unmanaged file at the URI :uri exists with the content :content</code></summary>
 
 <br/>
 Create an unmanaged file with specified content
 <br/><br/>
 
 ```gherkin
-Given the unmanaged file at the URI "public://data.txt" exists with "Sample content"
+Given the unmanaged file at the URI "public://data.txt" exists with the content "Sample content"
 
 ```
 
@@ -5059,28 +5059,28 @@ Then an unmanaged file at the URI "public://config.txt" should not contain "debu
 
 
 <details>
-  <summary><code>@Given :media_type media type does not exist</code></summary>
+  <summary><code>@Given the media type :media_type does not exist</code></summary>
 
 <br/>
 Remove media type
 <br/><br/>
 
 ```gherkin
-Given "video" media type does not exist
+Given the media type "video" does not exist
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Given the following media :media_type exist:</code></summary>
+  <summary><code>@Given the following :media_type media exist:</code></summary>
 
 <br/>
 Create media of a given type
 <br/><br/>
 
 ```gherkin
-Given the following media "video" exist:
+Given the following "video" media exist:
   | name     | field1   | field2 | field3           |
   | My media | file.jpg | value  | value            |
   | ...      | ...      | ...    | ...              |
@@ -5090,14 +5090,14 @@ Given the following media "video" exist:
 </details>
 
 <details>
-  <summary><code>@Given the following :bundle media with fields:</code></summary>
+  <summary><code>@Given the following :media_type media with fields exist:</code></summary>
 
 <br/>
 Create media entities with vertical field format
 <br/><br/>
 
 ```gherkin
-Given the following image media with fields:
+Given the following image media with fields exist:
   | name              | [TEST] Image 1       | [TEST] Image 2       |
   | field_media_image | image1.jpg           | image2.jpg           |
 
@@ -5106,14 +5106,14 @@ Given the following image media with fields:
 </details>
 
 <details>
-  <summary><code>@Given the following media :media_type do not exist:</code></summary>
+  <summary><code>@Given the following :media_type media do not exist:</code></summary>
 
 <br/>
 Remove media defined by provided properties
 <br/><br/>
 
 ```gherkin
-Given the following media "image" do not exist:
+Given the following "image" media do not exist:
   | name               |
   | Media item         |
   | Another media item |
@@ -5123,84 +5123,84 @@ Given the following media "image" do not exist:
 </details>
 
 <details>
-  <summary><code>@When I edit the media :media_type with the name :name</code></summary>
+  <summary><code>@When I edit the :media_type media with the name :name</code></summary>
 
 <br/>
 Navigate to edit media with specified type and name
 <br/><br/>
 
 ```gherkin
-When I edit the media "document" with the name "Test document"
+When I edit the "document" media with the name "Test document"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@When I visit the media :media_type with the name :name</code></summary>
+  <summary><code>@When I visit the :media_type media with the name :name</code></summary>
 
 <br/>
 Navigate to view page of media with specified type and name
 <br/><br/>
 
 ```gherkin
-When I visit the media "image" with the name "Test media image"
+When I visit the "image" media with the name "Test media image"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@When I visit the media :media_type delete page with the name :name</code></summary>
+  <summary><code>@When I visit the :media_type media delete page with the name :name</code></summary>
 
 <br/>
 Navigate to delete page of media with specified type and name
 <br/><br/>
 
 ```gherkin
-When I visit the media "image" delete page with the name "Test media image"
+When I visit the "image" media delete page with the name "Test media image"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@When I visit the media :media_type revisions page with the name :name</code></summary>
+  <summary><code>@When I visit the :media_type media revisions page with the name :name</code></summary>
 
 <br/>
 Navigate to revisions page of media with specified type and name
 <br/><br/>
 
 ```gherkin
-When I visit the media "image" revisions page with the name "Test media image"
+When I visit the "image" media revisions page with the name "Test media image"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Then the :media_type media type should exist</code></summary>
+  <summary><code>@Then the media type :media_type should exist</code></summary>
 
 <br/>
 Assert that a media type exists
 <br/><br/>
 
 ```gherkin
-Then the "image" media type should exist
+Then the media type "image" should exist
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Then the :media_type media type should not exist</code></summary>
+  <summary><code>@Then the media type :media_type should not exist</code></summary>
 
 <br/>
 Assert that a media type does not exist
 <br/><br/>
 
 ```gherkin
-Then the "test_type" media type should not exist
+Then the media type "test_type" should not exist
 
 ```
 
@@ -5259,14 +5259,14 @@ Given the menu "Test Menu" does not exist
 </details>
 
 <details>
-  <summary><code>@Given the following menus:</code></summary>
+  <summary><code>@Given the following menus exist:</code></summary>
 
 <br/>
 Create menus
 <br/><br/>
 
 ```gherkin
-Given the following menus:
+Given the following menus exist:
   | label            | description                    |
   | Footer Menu     | Links displayed in the footer  |
   | Secondary Menu  | Secondary navigation menu      |
@@ -5765,14 +5765,14 @@ Given the state "my_module.launched" does not exist
 </details>
 
 <details>
-  <summary><code>@Given the following state values:</code></summary>
+  <summary><code>@Given the following state values exist:</code></summary>
 
 <br/>
 Set multiple Drupal state values from a table
 <br/><br/>
 
 ```gherkin
-Given the following state values:
+Given the following state values exist:
   | name                   | value |
   | my_module.launched     | 1     |
   | my_module.feature_flag | 0     |
@@ -5820,14 +5820,14 @@ Then the state "my_module.launched" should not exist
 
 
 <details>
-  <summary><code>@Given the following :vocabulary terms with fields:</code></summary>
+  <summary><code>@Given the following :vocabulary terms with fields exist:</code></summary>
 
 <br/>
 Create taxonomy terms with vertical field format
 <br/><br/>
 
 ```gherkin
-Given the following tags terms with fields:
+Given the following tags terms with fields exist:
   | name        | [TEST] Behat    | [TEST] Testing  |
   | description | Testing tag     | QA tag          |
 
@@ -5836,14 +5836,14 @@ Given the following tags terms with fields:
 </details>
 
 <details>
-  <summary><code>@Given the following :vocabulary_machine_name vocabulary terms do not exist:</code></summary>
+  <summary><code>@Given the following :vocabulary terms do not exist:</code></summary>
 
 <br/>
 Remove terms from a specified vocabulary
 <br/><br/>
 
 ```gherkin
-Given the following "fruits" vocabulary terms do not exist:
+Given the following "fruits" terms do not exist:
   | Apple |
   | Pear  |
 
@@ -5852,7 +5852,7 @@ Given the following "fruits" vocabulary terms do not exist:
 </details>
 
 <details>
-  <summary><code>@When I visit the :vocabulary_machine_name term page with the name :term_name</code></summary>
+  <summary><code>@When I visit the :vocabulary term page with the name :term_name</code></summary>
 
 <br/>
 Visit specified vocabulary term page
@@ -5866,7 +5866,7 @@ When I visit the "fruits" term page with the name "Apple"
 </details>
 
 <details>
-  <summary><code>@When I visit the :vocabulary_machine_name term edit page with the name :term_name</code></summary>
+  <summary><code>@When I visit the :vocabulary term edit page with the name :term_name</code></summary>
 
 <br/>
 Visit specified vocabulary term edit page
@@ -5880,7 +5880,7 @@ When I visit the "fruits" term edit page with the name "Apple"
 </details>
 
 <details>
-  <summary><code>@When I visit the :vocabulary_machine_name term delete page with the name :term_name</code></summary>
+  <summary><code>@When I visit the :vocabulary term delete page with the name :term_name</code></summary>
 
 <br/>
 Visit specified vocabulary term delete page
@@ -5894,7 +5894,7 @@ When I visit the "tags" term delete page with the name "[TEST] Remove"
 </details>
 
 <details>
-  <summary><code>@Then the vocabulary :machine_name with the name :name should exist</code></summary>
+  <summary><code>@Then the vocabulary :vocabulary with the name :name should exist</code></summary>
 
 <br/>
 Assert that a vocabulary with a specific name exists
@@ -5908,7 +5908,7 @@ Then the vocabulary "topics" with the name "Topics" should exist
 </details>
 
 <details>
-  <summary><code>@Then the vocabulary :machine_name should not exist</code></summary>
+  <summary><code>@Then the vocabulary :vocabulary should not exist</code></summary>
 
 <br/>
 Assert that a vocabulary with a specific name does not exist
@@ -5922,7 +5922,7 @@ Then the vocabulary "topics" should not exist
 </details>
 
 <details>
-  <summary><code>@Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should exist</code></summary>
+  <summary><code>@Then the taxonomy term :term_name from the vocabulary :vocabulary should exist</code></summary>
 
 <br/>
 Assert that a taxonomy term exist by name
@@ -5936,7 +5936,7 @@ Then the taxonomy term "Apple" from the vocabulary "Fruits" should exist
 </details>
 
 <details>
-  <summary><code>@Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should not exist</code></summary>
+  <summary><code>@Then the taxonomy term :term_name from the vocabulary :vocabulary should not exist</code></summary>
 
 <br/>
 Assert that a taxonomy term does not exist by name
@@ -6039,14 +6039,14 @@ Given the following users do not exist:
 </details>
 
 <details>
-  <summary><code>@Given the following users with fields:</code></summary>
+  <summary><code>@Given the following users with fields exist:</code></summary>
 
 <br/>
 Create users with vertical field format
 <br/><br/>
 
 ```gherkin
-Given the following users with fields:
+Given the following users with fields exist:
   | name  | [TEST] user1         | [TEST] user2         |
   | mail  | user1@example.com    | user2@example.com    |
   | roles | editor               | author               |
@@ -6100,28 +6100,28 @@ Given the last login time for the user "John" is "1732319174"
 </details>
 
 <details>
-  <summary><code>@Given the role :role_name with the permissions :permissions</code></summary>
+  <summary><code>@Given the role :role_name has the permissions :permissions</code></summary>
 
 <br/>
 Create a single role with specified permissions
 <br/><br/>
 
 ```gherkin
-Given the role "Content Manager" with the permissions "access content, create article content, edit any article content"
+Given the role "Content Manager" has the permissions "access content, create article content, edit any article content"
 
 ```
 
 </details>
 
 <details>
-  <summary><code>@Given the following roles:</code></summary>
+  <summary><code>@Given the following roles exist:</code></summary>
 
 <br/>
 Create multiple roles from the specified table
 <br/><br/>
 
 ```gherkin
-Given the following roles:
+Given the following roles exist:
   | name              | permissions                              |
   | Content Editor    | access content, create article content   |
   | Content Approver  | access content, edit any article content |
@@ -6371,14 +6371,14 @@ Given the webform "Test form" does not exist
 </details>
 
 <details>
-  <summary><code>@Given a webform :title from template :template</code></summary>
+  <summary><code>@Given the webform :title exists from the template :template</code></summary>
 
 <br/>
 Clone a webform template into a new webform with the given title
 <br/><br/>
 
 ```gherkin
-Given a webform "My contact form" from template "Contact"
+Given the webform "My contact form" exists from the template "Contact"
 
 ```
 

--- a/src/Drupal/CacheTrait.php
+++ b/src/Drupal/CacheTrait.php
@@ -24,10 +24,10 @@ trait CacheTrait {
    * the internal page cache to refresh the next time the path is requested.
    *
    * @code
-   * Given the page cache for the path "/about" has been cleared
+   * Given the page cache for the path "/about" is empty
    * @endcode
    */
-  #[Given('the page cache for the path :path has been cleared')]
+  #[Given('the page cache for the path :path is empty')]
   public function cacheClearPagePath(string $path): void {
     if ($path === '') {
       throw new \InvalidArgumentException('The path must not be empty.');
@@ -47,10 +47,10 @@ trait CacheTrait {
    * (`%`, `_`, `\`) are escaped so they are treated literally.
    *
    * @code
-   * Given the page cache for the paths matching "/news*" has been cleared
+   * Given the page cache for the paths matching "/news*" is empty
    * @endcode
    */
-  #[Given('the page cache for the paths matching :path_pattern has been cleared')]
+  #[Given('the page cache for the paths matching :path_pattern is empty')]
   public function cacheClearPagePathWildcard(string $path_pattern): void {
     if ($path_pattern === '') {
       throw new \InvalidArgumentException('The path pattern must not be empty.');
@@ -82,10 +82,10 @@ trait CacheTrait {
    * Clear the render cache.
    *
    * @code
-   * Given the render cache has been cleared
+   * Given the render cache is empty
    * @endcode
    */
-  #[Given('the render cache has been cleared')]
+  #[Given('the render cache is empty')]
   public function cacheClearRender(): void {
     \Drupal::cache('render')->deleteAll();
   }

--- a/src/Drupal/ConfigTrait.php
+++ b/src/Drupal/ConfigTrait.php
@@ -109,14 +109,14 @@ trait ConfigTrait {
    * Set multiple stored Drupal configuration values from a table.
    *
    * @code
-   * Given the following config values:
+   * Given the following config values exist:
    *   | name              | key          | value                   |
    *   | system.site       | name         | My site                 |
    *   | mymodule.settings | api.endpoint | https://api.example.com |
    *   | mymodule.settings | roles        | ["editor","reviewer"]   |
    * @endcode
    */
-  #[Given('the following config values:')]
+  #[Given('the following config values exist:')]
   public function configSetMultiple(TableNode $table): void {
     foreach ($table->getHash() as $row) {
       if (!isset($row['name'], $row['key']) || !array_key_exists('value', $row)) {

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -31,12 +31,12 @@ trait ContentBlockTrait {
    * Then the content block type "Search" should exist
    * @endcode
    */
-  #[Then('the content block type :type should exist')]
-  public function contentBlockAssertTypeExists(string $type): void {
-    $block_content_type = \Drupal::entityTypeManager()->getStorage('block_content_type')->load($type);
+  #[Then('the content block type :content_block_type should exist')]
+  public function contentBlockAssertTypeExists(string $content_block_type): void {
+    $block_content_type = \Drupal::entityTypeManager()->getStorage('block_content_type')->load($content_block_type);
 
     if (!$block_content_type instanceof BlockContentTypeInterface) {
-      throw new ExpectationException(sprintf('Content block type "%s" does not exist.', $type), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('Content block type "%s" does not exist.', $content_block_type), $this->getSession()->getDriver());
     }
   }
 
@@ -55,12 +55,12 @@ trait ContentBlockTrait {
    * @throws \Drupal\Core\Entity\EntityStorageException
    *   When the entity cannot be deleted.
    */
-  #[Given('the following :type content blocks do not exist:')]
-  public function contentBlockDelete(string $type, TableNode $content_block_table): void {
+  #[Given('the following :content_block_type content blocks do not exist:')]
+  public function contentBlockDelete(string $content_block_type, TableNode $content_block_table): void {
     foreach ($content_block_table->getColumn(0) as $description) {
       $content_blocks = \Drupal::entityTypeManager()->getStorage('block_content')->loadByProperties([
         'info' => $description,
-        'type' => $type,
+        'type' => $content_block_type,
       ]);
 
       foreach ($content_blocks as $content_block) {
@@ -81,14 +81,14 @@ trait ContentBlockTrait {
    * When I edit the "basic" content block with the description "[TEST] Footer Block"
    * @endcode
    */
-  #[When('I edit the :type content block with the description :description')]
-  public function contentBlockEditBlockContentWithDescription(string $type, string $description): void {
-    $block_ids = $this->contentBlockLoadMultiple($type, [
+  #[When('I edit the :content_block_type content block with the description :description')]
+  public function contentBlockEditBlockContentWithDescription(string $content_block_type, string $description): void {
+    $block_ids = $this->contentBlockLoadMultiple($content_block_type, [
       'info' => $description,
     ]);
 
     if (empty($block_ids)) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" content block with the description "%s".', $type, $description));
+      throw new \RuntimeException(sprintf('Unable to find "%s" content block with the description "%s".', $content_block_type, $description));
     }
 
     ksort($block_ids);
@@ -113,7 +113,7 @@ trait ContentBlockTrait {
    * - created: Creation timestamp (format: YYYY-MM-DD H:MMam/pm)
    * - body: Block content (for blocks with a body field)
    *
-   * @param string $type
+   * @param string $content_block_type
    *   The content block type machine name.
    * @param \Behat\Gherkin\Node\TableNode $content_block_table
    *   Table containing field values for each block to create.
@@ -125,10 +125,10 @@ trait ContentBlockTrait {
    *     | [TEST] Copyright      | 1      | © 2023 Example Company | 2023-01-18 9:00am |
    * @endcode
    */
-  #[Given('the following :type content blocks exist:')]
-  public function contentBlockCreate(string $type, TableNode $content_block_table): void {
+  #[Given('the following :content_block_type content blocks exist:')]
+  public function contentBlockCreate(string $content_block_type, TableNode $content_block_table): void {
     foreach ($content_block_table->getHash() as $hash) {
-      $this->contentBlockCreateSingle($type, $hash);
+      $this->contentBlockCreateSingle($content_block_type, $hash);
     }
   }
 
@@ -138,24 +138,24 @@ trait ContentBlockTrait {
    * Supports both single and multiple entity creation using vertical table
    * format where fields are listed in rows instead of columns.
    *
-   * @param string $type
+   * @param string $content_block_type
    *   The content block type machine name.
    * @param \Behat\Gherkin\Node\TableNode $table
    *   Vertical format table with field names in first column.
    *
    * @code
-   *   Given the following basic content blocks with fields:
+   *   Given the following basic content blocks with fields exist:
    *     | info   | [TEST] Block 1        | [TEST] Block 2        |
    *     | body   | First block content   | Second block content  |
    *     | status | 1                     | 1                     |
    * @endcode
    */
-  #[Given('the following :type content blocks with fields:')]
-  public function contentBlockCreateWithFields(string $type, TableNode $table): void {
+  #[Given('the following :content_block_type content blocks with fields exist:')]
+  public function contentBlockCreateWithFields(string $content_block_type, TableNode $table): void {
     $entities = $this->helperTransposeVerticalTable($table);
 
     foreach ($entities as $entity_data) {
-      $this->contentBlockCreateSingle($type, $entity_data);
+      $this->contentBlockCreateSingle($content_block_type, $entity_data);
     }
   }
 

--- a/src/Drupal/ContentTrait.php
+++ b/src/Drupal/ContentTrait.php
@@ -79,23 +79,23 @@ trait ContentTrait {
    * Supports both single and multiple entity creation using vertical table
    * format where fields are listed in rows instead of columns.
    *
-   * @param string $type
+   * @param string $content_type
    *   The content type machine name.
    * @param \Behat\Gherkin\Node\TableNode $table
    *   Vertical format table with field names in first column.
    *
    * @code
-   *   Given the following page content with fields:
+   *   Given the following page content with fields exist:
    *     | title  | [TEST] Page 1        | [TEST] Page 2        |
    *     | body   | First page content   | Second page content  |
    *     | status | 1                    | 1                    |
    * @endcode
    */
-  #[Given('the following :type content with fields:')]
-  public function contentCreateWithFields(string $type, TableNode $table): void {
+  #[Given('the following :content_type content with fields exist:')]
+  public function contentCreateWithFields(string $content_type, TableNode $table): void {
     $entities = $this->helperTransposeVerticalTable($table);
     $horizontal_table = $this->helperBuildHorizontalTable($entities);
-    $this->createNodes($type, $horizontal_table);
+    $this->createNodes($content_type, $horizontal_table);
   }
 
   /**

--- a/src/Drupal/DraggableviewsTrait.php
+++ b/src/Drupal/DraggableviewsTrait.php
@@ -28,14 +28,14 @@ trait DraggableviewsTrait {
    *   | Third Article  |
    * @endcode
    */
-  #[When('I save the draggable views items of the view :view_id and the display :view_display_id for the :bundle content in the following order:')]
-  public function draggableViewsSaveBundleOrder(string $view_id, string $view_display_id, string $bundle, TableNode $order_table): void {
+  #[When('I save the draggable views items of the view :view_id and the display :view_display_id for the :content_type content in the following order:')]
+  public function draggableViewsSaveBundleOrder(string $view_id, string $view_display_id, string $content_type, TableNode $order_table): void {
     $this->helperAssertModuleEnabled('draggableviews', 'drupal/draggableviews');
 
     $database = Database::getConnection();
 
     foreach ($order_table->getColumn(0) as $weight => $title) {
-      $node = $this->draggableViewsFindNode($bundle, ['title' => $title]);
+      $node = $this->draggableViewsFindNode($content_type, ['title' => $title]);
 
       if (empty($node)) {
         throw new \RuntimeException(sprintf('Unable to find the node "%s".', $title));

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -117,10 +117,10 @@ trait EmailTrait {
    * Assert that an email should be sent to an address.
    *
    * @code
-   * Then an email should be sent to the "user@example.com"
+   * Then an email should be sent to the address "user@example.com"
    * @endcode
    */
-  #[Then('an email should be sent to the :address')]
+  #[Then('an email should be sent to the address :address')]
   public function emailAssertMessageSentTo(string $address): void {
     foreach ($this->emailGetCollectedMessages() as $message) {
       $to = $this->helperSplitCommaSeparated((string) $message['to']);
@@ -152,10 +152,10 @@ trait EmailTrait {
    * Assert that no email messages should be sent to a specified address.
    *
    * @code
-   * Then no emails should have been sent to the "user@example.com"
+   * Then no emails should have been sent to the address "user@example.com"
    * @endcode
    */
-  #[Then('no emails should have been sent to the :address')]
+  #[Then('no emails should have been sent to the address :address')]
   public function emailAssertNoMessagesSentToAddress(string $address): void {
     foreach ($this->emailGetCollectedMessages() as $message) {
       $to = $this->helperSplitCommaSeparated((string) $message['to']);

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -74,13 +74,13 @@ trait FileTrait {
    * Create managed files with properties provided in the table.
    *
    * @code
-   * Given the following managed files:
+   * Given the following managed files exist:
    *   | path         | uri                    | status |
    *   | document.pdf | public://document.pdf  | 1      |
    *   | image.jpg    | public://images/pic.jpg| 1      |
    * @endcode
    */
-  #[Given('the following managed files:')]
+  #[Given('the following managed files exist:')]
   public function fileCreateManaged(TableNode $table): void {
     foreach ($table->getHash() as $hash) {
       if (empty($hash['path'])) {
@@ -282,10 +282,10 @@ trait FileTrait {
    * Create an unmanaged file with specified content.
    *
    * @code
-   * Given the unmanaged file at the URI "public://data.txt" exists with "Sample content"
+   * Given the unmanaged file at the URI "public://data.txt" exists with the content "Sample content"
    * @endcode
    */
-  #[Given('the unmanaged file at the URI :uri exists with :content')]
+  #[Given('the unmanaged file at the URI :uri exists with the content :content')]
   public function fileCreateUnmanagedWithContent(string $uri, string $content): void {
     $this->fileCreateUnmanaged($uri, $content);
   }

--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -31,12 +31,12 @@ trait MediaTrait {
    * Remove media type.
    *
    * @code
-   * Given "video" media type does not exist
+   * Given the media type "video" does not exist
    * @endcode
    */
-  #[Given(':media_type media type does not exist')]
-  public function mediaRemoveType(string $type): void {
-    $type_entity = \Drupal::entityTypeManager()->getStorage('media_type')->load($type);
+  #[Given('the media type :media_type does not exist')]
+  public function mediaRemoveType(string $media_type): void {
+    $type_entity = \Drupal::entityTypeManager()->getStorage('media_type')->load($media_type);
     if ($type_entity) {
       $type_entity->delete();
     }
@@ -46,13 +46,13 @@ trait MediaTrait {
    * Create media of a given type.
    *
    * @code
-   * Given the following media "video" exist:
+   * Given the following "video" media exist:
    *   | name     | field1   | field2 | field3           |
    *   | My media | file.jpg | value  | value            |
    *   | ...      | ...      | ...    | ...              |
    * @endcode
    */
-  #[Given('the following media :media_type exist:')]
+  #[Given('the following :media_type media exist:')]
   public function mediaCreate(string $media_type, TableNode $table): void {
     $this->mediaDelete($media_type, $table);
 
@@ -68,26 +68,26 @@ trait MediaTrait {
    * Supports both single and multiple entity creation using vertical table
    * format where fields are listed in rows instead of columns.
    *
-   * @param string $bundle
+   * @param string $media_type
    *   The media bundle machine name.
    * @param \Behat\Gherkin\Node\TableNode $table
    *   Vertical format table with field names in first column.
    *
    * @code
-   *   Given the following image media with fields:
+   *   Given the following image media with fields exist:
    *     | name              | [TEST] Image 1       | [TEST] Image 2       |
    *     | field_media_image | image1.jpg           | image2.jpg           |
    * @endcode
    */
-  #[Given('the following :bundle media with fields:')]
-  public function mediaCreateWithFields(string $bundle, TableNode $table): void {
+  #[Given('the following :media_type media with fields exist:')]
+  public function mediaCreateWithFields(string $media_type, TableNode $table): void {
     $entities = $this->helperTransposeVerticalTable($table);
     $horizontal_table = $this->helperBuildHorizontalTable($entities);
 
-    $this->mediaDelete($bundle, $horizontal_table);
+    $this->mediaDelete($media_type, $horizontal_table);
 
     foreach ($entities as $entity_data) {
-      $stub = new EntityStub('media', $bundle, $entity_data);
+      $stub = new EntityStub('media', $media_type, $entity_data);
       $this->mediaCreateSingle($stub);
     }
   }
@@ -96,13 +96,13 @@ trait MediaTrait {
    * Remove media defined by provided properties.
    *
    * @code
-   * Given the following media "image" do not exist:
+   * Given the following "image" media do not exist:
    *   | name               |
    *   | Media item         |
    *   | Another media item |
    * @endcode
    */
-  #[Given('the following media :media_type do not exist:')]
+  #[Given('the following :media_type media do not exist:')]
   public function mediaDelete(string $media_type, TableNode $table): void {
     foreach ($table->getHash() as $media_hash) {
       $ids = $this->mediaLoadMultiple($media_type, $media_hash);
@@ -116,10 +116,10 @@ trait MediaTrait {
    * Navigate to edit media with specified type and name.
    *
    * @code
-   * When I edit the media "document" with the name "Test document"
+   * When I edit the "document" media with the name "Test document"
    * @endcode
    */
-  #[When('I edit the media :media_type with the name :name')]
+  #[When('I edit the :media_type media with the name :name')]
   public function mediaEditWithName(string $media_type, string $name): void {
     $this->mediaVisitActionPageWithName($media_type, $name, '/edit');
   }
@@ -128,10 +128,10 @@ trait MediaTrait {
    * Navigate to view page of media with specified type and name.
    *
    * @code
-   * When I visit the media "image" with the name "Test media image"
+   * When I visit the "image" media with the name "Test media image"
    * @endcode
    */
-  #[When('I visit the media :media_type with the name :name')]
+  #[When('I visit the :media_type media with the name :name')]
   public function mediaVisitViewWithName(string $media_type, string $name): void {
     $this->mediaVisitActionPageWithName($media_type, $name);
   }
@@ -140,10 +140,10 @@ trait MediaTrait {
    * Navigate to delete page of media with specified type and name.
    *
    * @code
-   * When I visit the media "image" delete page with the name "Test media image"
+   * When I visit the "image" media delete page with the name "Test media image"
    * @endcode
    */
-  #[When('I visit the media :media_type delete page with the name :name')]
+  #[When('I visit the :media_type media delete page with the name :name')]
   public function mediaVisitDeleteWithName(string $media_type, string $name): void {
     $this->mediaVisitActionPageWithName($media_type, $name, '/delete');
   }
@@ -152,10 +152,10 @@ trait MediaTrait {
    * Navigate to revisions page of media with specified type and name.
    *
    * @code
-   * When I visit the media "image" revisions page with the name "Test media image"
+   * When I visit the "image" media revisions page with the name "Test media image"
    * @endcode
    */
-  #[When('I visit the media :media_type revisions page with the name :name')]
+  #[When('I visit the :media_type media revisions page with the name :name')]
   public function mediaVisitRevisionsWithName(string $media_type, string $name): void {
     $this->mediaVisitActionPageWithName($media_type, $name, '/revisions');
   }
@@ -164,10 +164,10 @@ trait MediaTrait {
    * Assert that a media type exists.
    *
    * @code
-   * Then the "image" media type should exist
+   * Then the media type "image" should exist
    * @endcode
    */
-  #[Then('the :media_type media type should exist')]
+  #[Then('the media type :media_type should exist')]
   public function mediaAssertTypeExists(string $media_type): void {
     $type_entity = \Drupal::entityTypeManager()->getStorage('media_type')->load($media_type);
 
@@ -180,10 +180,10 @@ trait MediaTrait {
    * Assert that a media type does not exist.
    *
    * @code
-   * Then the "test_type" media type should not exist
+   * Then the media type "test_type" should not exist
    * @endcode
    */
-  #[Then('the :media_type media type should not exist')]
+  #[Then('the media type :media_type should not exist')]
   public function mediaAssertTypeNotExists(string $media_type): void {
     $type_entity = \Drupal::entityTypeManager()->getStorage('media_type')->load($media_type);
 

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -49,13 +49,13 @@ trait MenuTrait {
    * | ...          | ...             |
    *
    * @code
-   * Given the following menus:
+   * Given the following menus exist:
    *   | label            | description                    |
    *   | Footer Menu     | Links displayed in the footer  |
    *   | Secondary Menu  | Secondary navigation menu      |
    * @endcode
    */
-  #[Given('the following menus:')]
+  #[Given('the following menus exist:')]
   public function menuCreate(TableNode $table): void {
     foreach ($table->getHash() as $menu_hash) {
       if (empty($menu_hash['id'])) {

--- a/src/Drupal/SearchApiTrait.php
+++ b/src/Drupal/SearchApiTrait.php
@@ -25,15 +25,15 @@ trait SearchApiTrait {
    * @endcode
    */
   #[When('I add the :content_type content with the title :title to the search index')]
-  public function searchApiIndexContent(string $type, string $title): void {
+  public function searchApiIndexContent(string $content_type, string $title): void {
     $this->helperAssertModuleEnabled('search_api', 'drupal/search_api');
 
-    $nids = $this->contentLoadMultiple($type, [
+    $nids = $this->contentLoadMultiple($content_type, [
       'title' => $title,
     ]);
 
     if (empty($nids)) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" page "%s".', $type, $title));
+      throw new \RuntimeException(sprintf('Unable to find "%s" page "%s".', $content_type, $title));
     }
 
     ksort($nids);
@@ -54,8 +54,8 @@ trait SearchApiTrait {
    * @endcode
    */
   #[When('I run search indexing for :count item(s)')]
-  public function searchApiDoIndex(string|int $limit): void {
-    $limit = (int) $limit;
+  public function searchApiDoIndex(string|int $count): void {
+    $count = (int) $count;
 
     $index_storage = \Drupal::entityTypeManager()->getStorage('search_api_index');
 
@@ -68,7 +68,7 @@ trait SearchApiTrait {
     }
     // @codeCoverageIgnoreEnd
     foreach ($indexes as $index) {
-      $index->indexItems($limit);
+      $index->indexItems($count);
     }
   }
 

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -100,13 +100,13 @@ trait StateTrait {
    * Set multiple Drupal state values from a table.
    *
    * @code
-   * Given the following state values:
+   * Given the following state values exist:
    *   | name                   | value |
    *   | my_module.launched     | 1     |
    *   | my_module.feature_flag | 0     |
    * @endcode
    */
-  #[Given('the following state values:')]
+  #[Given('the following state values exist:')]
   public function stateSetMultiple(TableNode $table): void {
     $state = \Drupal::state();
     foreach ($table->getHash() as $row) {

--- a/src/Drupal/TaxonomyTrait.php
+++ b/src/Drupal/TaxonomyTrait.php
@@ -44,12 +44,12 @@ trait TaxonomyTrait {
    *   Vertical format table with field names in first column.
    *
    * @code
-   *   Given the following tags terms with fields:
+   *   Given the following tags terms with fields exist:
    *     | name        | [TEST] Behat    | [TEST] Testing  |
    *     | description | Testing tag     | QA tag          |
    * @endcode
    */
-  #[Given('the following :vocabulary terms with fields:')]
+  #[Given('the following :vocabulary terms with fields exist:')]
   public function taxonomyCreateWithFields(string $vocabulary, TableNode $table): void {
     $entities = $this->helperTransposeVerticalTable($table);
     $horizontal_table = $this->helperBuildHorizontalTable($entities);
@@ -60,23 +60,23 @@ trait TaxonomyTrait {
    * Remove terms from a specified vocabulary.
    *
    * @code
-   * Given the following "fruits" vocabulary terms do not exist:
+   * Given the following "fruits" terms do not exist:
    *   | Apple |
    *   | Pear  |
    * @endcode
    */
-  #[Given('the following :vocabulary_machine_name vocabulary terms do not exist:')]
-  public function taxonomyDeleteTerms(string $vocabulary_machine_name, TableNode $terms_table): void {
-    $vocab = Vocabulary::load($vocabulary_machine_name);
+  #[Given('the following :vocabulary terms do not exist:')]
+  public function taxonomyDeleteTerms(string $vocabulary, TableNode $terms_table): void {
+    $vocab = Vocabulary::load($vocabulary);
 
     if (!$vocab) {
-      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
+      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary));
     }
 
     foreach ($terms_table->getColumn(0) as $term_name) {
       $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
         'name' => $term_name,
-        'vid' => $vocabulary_machine_name,
+        'vid' => $vocabulary,
       ]);
 
       /** @var \Drupal\taxonomy\Entity\Term $term */
@@ -93,17 +93,17 @@ trait TaxonomyTrait {
    * Then the vocabulary "topics" with the name "Topics" should exist
    * @endcode
    */
-  #[Then('the vocabulary :machine_name with the name :name should exist')]
-  public function taxonomyAssertVocabularyExists(string $machine_name, string $name): void {
-    $vocab = Vocabulary::load($machine_name);
+  #[Then('the vocabulary :vocabulary with the name :name should exist')]
+  public function taxonomyAssertVocabularyExists(string $vocabulary, string $name): void {
+    $vocab = Vocabulary::load($vocabulary);
 
     if (!$vocab) {
-      throw new ExpectationException(sprintf('The vocabulary "%s" does not exist.', $machine_name), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The vocabulary "%s" does not exist.', $vocabulary), $this->getSession()->getDriver());
     }
 
     $actual_name = $vocab->get('name');
     if ($actual_name !== $name) {
-      throw new ExpectationException(sprintf('The vocabulary "%s" exists with a name "%s", but expected "%s".', $machine_name, $actual_name, $name), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The vocabulary "%s" exists with a name "%s", but expected "%s".', $vocabulary, $actual_name, $name), $this->getSession()->getDriver());
     }
   }
 
@@ -114,12 +114,12 @@ trait TaxonomyTrait {
    * Then the vocabulary "topics" should not exist
    * @endcode
    */
-  #[Then('the vocabulary :machine_name should not exist')]
-  public function taxonomyAssertVocabularyNotExists(string $machine_name): void {
-    $vocab = Vocabulary::load($machine_name);
+  #[Then('the vocabulary :vocabulary should not exist')]
+  public function taxonomyAssertVocabularyNotExists(string $vocabulary): void {
+    $vocab = Vocabulary::load($vocabulary);
 
     if ($vocab) {
-      throw new ExpectationException(sprintf('The vocabulary "%s" exists, but it should not.', $machine_name), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The vocabulary "%s" exists, but it should not.', $vocabulary), $this->getSession()->getDriver());
     }
   }
 
@@ -130,23 +130,23 @@ trait TaxonomyTrait {
    * Then the taxonomy term "Apple" from the vocabulary "Fruits" should exist
    * @endcode
    */
-  #[Then('the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should exist')]
-  public function taxonomyAssertTermExistsByName(string $term_name, string $vocabulary_machine_name): void {
-    $vocab = Vocabulary::load($vocabulary_machine_name);
+  #[Then('the taxonomy term :term_name from the vocabulary :vocabulary should exist')]
+  public function taxonomyAssertTermExistsByName(string $term_name, string $vocabulary): void {
+    $vocab = Vocabulary::load($vocabulary);
 
     if (!$vocab) {
-      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
+      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary));
     }
 
     $found = \Drupal::entityTypeManager()
       ->getStorage('taxonomy_term')
       ->loadByProperties([
         'name' => $term_name,
-        'vid' => $vocabulary_machine_name,
+        'vid' => $vocabulary,
       ]);
 
     if (count($found) === 0) {
-      throw new ExpectationException(sprintf('The taxonomy term "%s" from the vocabulary "%s" does not exist.', $term_name, $vocabulary_machine_name), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The taxonomy term "%s" from the vocabulary "%s" does not exist.', $term_name, $vocabulary), $this->getSession()->getDriver());
     }
   }
 
@@ -157,23 +157,23 @@ trait TaxonomyTrait {
    * Then the taxonomy term "Apple" from the vocabulary "Fruits" should not exist
    * @endcode
    */
-  #[Then('the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should not exist')]
-  public function taxonomyAssertTermNotExistsByName(string $term_name, string $vocabulary_machine_name): void {
-    $vocab = Vocabulary::load($vocabulary_machine_name);
+  #[Then('the taxonomy term :term_name from the vocabulary :vocabulary should not exist')]
+  public function taxonomyAssertTermNotExistsByName(string $term_name, string $vocabulary): void {
+    $vocab = Vocabulary::load($vocabulary);
 
     if (!$vocab) {
-      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
+      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary));
     }
 
     $found = \Drupal::entityTypeManager()
       ->getStorage('taxonomy_term')
       ->loadByProperties([
         'name' => $term_name,
-        'vid' => $vocabulary_machine_name,
+        'vid' => $vocabulary,
       ]);
 
     if (count($found) > 0) {
-      throw new ExpectationException(sprintf('The taxonomy term "%s" from the vocabulary "%s" exists, but it should not.', $term_name, $vocabulary_machine_name), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The taxonomy term "%s" from the vocabulary "%s" exists, but it should not.', $term_name, $vocabulary), $this->getSession()->getDriver());
     }
   }
 
@@ -184,9 +184,9 @@ trait TaxonomyTrait {
    * When I visit the "fruits" term page with the name "Apple"
    * @endcode
    */
-  #[When('I visit the :vocabulary_machine_name term page with the name :term_name')]
-  public function taxonomyVisitTermPageWithName(string $vocabulary_machine_name, string $term_name): void {
-    $this->taxonomyVisitActionPageWithName($vocabulary_machine_name, $term_name);
+  #[When('I visit the :vocabulary term page with the name :term_name')]
+  public function taxonomyVisitTermPageWithName(string $vocabulary, string $term_name): void {
+    $this->taxonomyVisitActionPageWithName($vocabulary, $term_name);
   }
 
   /**
@@ -196,9 +196,9 @@ trait TaxonomyTrait {
    * When I visit the "fruits" term edit page with the name "Apple"
    * @endcode
    */
-  #[When('I visit the :vocabulary_machine_name term edit page with the name :term_name')]
-  public function taxonomyVisitTermEditPageWithName(string $vocabulary_machine_name, string $term_name): void {
-    $this->taxonomyVisitActionPageWithName($vocabulary_machine_name, $term_name, '/edit');
+  #[When('I visit the :vocabulary term edit page with the name :term_name')]
+  public function taxonomyVisitTermEditPageWithName(string $vocabulary, string $term_name): void {
+    $this->taxonomyVisitActionPageWithName($vocabulary, $term_name, '/edit');
   }
 
   /**
@@ -208,34 +208,34 @@ trait TaxonomyTrait {
    * When I visit the "tags" term delete page with the name "[TEST] Remove"
    * @endcode
    */
-  #[When('I visit the :vocabulary_machine_name term delete page with the name :term_name')]
-  public function taxonomyVisitTermDeletePageWithName(string $vocabulary_machine_name, string $term_name): void {
-    $this->taxonomyVisitActionPageWithName($vocabulary_machine_name, $term_name, '/delete');
+  #[When('I visit the :vocabulary term delete page with the name :term_name')]
+  public function taxonomyVisitTermDeletePageWithName(string $vocabulary, string $term_name): void {
+    $this->taxonomyVisitActionPageWithName($vocabulary, $term_name, '/delete');
   }
 
   /**
    * Visit the action page of the term with a specified name.
    *
-   * @param string $vocabulary_machine_name
+   * @param string $vocabulary
    *   The term vocabulary machine name.
    * @param string $term_name
    *   The name of the term.
    * @param string $action_subpath
    *   The operation to perform, e.g., '/delete', '/edit', etc.
    */
-  protected function taxonomyVisitActionPageWithName(string $vocabulary_machine_name, string $term_name, string $action_subpath = ''): void {
-    $vocab = Vocabulary::load($vocabulary_machine_name);
+  protected function taxonomyVisitActionPageWithName(string $vocabulary, string $term_name, string $action_subpath = ''): void {
+    $vocab = Vocabulary::load($vocabulary);
 
     if (!$vocab) {
-      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary_machine_name));
+      throw new \RuntimeException(sprintf('The vocabulary "%s" does not exist.', $vocabulary));
     }
 
-    $tids = $this->taxonomyLoadMultiple($vocabulary_machine_name, [
+    $tids = $this->taxonomyLoadMultiple($vocabulary, [
       'name' => $term_name,
     ]);
 
     if (empty($tids)) {
-      throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary_machine_name));
+      throw new \RuntimeException(sprintf('Unable to find the term "%s" in the vocabulary "%s".', $term_name, $vocabulary));
     }
 
     ksort($tids);
@@ -249,7 +249,7 @@ trait TaxonomyTrait {
   /**
    * Load multiple terms with specified vocabulary and conditions.
    *
-   * @param string $vocabulary_machine_name
+   * @param string $vocabulary
    *   The term vocabulary.
    * @param array<string, string> $conditions
    *   Conditions keyed by field names.
@@ -257,10 +257,10 @@ trait TaxonomyTrait {
    * @return array<int, string>
    *   Array of term ids.
    */
-  protected function taxonomyLoadMultiple(string $vocabulary_machine_name, array $conditions = []): array {
+  protected function taxonomyLoadMultiple(string $vocabulary, array $conditions = []): array {
     $query = \Drupal::entityQuery('taxonomy_term')
       ->accessCheck(FALSE)
-      ->condition('vid', $vocabulary_machine_name);
+      ->condition('vid', $vocabulary);
 
     foreach ($conditions as $k => $v) {
       $and = $query->andConditionGroup();

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -76,13 +76,13 @@ trait UserTrait {
    *   Vertical format table with field names in first column.
    *
    * @code
-   *   Given the following users with fields:
+   *   Given the following users with fields exist:
    *     | name  | [TEST] user1         | [TEST] user2         |
    *     | mail  | user1@example.com    | user2@example.com    |
    *     | roles | editor               | author               |
    * @endcode
    */
-  #[Given('the following users with fields:')]
+  #[Given('the following users with fields exist:')]
   public function userCreateWithFields(TableNode $table): void {
     $entities = $this->helperTransposeVerticalTable($table);
     $horizontal_table = $this->helperBuildHorizontalTable($entities);
@@ -492,10 +492,10 @@ trait UserTrait {
    * Create a single role with specified permissions.
    *
    * @code
-   * Given the role "Content Manager" with the permissions "access content, create article content, edit any article content"
+   * Given the role "Content Manager" has the permissions "access content, create article content, edit any article content"
    * @endcode
    */
-  #[Given('the role :role_name with the permissions :permissions')]
+  #[Given('the role :role_name has the permissions :permissions')]
   public function userCreateRole(string $role_name, string $permissions): void {
     $permissions = $this->helperSplitCommaSeparated($permissions);
 
@@ -528,13 +528,13 @@ trait UserTrait {
    * Create multiple roles from the specified table.
    *
    * @code
-   * Given the following roles:
+   * Given the following roles exist:
    *   | name              | permissions                              |
    *   | Content Editor    | access content, create article content   |
    *   | Content Approver  | access content, edit any article content |
    * @endcode
    */
-  #[Given('the following roles:')]
+  #[Given('the following roles exist:')]
   public function userCreateRoles(TableNode $table): void {
     foreach ($table->getHash() as $hash) {
       if (!isset($hash['name'])) {

--- a/src/Drupal/WebformTrait.php
+++ b/src/Drupal/WebformTrait.php
@@ -52,10 +52,10 @@ trait WebformTrait {
    *   The title (or partial title) of the template to clone.
    *
    * @code
-   *   Given a webform "My contact form" from template "Contact"
+   *   Given the webform "My contact form" exists from the template "Contact"
    * @endcode
    */
-  #[Given('a webform :title from template :template')]
+  #[Given('the webform :title exists from the template :template')]
   public function webformCloneTemplate(string $title, string $template): void {
     $templates = $this->webformTemplates($template);
 

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -161,17 +161,17 @@ trait FieldTrait {
    * Then the field "field_body" should exist
    * @endcode
    */
-  #[Then('the field :name should exist')]
-  public function fieldAssertExists(string $name): NodeElement {
+  #[Then('the field :field should exist')]
+  public function fieldAssertExists(string $field): NodeElement {
     $page = $this->getSession()->getPage();
-    $field = $page->findField($name);
-    $field = $field ?: $page->findById($name);
+    $field_element = $page->findField($field);
+    $field_element = $field_element ?: $page->findById($field);
 
-    if ($field === NULL) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'form field', 'id|name|label|value', $name);
+    if ($field_element === NULL) {
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'form field', 'id|name|label|value', $field);
     }
 
-    return $field;
+    return $field_element;
   }
 
   /**
@@ -182,14 +182,14 @@ trait FieldTrait {
    * Then the field "field_body" should not exist
    * @endcode
    */
-  #[Then('the field :name should not exist')]
-  public function fieldAssertNotExists(string $name): void {
+  #[Then('the field :field should not exist')]
+  public function fieldAssertNotExists(string $field): void {
     $page = $this->getSession()->getPage();
-    $field = $page->findField($name);
-    $field = $field ?: $page->findById($name);
+    $field_element = $page->findField($field);
+    $field_element = $field_element ?: $page->findById($field);
 
-    if ($field !== NULL) {
-      throw new ExpectationException(sprintf('A field "%s" appears on this page, but it should not.', $name), $this->getSession()->getDriver());
+    if ($field_element !== NULL) {
+      throw new ExpectationException(sprintf('A field "%s" appears on this page, but it should not.', $field), $this->getSession()->getDriver());
     }
   }
 
@@ -197,22 +197,22 @@ trait FieldTrait {
    * Assert whether the field has a state.
    *
    * @code
-   * Then the field "Body" should have "disabled" state
-   * Then the field "field_body" should have "disabled" state
-   * Then the field "Tags" should have "enabled" state
-   * Then the field "field_tags" should have "not enabled" state
+   * Then the field "Body" should have the "disabled" state
+   * Then the field "field_body" should have the "disabled" state
+   * Then the field "Tags" should have the "enabled" state
+   * Then the field "field_tags" should have the "not enabled" state
    * @endcode
    */
-  #[Then('the field :name should have :enabled_or_disabled state')]
-  public function fieldAssertState(string $name, string $enabled_or_disabled): void {
-    $field = $this->fieldAssertExists($name);
+  #[Then('the field :field should have the :enabled_or_disabled state')]
+  public function fieldAssertState(string $field, string $enabled_or_disabled): void {
+    $field_element = $this->fieldAssertExists($field);
 
-    if ($enabled_or_disabled === 'disabled' && !$field->hasAttribute('disabled')) {
-      throw new ExpectationException(sprintf('A field "%s" should be disabled, but it is not.', $name), $this->getSession()->getDriver());
+    if ($enabled_or_disabled === 'disabled' && !$field_element->hasAttribute('disabled')) {
+      throw new ExpectationException(sprintf('A field "%s" should be disabled, but it is not.', $field), $this->getSession()->getDriver());
     }
 
-    if ($enabled_or_disabled !== 'disabled' && $field->hasAttribute('disabled')) {
-      throw new ExpectationException(sprintf('A field "%s" should not be disabled, but it is.', $name), $this->getSession()->getDriver());
+    if ($enabled_or_disabled !== 'disabled' && $field_element->hasAttribute('disabled')) {
+      throw new ExpectationException(sprintf('A field "%s" should not be disabled, but it is.', $field), $this->getSession()->getDriver());
     }
   }
 
@@ -513,10 +513,10 @@ JS;
    * fill it in. If used with webdriver - it will fill in the field as normal.
    *
    * @code
-   * When I fill in the WYSIWYG field "edit-body-0-value" with the "<p>This is a <strong>formatted</strong> paragraph.</p>"
+   * When I fill in the WYSIWYG field "edit-body-0-value" with the value "<p>This is a <strong>formatted</strong> paragraph.</p>"
    * @endcode
    */
-  #[When('I fill in the WYSIWYG field :field with the :value')]
+  #[When('I fill in the WYSIWYG field :field with the value :value')]
   public function fieldFillWysiwyg(string $field, string $value): void {
     $field = $this->helperFixStepArgument($field);
     $value = $this->helperFixStepArgument($value);
@@ -885,11 +885,11 @@ JS;
    * (e.g., dynamically generated fields in Paragraphs or Layout Builder).
    *
    * @code
-   * When I fill in the field ".field--name-body textarea" with "Hello world"
-   * When I fill in the field "#edit-field-custom-0-value" with "Test value"
+   * When I fill in the field ".field--name-body textarea" with the value "Hello world"
+   * When I fill in the field "#edit-field-custom-0-value" with the value "Test value"
    * @endcode
    */
-  #[When('I fill in the field :selector with :value')]
+  #[When('I fill in the field :selector with the value :value')]
   public function fieldFillField(string $selector, string $value): void {
     $field = $this->getSession()->getPage()->find('css', $selector);
 
@@ -907,13 +907,13 @@ JS;
    * automatically applied after each step when the form becomes available.
    *
    * @code
-   * Given browser validation for the form "#node-article-form" is disabled
+   * Given the browser validation for the form "#node-article-form" is disabled
    * When I go to "node/add/article"
    * And I press "Save"
    * Then I should see "Title field is required"
    * @endcode
    */
-  #[Given('browser validation for the form :selector is disabled')]
+  #[Given('the browser validation for the form :selector is disabled')]
   public function fieldDisableFormBrowserValidation(string $selector): void {
     if (!in_array($selector, $this->fieldFormValidationRegistry, TRUE)) {
       $this->fieldFormValidationRegistry[] = $selector;

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -228,14 +228,14 @@ trait FileDownloadTrait {
    * Then the downloaded file name should contain "report"
    * @endcode
    */
-  #[Then('the downloaded file name should contain :file_name_part')]
-  public function fileDownloadAssertFileNameContains(string $file_name_part): void {
+  #[Then('the downloaded file name should contain :partial_name')]
+  public function fileDownloadAssertFileNameContains(string $partial_name): void {
     if (!$this->fileDownloadDownloadedFileInfo || empty($this->fileDownloadDownloadedFileInfo['file_name'])) {
       throw new \RuntimeException('Downloaded file name content has no data.');
     }
 
-    if (!str_contains((string) $this->fileDownloadDownloadedFileInfo['file_name'], $file_name_part)) {
-      throw new ExpectationException(sprintf('Downloaded file name "%s" does not contain "%s".', $this->fileDownloadDownloadedFileInfo['file_name'], $file_name_part), $this->getSession()->getDriver());
+    if (!str_contains((string) $this->fileDownloadDownloadedFileInfo['file_name'], $partial_name)) {
+      throw new ExpectationException(sprintf('Downloaded file name "%s" does not contain "%s".', $this->fileDownloadDownloadedFileInfo['file_name'], $partial_name), $this->getSession()->getDriver());
     }
   }
 

--- a/src/IframeTrait.php
+++ b/src/IframeTrait.php
@@ -21,18 +21,18 @@ trait IframeTrait {
    * Handles unnamed iframes by auto-assigning a name via JavaScript.
    *
    * @code
-   * When I switch to iframe with locator "iframe.payment-form"
-   * When I switch to iframe with locator "#recaptcha iframe"
+   * When I switch to the iframe with the selector "iframe.payment-form"
+   * When I switch to the iframe with the selector "#recaptcha iframe"
    * @endcode
    *
    * @javascript
    */
-  #[When('I switch to iframe with locator :locator')]
-  public function iframeSwitchTo(string $locator): void {
-    $iframe = $this->getSession()->getPage()->find('css', $locator);
+  #[When('I switch to the iframe with the selector :selector')]
+  public function iframeSwitchTo(string $selector): void {
+    $iframe = $this->getSession()->getPage()->find('css', $selector);
 
     if ($iframe === NULL) {
-      throw new ElementNotFoundException($this->getSession()->getDriver(), 'iframe', 'css', $locator);
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'iframe', 'css', $selector);
     }
 
     $iframe_name = $iframe->getAttribute('name');
@@ -49,10 +49,10 @@ trait IframeTrait {
         })()"
       );
 
-      $iframe = $this->getSession()->getPage()->find('css', $locator);
+      $iframe = $this->getSession()->getPage()->find('css', $selector);
 
       if ($iframe === NULL) {
-        throw new ElementNotFoundException($this->getSession()->getDriver(), 'iframe', 'css', $locator);
+        throw new ElementNotFoundException($this->getSession()->getDriver(), 'iframe', 'css', $selector);
       }
 
       $iframe_name = $iframe->getAttribute('name');

--- a/src/JsonTrait.php
+++ b/src/JsonTrait.php
@@ -68,10 +68,10 @@ trait JsonTrait {
    * Set the response JSON content from a fixture file.
    *
    * @code
-   * Given the response JSON from the file "json_valid.json"
+   * Given the response JSON is loaded from the file "json_valid.json"
    * @endcode
    */
-  #[Given('the response JSON from the file :filename')]
+  #[Given('the response JSON is loaded from the file :filename')]
   public function jsonSetContentFromFile(string $filename): void {
     $this->jsonTestContent = $this->jsonReadFile($filename);
     $this->jsonData = NULL;
@@ -82,13 +82,13 @@ trait JsonTrait {
    * Set the response JSON content directly from a PyString.
    *
    * @code
-   * Given the response JSON content is the following:
+   * Given the response JSON is the following:
    *   """
    *   {"name": "John Doe", "roles": ["admin", "editor"]}
    *   """
    * @endcode
    */
-  #[Given('the response JSON content is the following:')]
+  #[Given('the response JSON is the following:')]
   public function jsonSetContent(PyStringNode $content): void {
     $this->jsonTestContent = $content->getRaw();
     $this->jsonData = NULL;
@@ -102,7 +102,7 @@ trait JsonTrait {
    * Then the response should be in JSON format
    *
    * # Content set by a fixture step is validated instead of the page content.
-   * Given the response JSON from the file "json_valid.json"
+   * Given the response JSON is loaded from the file "json_valid.json"
    * Then the response should be in JSON format
    * @endcode
    */

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -107,7 +107,7 @@ trait MetatagTrait {
    * Then the "description" meta tag should not contain any HTML tags
    * @endcode
    */
-  #[Then('the :metaName meta tag should not contain any HTML tags')]
+  #[Then('the :meta_name meta tag should not contain any HTML tags')]
   public function metatagAssertNoHtml(string $meta_name): void {
     $meta_tag = $this->metatagFindMeta($meta_name);
 

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -96,10 +96,10 @@ trait PathTrait {
    * A parameter carrying an empty string or "0" counts as absent.
    *
    * @code
-   * Then current url should have the "filter" parameter
+   * Then the current URL should have the "filter" parameter
    * @endcode
    */
-  #[Then('current url should have the :param parameter')]
+  #[Then('the current URL should have the :param parameter')]
   public function pathAssertUrlHasParameter(string $param): void {
     $query = $this->pathGetCurrentUrlQuery();
 
@@ -114,10 +114,10 @@ trait PathTrait {
    * A parameter carrying an empty string or "0" counts as absent.
    *
    * @code
-   * Then current url should have the "filter" parameter with the "recent" value
+   * Then the current URL should have the "filter" parameter with the value "recent"
    * @endcode
    */
-  #[Then('current url should have the :param parameter with the :value value')]
+  #[Then('the current URL should have the :param parameter with the value :value')]
   public function pathAssertUrlHasParameterWithValue(string $param, string $value): void {
     $this->pathAssertUrlHasParameter($param);
 
@@ -136,10 +136,10 @@ trait PathTrait {
    * A parameter carrying an empty string or "0" counts as absent.
    *
    * @code
-   * Then current url should not have the "filter" parameter
+   * Then the current URL should not have the "filter" parameter
    * @endcode
    */
-  #[Then('current url should not have the :param parameter')]
+  #[Then('the current URL should not have the :param parameter')]
   public function pathAssertUrlHasNoParameter(string $param): void {
     $query = $this->pathGetCurrentUrlQuery();
 
@@ -154,10 +154,10 @@ trait PathTrait {
    * A parameter carrying an empty string or "0" counts as absent.
    *
    * @code
-   * Then current url should not have the "filter" parameter with the "recent" value
+   * Then the current URL should not have the "filter" parameter with the value "recent"
    * @endcode
    */
-  #[Then('current url should not have the :param parameter with the :value value')]
+  #[Then('the current URL should not have the :param parameter with the value :value')]
   public function pathAssertUrlHasNoParameterWithValue(string $param, string $value): void {
     $query = $this->pathGetCurrentUrlQuery();
 
@@ -174,10 +174,10 @@ trait PathTrait {
    * Set basic authentication for the current session.
    *
    * @code
-   * Given the basic authentication with the username "myusername" and the password "mypassword"
+   * Given the basic authentication has the username "myusername" and the password "mypassword"
    * @endcode
    */
-  #[Given('the basic authentication with the username :username and the password :password')]
+  #[Given('the basic authentication has the username :username and the password :password')]
   public function pathSetBasicAuth(string $username, string $password): void {
     $this->getSession()->setBasicAuth($username, $password);
   }

--- a/src/ResponseTrait.php
+++ b/src/ResponseTrait.php
@@ -21,12 +21,12 @@ trait ResponseTrait {
    * Then the response should contain the header "Connection"
    * @endcode
    */
-  #[Then('the response should contain the header :header_name')]
-  public function responseAssertContainsHeader(string $header_name): void {
-    $header = $this->getSession()->getResponseHeader($header_name);
+  #[Then('the response should contain the header :name')]
+  public function responseAssertContainsHeader(string $name): void {
+    $header = $this->getSession()->getResponseHeader($name);
 
     if (!$header) {
-      throw new ExpectationException(sprintf('The response does not contain the header "%s".', $header_name), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The response does not contain the header "%s".', $name), $this->getSession()->getDriver());
     }
   }
 
@@ -37,12 +37,12 @@ trait ResponseTrait {
    * Then the response should not contain the header "Connection"
    * @endcode
    */
-  #[Then('the response should not contain the header :header_name')]
-  public function responseAssertNotContainsHeader(string $header_name): void {
-    $header = $this->getSession()->getResponseHeader($header_name);
+  #[Then('the response should not contain the header :name')]
+  public function responseAssertNotContainsHeader(string $name): void {
+    $header = $this->getSession()->getResponseHeader($name);
 
     if ($header) {
-      throw new ExpectationException(sprintf('The response contains the header "%s", but should not.', $header_name), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The response contains the header "%s", but should not.', $name), $this->getSession()->getDriver());
     }
   }
 
@@ -53,15 +53,15 @@ trait ResponseTrait {
    * Then the response header "Connection" should contain the value "Keep-Alive"
    * @endcode
    */
-  #[Then('the response header :header_name should contain the value :header_value')]
-  public function responseAssertHeaderContains(string $header_name, string $header_value): void {
-    $header = $this->getSession()->getResponseHeader($header_name);
+  #[Then('the response header :name should contain the value :value')]
+  public function responseAssertHeaderContains(string $name, string $value): void {
+    $header = $this->getSession()->getResponseHeader($name);
 
     if (!$header) {
-      throw new ExpectationException(sprintf('The response does not contain the header "%s".', $header_name), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The response does not contain the header "%s".', $name), $this->getSession()->getDriver());
     }
 
-    $this->assertSession()->responseHeaderContains($header_name, $header_value);
+    $this->assertSession()->responseHeaderContains($name, $value);
   }
 
   /**
@@ -71,15 +71,15 @@ trait ResponseTrait {
    * Then the response header "Connection" should not contain the value "Keep-Alive"
    * @endcode
    */
-  #[Then('the response header :header_name should not contain the value :header_value')]
-  public function responseAssertHeaderNotContains(string $header_name, string $header_value): void {
-    $header = $this->getSession()->getResponseHeader($header_name);
+  #[Then('the response header :name should not contain the value :value')]
+  public function responseAssertHeaderNotContains(string $name, string $value): void {
+    $header = $this->getSession()->getResponseHeader($name);
 
     if (!$header) {
-      throw new ExpectationException(sprintf('The response does not contain the header "%s".', $header_name), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf('The response does not contain the header "%s".', $name), $this->getSession()->getDriver());
     }
 
-    $this->assertSession()->responseHeaderNotContains($header_name, $header_value);
+    $this->assertSession()->responseHeaderNotContains($name, $value);
   }
 
 }

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -108,13 +108,13 @@ trait ResponsiveTrait {
    * Set custom responsive breakpoints from a table.
    *
    * @code
-   * Given the following responsive breakpoints:
+   * Given the following responsive breakpoints exist:
    *   | name       | dimensions |
    *   | iphone_12  | 390x844    |
    *   | 4k_display | 3840x2160  |
    * @endcode
    */
-  #[Given('the following responsive breakpoints:')]
+  #[Given('the following responsive breakpoints exist:')]
   public function responsiveSetBreakpointsFromTable(TableNode $table): void {
     $breakpoints = [];
     foreach ($table->getHash() as $row) {

--- a/src/RestTrait.php
+++ b/src/RestTrait.php
@@ -47,11 +47,11 @@ trait RestTrait {
    * Set a REST header for subsequent requests.
    *
    * @code
-   * Given a REST header "Accept" with value "application/json"
-   * Given a REST header "Authorization" with value "Bearer abc123"
+   * Given the REST header "Accept" has the value "application/json"
+   * Given the REST header "Authorization" has the value "Bearer abc123"
    * @endcode
    */
-  #[Given('a REST header :name with value :value')]
+  #[Given('the REST header :name has the value :value')]
   public function restSetHeader(string $name, string $value): void {
     $this->restHeaders[$name] = $value;
   }

--- a/src/TableTrait.php
+++ b/src/TableTrait.php
@@ -206,7 +206,7 @@ trait TableTrait {
    *   | admin     |
    * @endcode
    */
-  #[Then('the :rowText row should contain the following:')]
+  #[Then('the :row_text row should contain the following:')]
   public function tableAssertMultipleTextsInRow(string $row_text, TableNode $table): void {
     $row = $this->tableFindRowByText($row_text);
 

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -75,10 +75,10 @@ trait XmlTrait {
    * Set the response XML content from a fixture file.
    *
    * @code
-   * Given the response content from the file "xml_valid.xml"
+   * Given the response XML is loaded from the file "xml_valid.xml"
    * @endcode
    */
-  #[Given('the response content from the file :filename')]
+  #[Given('the response XML is loaded from the file :filename')]
   public function xmlSetResponseContentFromFile(string $filename): void {
     $this->xmlTestContent = $this->xmlReadFile($filename);
     $this->xmlDocument = NULL;
@@ -90,13 +90,13 @@ trait XmlTrait {
    * Set the response XML content directly from a PyString.
    *
    * @code
-   * Given the response content is the following:
+   * Given the response XML is the following:
    *   """
    *   <?xml version="1.0"?><root><item>value</item></root>
    *   """
    * @endcode
    */
-  #[Given('the response content is the following:')]
+  #[Given('the response XML is the following:')]
   public function xmlSetResponseContentDirect(PyStringNode $content): void {
     $this->xmlTestContent = $content->getRaw();
     $this->xmlDocument = NULL;
@@ -111,7 +111,7 @@ trait XmlTrait {
    * Then the response should be in XML format
    *
    * # Content set by a fixture step is validated instead of the page content.
-   * Given the response content from the file "xml_valid.xml"
+   * Given the response XML is loaded from the file "xml_valid.xml"
    * Then the response should be in XML format
    * @endcode
    */
@@ -127,7 +127,7 @@ trait XmlTrait {
    * Then the response should not be in XML format
    *
    * # Content set by a fixture step is validated instead of the page content.
-   * Given the response content from the file "xml_invalid.xml"
+   * Given the response XML is loaded from the file "xml_invalid.xml"
    * Then the response should not be in XML format
    * @endcode
    */
@@ -191,8 +191,8 @@ trait XmlTrait {
    * Then the XML element "/library/book[1]/author" should be equal to "John Doe"
    * @endcode
    */
-  #[Then('the XML element :element should be equal to :text')]
-  public function xmlAssertElementEquals(string $element, string $text): void {
+  #[Then('the XML element :element should be equal to :value')]
+  public function xmlAssertElementEquals(string $element, string $value): void {
     $this->xmlEnsureDocument();
 
     $nodes = $this->xmlXpath->query($element);
@@ -208,8 +208,8 @@ trait XmlTrait {
     }
 
     $actual_text = trim($node->textContent);
-    if ($actual_text !== $text) {
-      throw new ExpectationException(sprintf('The XML element "%s" content is "%s", but expected "%s".', $element, $actual_text, $text), $this->getSession()->getDriver());
+    if ($actual_text !== $value) {
+      throw new ExpectationException(sprintf('The XML element "%s" content is "%s", but expected "%s".', $element, $actual_text, $value), $this->getSession()->getDriver());
     }
   }
 
@@ -221,8 +221,8 @@ trait XmlTrait {
    * Then the XML element "/library/book[1]/author" should not be equal to "Wrong Author"
    * @endcode
    */
-  #[Then('the XML element :element should not be equal to :text')]
-  public function xmlAssertElementNotEquals(string $element, string $text): void {
+  #[Then('the XML element :element should not be equal to :value')]
+  public function xmlAssertElementNotEquals(string $element, string $value): void {
     $this->xmlEnsureDocument();
 
     $nodes = $this->xmlXpath->query($element);
@@ -238,7 +238,7 @@ trait XmlTrait {
     }
 
     $actual_text = trim($node->textContent);
-    if ($actual_text === $text) {
+    if ($actual_text === $value) {
       throw new ExpectationException(sprintf('The XML element "%s" content is "%s", but it should not be.', $element, $actual_text), $this->getSession()->getDriver());
     }
   }
@@ -251,8 +251,8 @@ trait XmlTrait {
    * Then the XML element "/library/book[1]/description" should contain "detailed"
    * @endcode
    */
-  #[Then('the XML element :element should contain :text')]
-  public function xmlAssertElementContains(string $element, string $text): void {
+  #[Then('the XML element :element should contain :value')]
+  public function xmlAssertElementContains(string $element, string $value): void {
     $this->xmlEnsureDocument();
 
     $nodes = $this->xmlXpath->query($element);
@@ -268,8 +268,8 @@ trait XmlTrait {
     }
 
     $actual_text = $node->textContent;
-    if (!str_contains($actual_text, $text)) {
-      throw new ExpectationException(sprintf('The XML element "%s" does not contain "%s". Actual content: "%s".', $element, $text, trim($actual_text)), $this->getSession()->getDriver());
+    if (!str_contains($actual_text, $value)) {
+      throw new ExpectationException(sprintf('The XML element "%s" does not contain "%s". Actual content: "%s".', $element, $value, trim($actual_text)), $this->getSession()->getDriver());
     }
   }
 
@@ -281,8 +281,8 @@ trait XmlTrait {
    * Then the XML element "/library/book[1]/title" should not contain "wrong"
    * @endcode
    */
-  #[Then('the XML element :element should not contain :text')]
-  public function xmlAssertElementNotContains(string $element, string $text): void {
+  #[Then('the XML element :element should not contain :value')]
+  public function xmlAssertElementNotContains(string $element, string $value): void {
     $this->xmlEnsureDocument();
 
     $nodes = $this->xmlXpath->query($element);
@@ -298,8 +298,8 @@ trait XmlTrait {
     }
 
     $actual_text = $node->textContent;
-    if (str_contains($actual_text, $text)) {
-      throw new ExpectationException(sprintf('The XML element "%s" contains "%s", but it should not.', $element, $text), $this->getSession()->getDriver());
+    if (str_contains($actual_text, $value)) {
+      throw new ExpectationException(sprintf('The XML element "%s" contains "%s", but it should not.', $element, $value), $this->getSession()->getDriver());
     }
   }
 
@@ -357,8 +357,8 @@ trait XmlTrait {
    * Then the XML attribute "category" on element "/library/book[1]" should be equal to "fiction"
    * @endcode
    */
-  #[Then('the XML attribute :attribute on element :element should be equal to :text')]
-  public function xmlAssertAttributeEquals(string $attribute, string $element, string $text): void {
+  #[Then('the XML attribute :attribute on element :element should be equal to :value')]
+  public function xmlAssertAttributeEquals(string $attribute, string $element, string $value): void {
     $this->xmlEnsureDocument();
 
     $nodes = $this->xmlXpath->query($element);
@@ -372,8 +372,8 @@ trait XmlTrait {
     }
 
     $actual_value = $node->getAttribute($attribute);
-    if ($actual_value !== $text) {
-      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" is "%s", but expected "%s".', $attribute, $element, $actual_value, $text), $this->getSession()->getDriver());
+    if ($actual_value !== $value) {
+      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" is "%s", but expected "%s".', $attribute, $element, $actual_value, $value), $this->getSession()->getDriver());
     }
   }
 
@@ -385,8 +385,8 @@ trait XmlTrait {
    * Then the XML attribute "category" on element "/library/book[1]" should not be equal to "science"
    * @endcode
    */
-  #[Then('the XML attribute :attribute on element :element should not be equal to :text')]
-  public function xmlAssertAttributeNotEquals(string $attribute, string $element, string $text): void {
+  #[Then('the XML attribute :attribute on element :element should not be equal to :value')]
+  public function xmlAssertAttributeNotEquals(string $attribute, string $element, string $value): void {
     $this->xmlEnsureDocument();
 
     $nodes = $this->xmlXpath->query($element);
@@ -400,7 +400,7 @@ trait XmlTrait {
     }
 
     $actual_value = $node->getAttribute($attribute);
-    if ($actual_value === $text) {
+    if ($actual_value === $value) {
       throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" is "%s", but it should not be.', $attribute, $element, $actual_value), $this->getSession()->getDriver());
     }
   }
@@ -413,8 +413,8 @@ trait XmlTrait {
    * Then the XML attribute "id" on element "/library/book[1]" should contain "12"
    * @endcode
    */
-  #[Then('the XML attribute :attribute_name on element :element should contain :text')]
-  public function xmlAssertAttributeContains(string $attribute_name, string $element, string $text): void {
+  #[Then('the XML attribute :attribute on element :element should contain :value')]
+  public function xmlAssertAttributeContains(string $attribute, string $element, string $value): void {
     $this->xmlEnsureDocument();
 
     $nodes = $this->xmlXpath->query($element);
@@ -423,13 +423,13 @@ trait XmlTrait {
     }
 
     $node = $nodes->item(0);
-    if (!$node instanceof \DOMElement || !$node->hasAttribute($attribute_name)) {
-      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" was not found.', $attribute_name, $element), $this->getSession()->getDriver());
+    if (!$node instanceof \DOMElement || !$node->hasAttribute($attribute)) {
+      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" was not found.', $attribute, $element), $this->getSession()->getDriver());
     }
 
-    $actual_value = $node->getAttribute($attribute_name);
-    if (!str_contains($actual_value, $text)) {
-      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" does not contain "%s". Actual value: "%s".', $attribute_name, $element, $text, $actual_value), $this->getSession()->getDriver());
+    $actual_value = $node->getAttribute($attribute);
+    if (!str_contains($actual_value, $value)) {
+      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" does not contain "%s". Actual value: "%s".', $attribute, $element, $value, $actual_value), $this->getSession()->getDriver());
     }
   }
 
@@ -441,8 +441,8 @@ trait XmlTrait {
    * Then the XML attribute "id" on element "/library/book[1]" should not contain "999"
    * @endcode
    */
-  #[Then('the XML attribute :attribute_name on element :element should not contain :text')]
-  public function xmlAssertAttributeNotContains(string $attribute_name, string $element, string $text): void {
+  #[Then('the XML attribute :attribute on element :element should not contain :value')]
+  public function xmlAssertAttributeNotContains(string $attribute, string $element, string $value): void {
     $this->xmlEnsureDocument();
 
     $nodes = $this->xmlXpath->query($element);
@@ -451,13 +451,13 @@ trait XmlTrait {
     }
 
     $node = $nodes->item(0);
-    if (!$node instanceof \DOMElement || !$node->hasAttribute($attribute_name)) {
-      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" was not found.', $attribute_name, $element), $this->getSession()->getDriver());
+    if (!$node instanceof \DOMElement || !$node->hasAttribute($attribute)) {
+      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" was not found.', $attribute, $element), $this->getSession()->getDriver());
     }
 
-    $actual_value = $node->getAttribute($attribute_name);
-    if (str_contains($actual_value, $text)) {
-      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" contains "%s", but it should not.', $attribute_name, $element, $text), $this->getSession()->getDriver());
+    $actual_value = $node->getAttribute($attribute);
+    if (str_contains($actual_value, $value)) {
+      throw new ExpectationException(sprintf('The XML attribute "%s" on element "%s" contains "%s", but it should not.', $attribute, $element, $value), $this->getSession()->getDriver());
     }
   }
 

--- a/tests/behat/features/drupal_cache.feature
+++ b/tests/behat/features/drupal_cache.feature
@@ -4,23 +4,23 @@ Feature: Check that CacheTrait works
   So that users can clear specific caches in their tests without a full rebuild
 
   @api
-  Scenario: Assert "Given the page cache for the path :path has been cleared" clears a single path
+  Scenario: Assert "Given the page cache for the path :path is empty" clears a single path
     Given I am logged in as a user with the "administrator" role
-    And the page cache for the path "/user" has been cleared
+    And the page cache for the path "/user" is empty
     When I go to "/user"
     Then I should see "Member for"
 
   @api
-  Scenario: Assert "Given the page cache for the paths matching :path_pattern has been cleared" clears matching paths
+  Scenario: Assert "Given the page cache for the paths matching :path_pattern is empty" clears matching paths
     Given I am logged in as a user with the "administrator" role
-    And the page cache for the paths matching "/user*" has been cleared
+    And the page cache for the paths matching "/user*" is empty
     When I go to "/user"
     Then I should see "Member for"
 
   @api
-  Scenario: Assert "Given the render cache has been cleared" clears the render cache
+  Scenario: Assert "Given the render cache is empty" clears the render cache
     Given I am logged in as a user with the "administrator" role
-    And the render cache has been cleared
+    And the render cache is empty
     When I go to "/user"
     Then I should see "Member for"
 
@@ -30,7 +30,7 @@ Feature: Check that CacheTrait works
     And scenario steps:
       """
       Given I go to "/"
-      And the page cache for the path "" has been cleared
+      And the page cache for the path "" is empty
       """
     When I run "behat --no-colors"
     Then it should fail with a "InvalidArgumentException" exception:
@@ -44,7 +44,7 @@ Feature: Check that CacheTrait works
     And scenario steps:
       """
       Given I go to "/"
-      And the page cache for the path "about" has been cleared
+      And the page cache for the path "about" is empty
       """
     When I run "behat --no-colors"
     Then it should fail with a "InvalidArgumentException" exception:
@@ -58,7 +58,7 @@ Feature: Check that CacheTrait works
     And scenario steps:
       """
       Given I go to "/"
-      And the page cache for the paths matching "" has been cleared
+      And the page cache for the paths matching "" is empty
       """
     When I run "behat --no-colors"
     Then it should fail with a "InvalidArgumentException" exception:
@@ -72,7 +72,7 @@ Feature: Check that CacheTrait works
     And scenario steps:
       """
       Given I go to "/"
-      And the page cache for the paths matching "news/*" has been cleared
+      And the page cache for the paths matching "news/*" is empty
       """
     When I run "behat --no-colors"
     Then it should fail with a "InvalidArgumentException" exception:

--- a/tests/behat/features/drupal_config.feature
+++ b/tests/behat/features/drupal_config.feature
@@ -16,7 +16,7 @@ Feature: Check that ConfigTrait works
 
   @api
   Scenario: Set multiple config values of different types from a table
-    Given the following config values:
+    Given the following config values exist:
       | name                   | key      | value           |
       | behat_steps_test.types | enabled  | true            |
       | behat_steps_test.types | disabled | false           |
@@ -49,7 +49,7 @@ Feature: Check that ConfigTrait works
 
   @api
   Scenario: Assert stored array membership and its negation
-    Given the following config values:
+    Given the following config values exist:
       | name                 | key   | value                 |
       | behat_steps_test.arr | roles | ["editor","reviewer"] |
     Then the config "behat_steps_test.arr" key "roles" should contain the value "editor"
@@ -203,7 +203,7 @@ Feature: Check that ConfigTrait works
     And scenario steps:
       """
       Given I go to "/"
-      And the following config values:
+      And the following config values exist:
         | name                      | key    |
         | behat_steps_test.settings | broken |
       """

--- a/tests/behat/features/drupal_content.feature
+++ b/tests/behat/features/drupal_content.feature
@@ -279,7 +279,7 @@ Feature: Check that ContentTrait works
   @api
   Scenario: Create single node with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following page content with fields:
+    And the following page content with fields exist:
       | title  | [TEST] Vertical Page    |
       | body   | Vertical format content |
       | status | 1                       |
@@ -289,7 +289,7 @@ Feature: Check that ContentTrait works
   @api
   Scenario: Create multiple nodes with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following page content with fields:
+    And the following page content with fields exist:
       | title  | [TEST] V-Page 1    | [TEST] V-Page 2     | [TEST] V-Page 3    |
       | body   | First page content | Second page content | Third page content |
       | status | 1                  | 1                   | 1                  |

--- a/tests/behat/features/drupal_content_block.feature
+++ b/tests/behat/features/drupal_content_block.feature
@@ -185,7 +185,7 @@ Feature: Check that ContentBlockTrait works
   @api
   Scenario: Create single content block with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following basic content blocks with fields:
+    And the following basic content blocks with fields exist:
       | info   | [TEST] Vertical Block        |
       | body   | Created with vertical format |
       | status | 1                            |
@@ -197,7 +197,7 @@ Feature: Check that ContentBlockTrait works
   @api
   Scenario: Create multiple content blocks with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following basic content blocks with fields:
+    And the following basic content blocks with fields exist:
       | info   | [TEST] Vertical Block 1 | [TEST] Vertical Block 2 | [TEST] Vertical Block 3 |
       | body   | First vertical block    | Second vertical block   | Third vertical block    |
       | status | 1                       | 1                       | 1                       |

--- a/tests/behat/features/drupal_draggableviews.feature
+++ b/tests/behat/features/drupal_draggableviews.feature
@@ -33,7 +33,7 @@ Feature: Check that DraggableviewsTrait works
     And the ".view-draggableviews-demo .views-row:nth-child(2) .views-field-title" element should contain "Test 1"
 
   @trait:Drupal\DraggableviewsTrait
-  Scenario: Assert that negative assertion for "When I save the draggable views items of the view :view_id and the display :views_display_id for the :bundle content in the following order:" step throws an exception
+  Scenario: Assert that negative assertion for "When I save the draggable views items of the view :view_id and the display :view_display_id for the :content_type content in the following order:" step throws an exception
     Given some behat configuration
     And scenario steps:
       """

--- a/tests/behat/features/drupal_email.feature
+++ b/tests/behat/features/drupal_email.feature
@@ -12,7 +12,7 @@ Feature: Check that EmailTrait works
       Line two of the test email content
       Line three of the test email content
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the email field "body" should contain:
       """
       Line two of the test email content
@@ -27,7 +27,7 @@ Feature: Check that EmailTrait works
       Line two of the test email content
       Line three   with   tabs and    spaces
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the email field "body" should contain:
       """
       Line two of the test email content
@@ -62,9 +62,9 @@ Feature: Check that EmailTrait works
       Line two of the test email content
       Line three of the test email content
       """
-    Then an email should be sent to the "test@example.com"
-    And an email should be sent to the "test@example.com"
-    And no emails should have been sent to the "test3@example.com"
+    Then an email should be sent to the address "test@example.com"
+    And an email should be sent to the address "test@example.com"
+    And no emails should have been sent to the address "test3@example.com"
     And the email header "Content-Type" should contain:
       """
       text/plain
@@ -82,7 +82,7 @@ Feature: Check that EmailTrait works
       Test email content line two
       Test email content line three
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the email header "Content-Type" should exactly be:
       """
       text/plain; charset=utf-8; format=flowed; delsp=yes
@@ -169,7 +169,7 @@ Feature: Check that EmailTrait works
       Line two of the test email content
       Line three of the test email content
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the email field "body" should contain:
       """
       Line two of the test email content
@@ -188,7 +188,7 @@ Feature: Check that EmailTrait works
       Line two of the test email content
       Line three of the test email content
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the email field "body" should contain:
       """
       Line two of the test email content
@@ -212,7 +212,7 @@ Feature: Check that EmailTrait works
       "<content>"
       Line two of the test email content
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
 
     And I follow link number "<number>" in the email with the subject "Test Email"
     Then the response status code should be 200
@@ -232,7 +232,7 @@ Feature: Check that EmailTrait works
       """
       Here is your link: http://example.com/reset-password
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     When I follow link number 1 in the email with the subject containing "Test Email"
     Then I should be on "http://example.com/reset-password"
 
@@ -245,7 +245,7 @@ Feature: Check that EmailTrait works
       "<content>"
       Line two of the test email content
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
 
     When I clear the test email system queue
     Then no emails should have been sent
@@ -260,7 +260,7 @@ Feature: Check that EmailTrait works
       Test email content line two
       Test email content line three
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the email field "body" should contain:
       """
       Test email content line two
@@ -288,7 +288,7 @@ Feature: Check that EmailTrait works
       """
       This email contains an attachment.
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the email field "subject" should be:
       """
       Email with Attachment
@@ -301,7 +301,7 @@ Feature: Check that EmailTrait works
       """
       This email contains an attachment.
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the file "example.pdf" should be attached to the email with the subject containing "with Attachment"
 
   @api @email
@@ -311,7 +311,7 @@ Feature: Check that EmailTrait works
       """
       Test content
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
 
   @api @email
   Scenario: As a developer, I want to verify no emails sent to address assertion passes when address not used
@@ -319,7 +319,7 @@ Feature: Check that EmailTrait works
       """
       Test content
       """
-    Then no emails should have been sent to the "wrong@example.com"
+    Then no emails should have been sent to the address "wrong@example.com"
 
   @api @email
   Scenario: As a developer, I want to verify no emails sent to CC address assertion passes when address not used
@@ -327,7 +327,7 @@ Feature: Check that EmailTrait works
       """
       Test content with CC
       """
-    Then no emails should have been sent to the "wrong@example.com"
+    Then no emails should have been sent to the address "wrong@example.com"
 
   @api @email
   Scenario: As a developer, I want to verify no emails sent to BCC address assertion passes when address not used
@@ -335,7 +335,7 @@ Feature: Check that EmailTrait works
       """
       Test content with BCC
       """
-    Then no emails should have been sent to the "wrong@example.com"
+    Then no emails should have been sent to the address "wrong@example.com"
 
   @api @email @debug
   Scenario: As a developer, I want to verify email debug output is triggered with @debug tag
@@ -343,7 +343,7 @@ Feature: Check that EmailTrait works
       """
       Debug test content
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the email field "body" should contain:
       """
       Debug test content
@@ -355,7 +355,7 @@ Feature: Check that EmailTrait works
     And scenario steps tagged with "@api @email":
       """
       Given I am logged in as a user with the "administrator" role
-      Then an email should be sent to the "test@example.com"
+      Then an email should be sent to the address "test@example.com"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -385,7 +385,7 @@ Feature: Check that EmailTrait works
         '''
         Test content with CC
         '''
-      Then no emails should have been sent to the "cc@example.com"
+      Then no emails should have been sent to the address "cc@example.com"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -402,7 +402,7 @@ Feature: Check that EmailTrait works
         '''
         Test content with BCC
         '''
-      Then no emails should have been sent to the "bcc@example.com"
+      Then no emails should have been sent to the address "bcc@example.com"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -577,7 +577,7 @@ Feature: Check that EmailTrait works
         '''
         Test content
         '''
-      Then no emails should have been sent to the "test@example.com"
+      Then no emails should have been sent to the address "test@example.com"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -722,7 +722,7 @@ Feature: Check that EmailTrait works
         '''
         Test content
         '''
-      Then an email should be sent to the "test@example.com"
+      Then an email should be sent to the address "test@example.com"
       When I disable the test email system
       """
     When I run "behat --no-colors"
@@ -737,7 +737,7 @@ Feature: Check that EmailTrait works
         '''
         Test content
         '''
-      Then an email should be sent to the "test@example.com"
+      Then an email should be sent to the address "test@example.com"
       """
     When I run "behat --no-colors"
     Then it should pass
@@ -748,7 +748,7 @@ Feature: Check that EmailTrait works
       """
       Test content with custom handler type
       """
-    Then an email should be sent to the "test@example.com"
+    Then an email should be sent to the address "test@example.com"
     And the email field "body" should contain:
       """
       Test content with custom handler type

--- a/tests/behat/features/drupal_file.feature
+++ b/tests/behat/features/drupal_file.feature
@@ -4,14 +4,14 @@ Feature: Check that FileTrait works
   So that users can test file functionality and operations
 
   @api
-  Scenario: Assert "When the following managed files:"
+  Scenario: Assert "When the following managed files exist:"
     Given I am logged in as a user with the "administrator" role
-    When the following managed files:
+    When the following managed files exist:
       | path         |
       | document.pdf |
       | image.png    |
       | audio.mp3    |
-    And the following managed files:
+    And the following managed files exist:
       | uuid                                 | path     |
       | 9cb1b484-db7b-4496-bd63-8c702e207704 | text.txt |
     Then "document.pdf" file object exists
@@ -21,20 +21,20 @@ Feature: Check that FileTrait works
     And "file" entity exists with UUID "9cb1b484-db7b-4496-bd63-8c702e207704"
 
   @api
-  Scenario: Assert "When the following managed files: With subdirectory path"
+  Scenario: Assert "When the following managed files exist: With subdirectory path"
     Given I am logged in as a user with the "administrator" role
-    When the following managed files:
+    When the following managed files exist:
       | path                  |
       | subdir/document.pdf   |
     Then "document.pdf" file object exists
 
   @api
-  Scenario: Assert "When the following managed files: With uri"
+  Scenario: Assert "When the following managed files exist: With uri"
     Given I am logged in as a user with the "administrator" role
     And no "document.pdf" file object exists
     And no "image.png" file object exists
     And no "audio.mp3" file object exists
-    When the following managed files:
+    When the following managed files exist:
       | path         | uri                        |
       | document.pdf | public://test/document.pdf |
       | image.png    | public://test/image.png    |
@@ -46,7 +46,7 @@ Feature: Check that FileTrait works
   @api
   Scenario: Assert "When the following managed files do not exist: With filename"
     Given I am logged in as a user with the "administrator" role
-    When the following managed files:
+    When the following managed files exist:
       | path         |
       | document.pdf |
       | image.png    |
@@ -66,7 +66,7 @@ Feature: Check that FileTrait works
   @api
   Scenario: Assert "When the following managed files do not exist: With uri"
     Given I am logged in as a user with the "administrator" role
-    When the following managed files:
+    When the following managed files exist:
       | path         |
       | document.pdf |
       | image.png    |
@@ -86,7 +86,7 @@ Feature: Check that FileTrait works
   @api
   Scenario: Assert "When the following managed files do not exist: With status"
     Given I am logged in as a user with the "administrator" role
-    When the following managed files:
+    When the following managed files exist:
       | path         |
       | document.pdf |
       | image.png    |
@@ -104,7 +104,7 @@ Feature: Check that FileTrait works
   @api
   Scenario: Assert "When the following managed files do not exist: With filemime"
     Given I am logged in as a user with the "administrator" role
-    When the following managed files:
+    When the following managed files exist:
       | path         |
       | document.pdf |
       | image.png    |
@@ -127,14 +127,14 @@ Feature: Check that FileTrait works
     And an unmanaged file at the URI "public://test2.txt" should not exist
 
     Given an unmanaged file at the URI "public://test3.txt" should not exist
-    When the unmanaged file at the URI "public://test3.txt" exists with "test content"
+    When the unmanaged file at the URI "public://test3.txt" exists with the content "test content"
     Then an unmanaged file at the URI "public://test3.txt" should exist
     And an unmanaged file at the URI "public://test3.txt" should contain "test content"
     And an unmanaged file at the URI "public://test3.txt" should contain "content"
     And an unmanaged file at the URI "public://test3.txt" should not contain "test more content"
 
     Given an unmanaged file at the URI "public://test-random/test4.txt" should not exist
-    When the unmanaged file at the URI "public://test-random/test4.txt" exists with "test content"
+    When the unmanaged file at the URI "public://test-random/test4.txt" exists with the content "test content"
     Then an unmanaged file at the URI "public://test-random/test4.txt" should exist
 
   @trait:Drupal\FileTrait
@@ -169,7 +169,7 @@ Feature: Check that FileTrait works
     Given some behat configuration
     And scenario steps:
       """
-      Given the unmanaged file at the URI "public://test1.txt" exists with "test content"
+      Given the unmanaged file at the URI "public://test1.txt" exists with the content "test content"
       Then an unmanaged file at the URI "public://test1.txt" should exist
       And an unmanaged file at the URI "public://test1.txt" should contain "test other content"
       """
@@ -184,7 +184,7 @@ Feature: Check that FileTrait works
     Given some behat configuration
     And scenario steps:
       """
-      Given the unmanaged file at the URI "public://test1.txt" exists with "test content"
+      Given the unmanaged file at the URI "public://test1.txt" exists with the content "test content"
       Then an unmanaged file at the URI "public://test1.txt" should exist
       And an unmanaged file at the URI "public://test1.txt" should not contain "test content"
       """

--- a/tests/behat/features/drupal_media.feature
+++ b/tests/behat/features/drupal_media.feature
@@ -5,24 +5,24 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert "When I attach the file :file to :field_name media field"
-    Given the following managed files:
+    Given the following managed files exist:
       | path         |
       | document.pdf |
 
-    When the following media "image" do not exist:
+    When the following "image" media do not exist:
       | name             | field_media_image |
       | Test media image | image.png         |
 
-    And the following media "image" exist:
+    And the following "image" media exist:
       | name              | field_media_image |
       | Test media image  | image.png         |
       | Test media image2 | image.png         |
 
-    And the following media "image" do not exist:
+    And the following "image" media do not exist:
       | name              |
       | Test media image2 |
 
-    And the following media "document" exist:
+    And the following "document" media exist:
       | name                | field_media_document |
       | Test media document | document.pdf         |
 
@@ -34,23 +34,23 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert navigate to edit media with specified type and name
-    Given the following managed files:
+    Given the following managed files exist:
       | path         |
       | document.pdf |
-    And the following media "document" exist:
+    And the following "document" media exist:
       | name                | field_media_document |
       | Test media document | document.pdf         |
     And I am logged in as a user with the "administrator" role
-    When I edit the media "document" with the name "Test media document"
+    When I edit the "document" media with the name "Test media document"
     Then I should see "Edit Document Test media document"
 
   @api
   Scenario: Assert media file field resolves a fixture path in a subdirectory
-    Given the following media "document" exist:
+    Given the following "document" media exist:
       | name                      | field_media_document |
       | Test subdirectory media   | subdir/document.pdf  |
     And I am logged in as a user with the "administrator" role
-    When I edit the media "document" with the name "Test subdirectory media"
+    When I edit the "document" media with the name "Test subdirectory media"
     Then I should see "Edit Document Test subdirectory media"
     And the response should contain ".pdf"
 
@@ -65,17 +65,17 @@ Feature: Check that MediaTrait works
     And I press "Save"
     When I visit "/admin/structure/media"
     Then I should see "test_media_type"
-    When "test_media_type" media type does not exist
+    When the media type "test_media_type" does not exist
     And I visit "/admin/structure/media"
     Then I should not see "test_media_type"
 
   @api @trait:Drupal\MediaTrait
-  Scenario: Assert that negative assertion for "When I edit the media :media_type with the name :name" fails with an error
+  Scenario: Assert that negative assertion for "When I edit the :media_type media with the name :name" fails with an error
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I edit the media "document" with the name "Non-existent media"
+      When I edit the "document" media with the name "Non-existent media"
       """
     When I run "behat --no-colors"
     Then it should fail with a "RuntimeException" exception:
@@ -85,12 +85,12 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert that mediaCreate() deletes existing media before creating
-    Given the following managed files:
+    Given the following managed files exist:
       | path      |
       | image.png |
 
     # Create initial media
-    And the following media "image" exist:
+    And the following "image" media exist:
       | name                | field_media_image |
       | Duplicate test item | image.png         |
 
@@ -99,7 +99,7 @@ Feature: Check that MediaTrait works
     Then I should see the text "Duplicate test item"
 
     # Create media again with the same name - should replace the first one
-    When the following media "image" exist:
+    When the following "image" media exist:
       | name                | field_media_image |
       | Duplicate test item | image.png         |
 
@@ -111,10 +111,10 @@ Feature: Check that MediaTrait works
   @api
   Scenario: Create single media with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following managed files:
+    And the following managed files exist:
       | path      |
       | image.png |
-    And the following image media with fields:
+    And the following image media with fields exist:
       | name              | [TEST] Vertical Image |
       | field_media_image | image.png             |
     When I go to "/admin/content/media"
@@ -123,10 +123,10 @@ Feature: Check that MediaTrait works
   @api
   Scenario: Create multiple media with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following managed files:
+    And the following managed files exist:
       | path      |
       | image.png |
-    And the following image media with fields:
+    And the following image media with fields exist:
       | name              | [TEST] V-Image 1 | [TEST] V-Image 2 | [TEST] V-Image 3 |
       | field_media_image | image.png        | image.png        | image.png        |
     When I go to "/admin/content/media"
@@ -136,16 +136,16 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert that mediaCreateWithFields() deletes existing media before creating
-    Given the following managed files:
+    Given the following managed files exist:
       | path      |
       | image.png |
-    And the following image media with fields:
+    And the following image media with fields exist:
       | name              | [TEST] Duplicate vertical |
       | field_media_image | image.png                 |
     And I am logged in as a user with the "administrator" role
     And I visit "/admin/content/media"
     Then I should see the text "[TEST] Duplicate vertical"
-    When the following image media with fields:
+    When the following image media with fields exist:
       | name              | [TEST] Duplicate vertical |
       | field_media_image | image.png                 |
     And I visit "/admin/content/media"
@@ -153,24 +153,24 @@ Feature: Check that MediaTrait works
     And I should see 1 ".view-media td:contains('[TEST] Duplicate vertical')" elements
 
   @api
-  Scenario: Assert "When I visit the media :media_type with the name :name" works
-    Given the following managed files:
+  Scenario: Assert "When I visit the :media_type media with the name :name" works
+    Given the following managed files exist:
       | path      |
       | image.png |
-    And the following media "image" exist:
+    And the following "image" media exist:
       | name              | field_media_image |
       | Test media image  | image.png         |
     And I am logged in as a user with the "administrator" role
-    When I visit the media "image" with the name "Test media image"
+    When I visit the "image" media with the name "Test media image"
     Then the response should contain "200"
 
   @api @trait:Drupal\MediaTrait
-  Scenario: Assert that negative assertion for "When I visit the media :media_type with the name :name" fails with an error
+  Scenario: Assert that negative assertion for "When I visit the :media_type media with the name :name" fails with an error
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I visit the media "image" with the name "Non-existent media"
+      When I visit the "image" media with the name "Non-existent media"
       """
     When I run "behat --no-colors"
     Then it should fail with a "RuntimeException" exception:
@@ -179,25 +179,25 @@ Feature: Check that MediaTrait works
       """
 
   @api
-  Scenario: Assert "When I visit the media :media_type delete page with the name :name" works
-    Given the following managed files:
+  Scenario: Assert "When I visit the :media_type media delete page with the name :name" works
+    Given the following managed files exist:
       | path      |
       | image.png |
-    And the following media "image" exist:
+    And the following "image" media exist:
       | name              | field_media_image |
       | Test media image  | image.png         |
     And I am logged in as a user with the "administrator" role
-    When I visit the media "image" delete page with the name "Test media image"
+    When I visit the "image" media delete page with the name "Test media image"
     Then the response should contain "200"
     And I should see "Test media image"
 
   @api @trait:Drupal\MediaTrait
-  Scenario: Assert that negative assertion for "When I visit the media :media_type delete page with the name :name" fails with an error
+  Scenario: Assert that negative assertion for "When I visit the :media_type media delete page with the name :name" fails with an error
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I visit the media "image" delete page with the name "Non-existent media"
+      When I visit the "image" media delete page with the name "Non-existent media"
       """
     When I run "behat --no-colors"
     Then it should fail with a "RuntimeException" exception:
@@ -206,24 +206,24 @@ Feature: Check that MediaTrait works
       """
 
   @api
-  Scenario: Assert "When I visit the media :media_type revisions page with the name :name" works
-    Given the following managed files:
+  Scenario: Assert "When I visit the :media_type media revisions page with the name :name" works
+    Given the following managed files exist:
       | path      |
       | image.png |
-    And the following media "image" exist:
+    And the following "image" media exist:
       | name              | field_media_image |
       | Test media image  | image.png         |
     And I am logged in as a user with the "administrator" role
-    When I visit the media "image" revisions page with the name "Test media image"
+    When I visit the "image" media revisions page with the name "Test media image"
     Then the response should contain "200"
 
   @api @trait:Drupal\MediaTrait
-  Scenario: Assert that negative assertion for "When I visit the media :media_type revisions page with the name :name" fails with an error
+  Scenario: Assert that negative assertion for "When I visit the :media_type media revisions page with the name :name" fails with an error
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      When I visit the media "image" revisions page with the name "Non-existent media"
+      When I visit the "image" media revisions page with the name "Non-existent media"
       """
     When I run "behat --no-colors"
     Then it should fail with a "RuntimeException" exception:
@@ -232,17 +232,17 @@ Feature: Check that MediaTrait works
       """
 
   @api
-  Scenario: Assert "Then the :media_type media type should exist" works
+  Scenario: Assert "Then the media type :media_type should exist" works
     Given I am logged in as a user with the "administrator" role
-    Then the "image" media type should exist
+    Then the media type "image" should exist
 
   @api @trait:Drupal\MediaTrait
-  Scenario: Assert that negative assertion for "Then the :media_type media type should exist" fails with an error
+  Scenario: Assert that negative assertion for "Then the media type :media_type should exist" fails with an error
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      Then the "nonexistent_type" media type should exist
+      Then the media type "nonexistent_type" should exist
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -251,17 +251,17 @@ Feature: Check that MediaTrait works
       """
 
   @api
-  Scenario: Assert "Then the :media_type media type should not exist" works
+  Scenario: Assert "Then the media type :media_type should not exist" works
     Given I am logged in as a user with the "administrator" role
-    Then the "nonexistent_type" media type should not exist
+    Then the media type "nonexistent_type" should not exist
 
   @api @trait:Drupal\MediaTrait
-  Scenario: Assert that negative assertion for "Then the :media_type media type should not exist" fails with an error
+  Scenario: Assert that negative assertion for "Then the media type :media_type should not exist" fails with an error
     Given some behat configuration
     And scenario steps:
       """
       Given I am logged in as a user with the "administrator" role
-      Then the "image" media type should not exist
+      Then the media type "image" should not exist
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -271,10 +271,10 @@ Feature: Check that MediaTrait works
 
   @api
   Scenario: Assert "Then the :media_type media with the name :name should exist" works
-    Given the following managed files:
+    Given the following managed files exist:
       | path      |
       | image.png |
-    And the following media "image" exist:
+    And the following "image" media exist:
       | name              | field_media_image |
       | Test media image  | image.png         |
     And I am logged in as a user with the "administrator" role
@@ -301,16 +301,16 @@ Feature: Check that MediaTrait works
 
   @api @trait:Drupal\MediaTrait,Drupal\FileTrait
   Scenario: Assert that negative assertion for "Then the :media_type media with the name :name should not exist" fails with an error
-    Given the following managed files:
+    Given the following managed files exist:
       | path      |
       | image.png |
     And some behat configuration
     And scenario steps:
       """
-      Given the following managed files:
+      Given the following managed files exist:
         | path      |
         | image.png |
-      And the following media "image" exist:
+      And the following "image" media exist:
         | name              | field_media_image |
         | Test media image  | image.png         |
       Then the "image" media with the name "Test media image" should not exist

--- a/tests/behat/features/drupal_menu.feature
+++ b/tests/behat/features/drupal_menu.feature
@@ -4,8 +4,8 @@ Feature: Check that MenuTrait works
   So that users can test menu functionality
 
   @api
-  Scenario: Assert "When the following menus:"
-    When the following menus:
+  Scenario: Assert "When the following menus exist:"
+    When the following menus exist:
       | label               | description             |
       | [TEST] menu 1 title | Test menu 1 description |
       | [TEST] menu 2 title | Test menu 2 description |
@@ -18,7 +18,7 @@ Feature: Check that MenuTrait works
 
   @api
   Scenario: Assert "When the menu :menu_name does not exist"
-    Given the following menus:
+    Given the following menus exist:
       | label               | description             |
       | [TEST] menu 1 title | Test menu 1 description |
       | [TEST] menu 2 title | Test menu 2 description |
@@ -34,7 +34,7 @@ Feature: Check that MenuTrait works
 
   @api
   Scenario: Assert "When the following menu links exist/do not exist in the menu :menu_name"
-    When the following menus:
+    When the following menus exist:
       | label               | description             |
       | [TEST] menu 1 title | Test menu 1 description |
     And the following menu links exist in the menu "[TEST] menu 1 title":

--- a/tests/behat/features/drupal_state.feature
+++ b/tests/behat/features/drupal_state.feature
@@ -36,8 +36,8 @@ Feature: Check that StateTrait works
     Then the state "behat_steps_test.flag" should not exist
 
   @api
-  Scenario: Assert "Given the following state values:" sets multiple state values
-    Given the following state values:
+  Scenario: Assert "Given the following state values exist:" sets multiple state values
+    Given the following state values exist:
       | name                         | value |
       | behat_steps_test.launched    | 1     |
       | behat_steps_test.feature     | 0     |

--- a/tests/behat/features/drupal_taxonomy.feature
+++ b/tests/behat/features/drupal_taxonomy.feature
@@ -12,12 +12,12 @@ Feature: Check that TaxonomyTrait works
       | Tag3 |
 
   @api
-  Scenario: Assert "Then the vocabulary :machine_name with the name :name should exist" works
+  Scenario: Assert "Then the vocabulary :vocabulary with the name :name should exist" works
     Given I am logged in as a user with the "administrator" role
     Then the vocabulary "tags" with the name "Tags" should exist
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "Then the vocabulary :machine_name with the name :name should exist" works with non-existing vocabulary
+  Scenario: Assert negative assertion for "Then the vocabulary :vocabulary with the name :name should exist" works with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
@@ -31,7 +31,7 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "Then the vocabulary :machine_name with the name :name should exist" works with existing vocabulary but incorrect name
+  Scenario: Assert negative assertion for "Then the vocabulary :vocabulary with the name :name should exist" works with existing vocabulary but incorrect name
     Given some behat configuration
     And scenario steps:
       """
@@ -45,12 +45,12 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api
-  Scenario: Assert "Then the vocabulary :machine_name should not exist" works
+  Scenario: Assert "Then the vocabulary :vocabulary should not exist" works
     Given I am logged in as a user with the "administrator" role
     Then the vocabulary "noneixisting" should not exist
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "Then the vocabulary :machine_name should not exist" works with existing vocabulary
+  Scenario: Assert negative assertion for "Then the vocabulary :vocabulary should not exist" works with existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
@@ -64,12 +64,12 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api
-  Scenario: Assert "Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should exist" works
+  Scenario: Assert "Then the taxonomy term :term_name from the vocabulary :vocabulary should exist" works
     Given I am logged in as a user with the "administrator" role
     Then the taxonomy term "Tag1" from the vocabulary "tags" should exist
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should exist" works with non-existing vocabulary
+  Scenario: Assert negative assertion for "Then the taxonomy term :term_name from the vocabulary :vocabulary should exist" works with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
@@ -83,7 +83,7 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should exist" works with non-existing term
+  Scenario: Assert negative assertion for "Then the taxonomy term :term_name from the vocabulary :vocabulary should exist" works with non-existing term
     Given some behat configuration
     And scenario steps:
       """
@@ -97,12 +97,12 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api
-  Scenario: Assert "Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should not exist" works
+  Scenario: Assert "Then the taxonomy term :term_name from the vocabulary :vocabulary should not exist" works
     Given I am logged in as a user with the "administrator" role
     Then the taxonomy term "Nonexisting" from the vocabulary "tags" should not exist
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should not exist" works with non-existing vocabulary
+  Scenario: Assert negative assertion for "Then the taxonomy term :term_name from the vocabulary :vocabulary should not exist" works with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
@@ -116,7 +116,7 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "Then the taxonomy term :term_name from the vocabulary :vocabulary_machine_name should not exist" works with an existing term
+  Scenario: Assert negative assertion for "Then the taxonomy term :term_name from the vocabulary :vocabulary should not exist" works with an existing term
     Given some behat configuration
     And scenario steps:
       """
@@ -130,8 +130,8 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert "Given the following :vocabulary_machine_name vocabulary terms do not exist" works
-    Given the following "tags" vocabulary terms do not exist:
+  Scenario: Assert "Given the following :vocabulary terms do not exist" works
+    Given the following "tags" terms do not exist:
       | Tag1        |
       | Tag2        |
       | Nonexisting |
@@ -141,11 +141,11 @@ Feature: Check that TaxonomyTrait works
     And the taxonomy term "Tag3" from the vocabulary "tags" should exist
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "Given the following :vocabulary_machine_name vocabulary terms do not exist" fails with non-existing vocabulary
+  Scenario: Assert negative assertion for "Given the following :vocabulary terms do not exist" fails with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
-      Given the following "nonexisting" vocabulary terms do not exist:
+      Given the following "nonexisting" terms do not exist:
         | Tag1        |
       """
     When I run "behat --no-colors"
@@ -155,14 +155,14 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api
-  Scenario: Assert "When I visit the :vocabulary_machine_name term page with the name :term_name" works
+  Scenario: Assert "When I visit the :vocabulary term page with the name :term_name" works
     Given I am logged in as a user with the "administrator" role
     When I visit the "tags" term page with the name "Tag1"
     Then the response should contain "200"
     And I should see "Tag1"
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term page with the name :term_name" fails with non-existing vocabulary
+  Scenario: Assert negative assertion for "When I visit the :vocabulary term page with the name :term_name" fails with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
@@ -176,7 +176,7 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term page with the name :term_name" fails with non-existing term
+  Scenario: Assert negative assertion for "When I visit the :vocabulary term page with the name :term_name" fails with non-existing term
     Given some behat configuration
     And scenario steps:
       """
@@ -190,14 +190,14 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api
-  Scenario: Assert "When I visit the :vocabulary_machine_name term edit page with the name :term_name" works
+  Scenario: Assert "When I visit the :vocabulary term edit page with the name :term_name" works
     Given I am logged in as a user with the "administrator" role
     When I visit the "tags" term edit page with the name "Tag1"
     Then the response should contain "200"
     And I should see "Tag1"
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term edit page with the name :term_name" fails with non-existing vocabulary
+  Scenario: Assert negative assertion for "When I visit the :vocabulary term edit page with the name :term_name" fails with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
@@ -211,7 +211,7 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term edit page with the name :term_name" fails with non-existing term
+  Scenario: Assert negative assertion for "When I visit the :vocabulary term edit page with the name :term_name" fails with non-existing term
     Given some behat configuration
     And scenario steps:
       """
@@ -225,14 +225,14 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api
-  Scenario: Assert "When I visit the :vocabulary_machine_name term delete page with the name :term_name" works
+  Scenario: Assert "When I visit the :vocabulary term delete page with the name :term_name" works
     Given I am logged in as a user with the "administrator" role
     When I visit the "tags" term delete page with the name "Tag1"
     Then the response should contain "200"
     And I should see "Tag1"
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term delete page with the name :term_name" fails with non-existing vocabulary
+  Scenario: Assert negative assertion for "When I visit the :vocabulary term delete page with the name :term_name" fails with non-existing vocabulary
     Given some behat configuration
     And scenario steps:
       """
@@ -246,7 +246,7 @@ Feature: Check that TaxonomyTrait works
       """
 
   @api @trait:Drupal\TaxonomyTrait
-  Scenario: Assert negative assertion for "When I visit the :vocabulary_machine_name term delete page with the name :term_name" fails with non-existing term
+  Scenario: Assert negative assertion for "When I visit the :vocabulary term delete page with the name :term_name" fails with non-existing term
     Given some behat configuration
     And scenario steps:
       """
@@ -262,7 +262,7 @@ Feature: Check that TaxonomyTrait works
   @api
   Scenario: Create single taxonomy term with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following tags terms with fields:
+    And the following tags terms with fields exist:
       | name        | [TEST] Vertical Tag  |
       | description | Vertical format term |
     When I go to "admin/structure/taxonomy/manage/tags/overview"
@@ -271,7 +271,7 @@ Feature: Check that TaxonomyTrait works
   @api
   Scenario: Create multiple taxonomy terms with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following tags terms with fields:
+    And the following tags terms with fields exist:
       | name        | [TEST] V-Tag 1      | [TEST] V-Tag 2       | [TEST] V-Tag 3      |
       | description | First vertical term | Second vertical term | Third vertical term |
     When I go to "admin/structure/taxonomy/manage/tags/overview"

--- a/tests/behat/features/drupal_user.feature
+++ b/tests/behat/features/drupal_user.feature
@@ -494,23 +494,23 @@ Feature: Check that UserTrait works
       """
 
   @api
-  Scenario: Assert "Given the role :role_name with the permissions :permissions" works
-    Given the role "Content Manager" with the permissions "access content, create article content"
+  Scenario: Assert "Given the role :role_name has the permissions :permissions" works
+    Given the role "Content Manager" has the permissions "access content, create article content"
     And I am logged in as a user with the "administrator" role
     And I visit "/admin/people/roles"
     Then I should see "Content Manager"
 
   @api
-  Scenario: Assert "Given the role :role_name with the permissions :permissions" replaces existing role
-    Given the role "Editor" with the permissions "access content"
-    And the role "Editor" with the permissions "access content, create article content"
+  Scenario: Assert "Given the role :role_name has the permissions :permissions" replaces existing role
+    Given the role "Editor" has the permissions "access content"
+    And the role "Editor" has the permissions "access content, create article content"
     And I am logged in as a user with the "administrator" role
     And I visit "/admin/people/roles"
     Then I should see "Editor"
 
   @api
-  Scenario: Assert "Given the following roles:" works with table
-    Given the following roles:
+  Scenario: Assert "Given the following roles exist:" works with table
+    Given the following roles exist:
       | name             | permissions                              |
       | Content Editor   | access content, create article content   |
       | Content Approver | access content, edit any article content |
@@ -520,8 +520,8 @@ Feature: Check that UserTrait works
     And I should see "Content Approver"
 
   @api
-  Scenario: Assert "Given the following roles:" works with empty permissions
-    Given the following roles:
+  Scenario: Assert "Given the following roles exist:" works with empty permissions
+    Given the following roles exist:
       | name           | permissions |
       | Limited Editor |             |
     And I am logged in as a user with the "administrator" role
@@ -529,11 +529,11 @@ Feature: Check that UserTrait works
     Then I should see "Limited Editor"
 
   @api @trait:Drupal\UserTrait
-  Scenario: Assert "Given the following roles:" fails when name column is missing
+  Scenario: Assert "Given the following roles exist:" fails when name column is missing
     Given some behat configuration
     And scenario steps:
       """
-      Given the following roles:
+      Given the following roles exist:
         | role        | permissions         |
         | Test Role   | access content      |
       """
@@ -546,7 +546,7 @@ Feature: Check that UserTrait works
   @api
   Scenario: Create single user with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following users with fields:
+    And the following users with fields exist:
       | name   | [TEST] vertical_user |
       | mail   | vertical@example.com |
       | status | 1                    |
@@ -556,7 +556,7 @@ Feature: Check that UserTrait works
   @api
   Scenario: Create multiple users with vertical field format
     Given I am logged in as a user with the "administrator" role
-    And the following users with fields:
+    And the following users with fields exist:
       | name   | [TEST] vuser1      | [TEST] vuser2      | [TEST] vuser3      |
       | mail   | vuser1@example.com | vuser2@example.com | vuser3@example.com |
       | status | 1                  | 1                  | 1                  |

--- a/tests/behat/features/drupal_webform.feature
+++ b/tests/behat/features/drupal_webform.feature
@@ -30,7 +30,7 @@ Feature: Check that WebformTrait works
     And I visit "/admin/structure/webform/manage/test_template_form/settings"
     And I check "Allow this webform to be used as a template"
     And I press "Save"
-    Given a webform "Cloned contact form" from template "Test template form"
+    Given the webform "Cloned contact form" exists from the template "Test template form"
     And I visit "/admin/structure/webform"
     Then I should see "Cloned contact form"
     # Clean up the template.
@@ -41,7 +41,7 @@ Feature: Check that WebformTrait works
     Given some behat configuration
     And scenario steps tagged with "@api":
       """
-      Given a webform "My form" from template "Non-existing template"
+      Given the webform "My form" exists from the template "Non-existing template"
       """
     When I run "behat --no-colors"
     Then it should fail with an exception:

--- a/tests/behat/features/drupal_webform.feature
+++ b/tests/behat/features/drupal_webform.feature
@@ -21,7 +21,7 @@ Feature: Check that WebformTrait works
     Given the webform "Non-existing webform" does not exist
 
   @api @module:webform_templates
-  Scenario: Assert "@Given a webform :title from template :template" works as expected
+  Scenario: Assert "@Given the webform :title exists from the template :template" works as expected
     Given I am logged in as a user with the "administrator" role
     When I visit "/admin/structure/webform/add"
     And I fill in "Title" with "Test template form"
@@ -37,7 +37,7 @@ Feature: Check that WebformTrait works
     When the webform "Test template form" does not exist
 
   @trait:Drupal\WebformTrait
-  Scenario: Assert "@Given a webform :title from template :template" fails for non-existing template
+  Scenario: Assert "@Given the webform :title exists from the template :template" fails for non-existing template
     Given some behat configuration
     And scenario steps tagged with "@api":
       """

--- a/tests/behat/features/field.feature
+++ b/tests/behat/features/field.feature
@@ -149,7 +149,7 @@ Feature: Check that FieldTrait works
       """
 
   @trait:FieldTrait
-  Scenario: Assert that negative assertion for "The field :name should not exist" fails with an error
+  Scenario: Assert that negative assertion for "The field :field should not exist" fails with an error for a label
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -163,7 +163,7 @@ Feature: Check that FieldTrait works
       """
 
   @trait:FieldTrait
-  Scenario: Assert that negative assertion for "The field :field should not exist" fails with an error
+  Scenario: Assert that negative assertion for "The field :field should not exist" fails with an error for an id
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -244,7 +244,7 @@ Feature: Check that FieldTrait works
       """
 
   @api
-  Scenario: Assert "When I fill in WYSIWYG "field" with "value"" works as expected
+  Scenario: Assert "When I fill in the WYSIWYG field :field with the value :value" works as expected
     Given the following page content:
       | title             |
       | [TEST] Page title |
@@ -257,7 +257,7 @@ Feature: Check that FieldTrait works
     And I should see "[TEST] description"
 
   @api @javascript
-  Scenario: Assert "When I fill in WYSIWYG "field" with "value"" works as expected with JS driver
+  Scenario: Assert "When I fill in the WYSIWYG field :field with the value :value" works as expected with JS driver
     Given the following page content:
       | title                       |
       | [TEST-JS-Driver] Page title |

--- a/tests/behat/features/field.feature
+++ b/tests/behat/features/field.feature
@@ -21,18 +21,18 @@ Feature: Check that FieldTrait works
     Then the field "field1" should not be empty
 
   @phpserver
-  Scenario: Assert "When I fill in the field :selector with :value" works with CSS selector
+  Scenario: Assert "When I fill in the field :selector with the value :value" works with CSS selector
     When I visit "http://cli:8888/fields.html"
-    And I fill in the field "#field1" with "CSS filled value"
+    And I fill in the field "#field1" with the value "CSS filled value"
     Then the field "field1" should not be empty
 
   @trait:FieldTrait
-  Scenario: Assert that "When I fill in the field :selector with :value" fails when element does not exist
+  Scenario: Assert that "When I fill in the field :selector with the value :value" fails when element does not exist
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
       When I visit "http://cli:8888/fields.html"
-      And I fill in the field "#nonexistent-field" with "some value"
+      And I fill in the field "#nonexistent-field" with the value "some value"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -110,7 +110,7 @@ Feature: Check that FieldTrait works
   @phpserver
   Scenario Outline: Assert if field is disabled or enabled
     When I visit "http://cli:8888/fields.html"
-    Then the field "<field>" should have "<enabled_or_disabled>" state
+    Then the field "<field>" should have the "<enabled_or_disabled>" state
     Examples:
       | field          | enabled_or_disabled |
       | field1         | enabled             |
@@ -182,7 +182,7 @@ Feature: Check that FieldTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I visit "http://cli:8888/fields.html"
-      Then the field "field3disabled" should have "enabled" state
+      Then the field "field3disabled" should have the "enabled" state
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -196,7 +196,7 @@ Feature: Check that FieldTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I visit "http://cli:8888/fields.html"
-      Then the field "field1" should have "disabled" state
+      Then the field "field1" should have the "disabled" state
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -250,8 +250,8 @@ Feature: Check that FieldTrait works
       | [TEST] Page title |
     And I am logged in as a user with the "administrator" role
     And I visit the "page" content edit page with the title "[TEST] Page title"
-    When I fill in the WYSIWYG field "Body" with the "[TEST] body"
-    And I fill in the WYSIWYG field "Description" with the "[TEST] description"
+    When I fill in the WYSIWYG field "Body" with the value "[TEST] body"
+    And I fill in the WYSIWYG field "Description" with the value "[TEST] description"
     And I press "Save"
     Then I should see "[TEST] body"
     And I should see "[TEST] description"
@@ -263,8 +263,8 @@ Feature: Check that FieldTrait works
       | [TEST-JS-Driver] Page title |
     And I am logged in as a user with the "administrator" role
     And I visit the "page" content edit page with the title "[TEST-JS-Driver] Page title"
-    When I fill in the WYSIWYG field "Body" with the "[TEST-JS-Driver] body"
-    And I fill in the WYSIWYG field "Description" with the "[TEST-JS-Driver] description"
+    When I fill in the WYSIWYG field "Body" with the value "[TEST-JS-Driver] body"
+    And I fill in the WYSIWYG field "Description" with the value "[TEST-JS-Driver] description"
     And I press "Save"
     Then I should see "[TEST-JS-Driver] body"
     And I should see "[TEST-JS-Driver] description"
@@ -554,7 +554,7 @@ Feature: Check that FieldTrait works
   @javascript @phpserver
   Scenario: Disable browser validation for form after visiting page
     When I visit "http://cli:8888/fields.html"
-    And browser validation for the form "#login-form" is disabled
+    And the browser validation for the form "#login-form" is disabled
     And I press "Submit 1"
     # Server-side validation message should appear
     Then I should see "Please fill in all required fields"
@@ -562,7 +562,7 @@ Feature: Check that FieldTrait works
   @javascript @phpserver
   Scenario: Disable browser validation as the VERY FIRST step (fixes issue #423)
     # This is the VERY FIRST step - no page visited yet - this is the core issue being fixed
-    Given browser validation for the form "#login-form" is disabled
+    Given the browser validation for the form "#login-form" is disabled
     When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     # Server-side validation message should appear (browser validation was disabled)
@@ -570,15 +570,15 @@ Feature: Check that FieldTrait works
 
   @javascript @phpserver
   Scenario: Disable browser validation for multiple forms
-    Given browser validation for the form "#login-form" is disabled
-    And browser validation for the form "#contact-form" is disabled
+    Given the browser validation for the form "#login-form" is disabled
+    And the browser validation for the form "#contact-form" is disabled
     When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     Then I should see "Please fill in all required fields"
 
   @javascript @behat-steps-skip:FieldTrait @phpserver
   Scenario: Skip FieldTrait hooks with behat-steps-skip tag
-    Given browser validation for the form "#login-form" is disabled
+    Given the browser validation for the form "#login-form" is disabled
     When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     # With the skip tag, validation disabling should not be applied
@@ -590,7 +590,7 @@ Feature: Check that FieldTrait works
     Given some behat configuration
     And scenario steps tagged with "@javascript @behat-steps-skip:FieldTrait @phpserver":
       """
-      Given browser validation for the form "#login-form" is disabled
+      Given the browser validation for the form "#login-form" is disabled
       When I visit "http://cli:8888/fields.html"
       And I press "Submit 1"
       Then I should not see "Please fill in all required fields"
@@ -600,7 +600,7 @@ Feature: Check that FieldTrait works
 
   @phpserver
   Scenario: Validation step works without JavaScript driver
-    Given browser validation for the form "#login-form" is disabled
+    Given the browser validation for the form "#login-form" is disabled
     When I visit "http://cli:8888/fields.html"
     # Without JavaScript, the registry stores the selector but AfterStep returns early
     # The step should not throw an error
@@ -643,7 +643,7 @@ Feature: Check that FieldTrait works
 
   @javascript @phpserver
   Scenario: Selector-based approach still works independently
-    Given browser validation for the form "#login-form" is disabled
+    Given the browser validation for the form "#login-form" is disabled
     When I visit "http://cli:8888/fields.html"
     And I press "Submit 1"
     Then I should see "Login form error: Please fill in all required fields"
@@ -857,15 +857,15 @@ Feature: Check that FieldTrait works
   @api @javascript @phpserver
   Scenario: Fill in WYSIWYG field with CKEditor 5
     When I visit "http://cli:8888/wysiwyg_ckeditor5.html"
-    And I fill in the WYSIWYG field "Body" with the "Updated CKEditor 5 body content"
-    And I fill in the WYSIWYG field "Description" with the "Updated CKEditor 5 description"
+    And I fill in the WYSIWYG field "Body" with the value "Updated CKEditor 5 body content"
+    And I fill in the WYSIWYG field "Description" with the value "Updated CKEditor 5 description"
 
   # Non-commercial version of CKEditor 4 throw an error about being insecure.
   @api @javascript @js-errors @phpserver
   Scenario: Fill in WYSIWYG field with CKEditor 4
     When I visit "http://cli:8888/wysiwyg_ckeditor4.html"
-    And I fill in the WYSIWYG field "Body" with the "Updated CKEditor 4 body content"
-    And I fill in the WYSIWYG field "Description" with the "Updated CKEditor 4 description"
+    And I fill in the WYSIWYG field "Body" with the value "Updated CKEditor 4 body content"
+    And I fill in the WYSIWYG field "Description" with the value "Updated CKEditor 4 description"
 
   @trait:FieldTrait
   Scenario: Assert negative WYSIWYG field not found
@@ -873,7 +873,7 @@ Feature: Check that FieldTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       When I visit "http://cli:8888/wysiwyg_ckeditor5.html"
-      When I fill in the WYSIWYG field "Non-existent WYSIWYG" with the "test content"
+      When I fill in the WYSIWYG field "Non-existent WYSIWYG" with the value "test content"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -887,7 +887,7 @@ Feature: Check that FieldTrait works
     And scenario steps tagged with "@javascript @phpserver":
       """
       When I visit "http://cli:8888/wysiwyg_ckeditor5.html"
-      When I fill in the WYSIWYG field "noid" with the "test content"
+      When I fill in the WYSIWYG field "noid" with the value "test content"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:

--- a/tests/behat/features/file_download.feature
+++ b/tests/behat/features/file_download.feature
@@ -5,7 +5,7 @@ Feature: Check that FileDownloadTrait works
 
   Background:
     Given I am logged in as a user with the "administrator" role
-    When the following managed files:
+    When the following managed files exist:
       | path                 |
       | document.pdf         |
       | image.png            |
@@ -275,7 +275,7 @@ Feature: Check that FileDownloadTrait works
   @api @trait:FileDownloadTrait,Drupal\ContentTrait
   Scenario: Assert that invalid ZIP file fails with an error
     Given some behat configuration
-    And the following managed files:
+    And the following managed files exist:
       | path                |
       | archive_invalid.zip |
     And scenario steps tagged with "@download @phpserver":

--- a/tests/behat/features/iframe.feature
+++ b/tests/behat/features/iframe.feature
@@ -4,31 +4,31 @@ Feature: Check that IframeTrait works
   So that users can test content inside iframes
 
   @javascript @phpserver
-  Scenario: Assert "When I switch to iframe with locator :locator" works for named iframe
+  Scenario: Assert "When I switch to the iframe with the selector :selector" works for named iframe
     Given I am an anonymous user
     When I visit "http://cli:8888/iframes.html"
-    And I switch to iframe with locator ".named-iframe"
+    And I switch to the iframe with the selector ".named-iframe"
     Then I should see "Content inside named iframe"
     When I switch to the root document
     Then I should see "Content in the root document"
 
   @javascript @phpserver
-  Scenario: Assert "When I switch to iframe with locator :locator" works for unnamed iframe
+  Scenario: Assert "When I switch to the iframe with the selector :selector" works for unnamed iframe
     Given I am an anonymous user
     When I visit "http://cli:8888/iframes.html"
-    And I switch to iframe with locator ".unnamed-iframe"
+    And I switch to the iframe with the selector ".unnamed-iframe"
     Then I should see "Content inside unnamed iframe"
     When I switch to the root document
     Then I should see "Content in the root document"
 
   @trait:IframeTrait
-  Scenario: Assert that "When I switch to iframe with locator :locator" fails when iframe does not exist
+  Scenario: Assert that "When I switch to the iframe with the selector :selector" fails when iframe does not exist
     Given some behat configuration
     And scenario steps tagged with "@javascript @phpserver":
       """
       Given I am an anonymous user
       When I visit "http://cli:8888/iframes.html"
-      And I switch to iframe with locator ".nonexistent-iframe"
+      And I switch to the iframe with the selector ".nonexistent-iframe"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:

--- a/tests/behat/features/json.feature
+++ b/tests/behat/features/json.feature
@@ -11,13 +11,13 @@ Feature: Check that JsonTrait works
   @phpserver
   Scenario: Assert "Then the response should be in JSON format" honours content set from a fixture file over the page content
     When I go to "http://cli:8888/json_invalid.json"
-    And the response JSON from the file "json_valid.json"
+    And the response JSON is loaded from the file "json_valid.json"
     Then the response should be in JSON format
 
   @phpserver
   Scenario: Assert "Then the response should be in JSON format" honours content set from a PyString over the page content
     When I go to "http://cli:8888/json_invalid.json"
-    And the response JSON content is the following:
+    And the response JSON is the following:
       """
       {"name": "Blue Widget", "price": 9.99}
       """
@@ -56,16 +56,16 @@ Feature: Check that JsonTrait works
       The response is valid JSON, but it should not be.
       """
 
-  Scenario: Assert "Given the response JSON from the file :filename" works
-    Given the response JSON from the file "json_valid.json"
+  Scenario: Assert "Given the response JSON is loaded from the file :filename" works
+    Given the response JSON is loaded from the file "json_valid.json"
     Then the JSON path "$.name" should be equal to "John Doe"
 
   @trait:JsonTrait
-  Scenario: Assert that "Given the response JSON from the file :filename" fails with an exception for missing file
+  Scenario: Assert that "Given the response JSON is loaded from the file :filename" fails with an exception for missing file
     Given some behat configuration
     And scenario steps:
       """
-      Given the response JSON from the file "nonexistent.json"
+      Given the response JSON is loaded from the file "nonexistent.json"
       Then the JSON path "$.name" should exist
       """
     When I run "behat --no-colors"
@@ -74,8 +74,8 @@ Feature: Check that JsonTrait works
       does not exist
       """
 
-  Scenario: Assert "Given the response JSON content is the following:" works with direct PyString content
-    Given the response JSON content is the following:
+  Scenario: Assert "Given the response JSON is the following:" works with direct PyString content
+    Given the response JSON is the following:
       """
       {"name": "Blue Widget", "meta": {"sku": "p1"}, "tags": ["a", "b"]}
       """
@@ -102,7 +102,7 @@ Feature: Check that JsonTrait works
     Given some behat configuration
     And scenario steps:
       """
-      Given the response JSON content is the following:
+      Given the response JSON is the following:
         '''
         42
         '''
@@ -474,7 +474,7 @@ Feature: Check that JsonTrait works
     Given some behat configuration
     And scenario steps tagged with "@api":
       """
-      Given the response JSON content is the following:
+      Given the response JSON is the following:
         '''
         {"age": 42}
         '''
@@ -511,7 +511,7 @@ Feature: Check that JsonTrait works
     Given some behat configuration
     And scenario steps tagged with "@api":
       """
-      Given the response JSON content is the following:
+      Given the response JSON is the following:
         '''
         {broken json
         '''
@@ -546,7 +546,7 @@ Feature: Check that JsonTrait works
       """
 
   Scenario: Assert "When I print last JSON response" works
-    Given the response JSON from the file "json_valid.json"
+    Given the response JSON is loaded from the file "json_valid.json"
     When I print last JSON response
 
   @trait:JsonTrait
@@ -554,7 +554,7 @@ Feature: Check that JsonTrait works
     Given some behat configuration
     And scenario steps tagged with "@api":
       """
-      Given the response JSON content is the following:
+      Given the response JSON is the following:
         '''
         {broken json
         '''

--- a/tests/behat/features/metatag.feature
+++ b/tests/behat/features/metatag.feature
@@ -50,19 +50,19 @@ Feature: Check that MetatagTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the :metaName meta tag should not contain any HTML tags" works for clean meta tag
+  Scenario: Assert "Then the :meta_name meta tag should not contain any HTML tags" works for clean meta tag
     Given I am an anonymous user
     When I visit "http://cli:8888/metatags.html"
     Then the "description" meta tag should not contain any HTML tags
 
   @phpserver
-  Scenario: Assert "Then the :metaName meta tag should not contain any HTML tags" works for clean OG meta tag
+  Scenario: Assert "Then the :meta_name meta tag should not contain any HTML tags" works for clean OG meta tag
     Given I am an anonymous user
     When I visit "http://cli:8888/metatags.html"
     Then the "og:title" meta tag should not contain any HTML tags
 
   @trait:MetatagTrait
-  Scenario: Assert that "Then the :metaName meta tag should not contain any HTML tags" fails when meta tag contains HTML
+  Scenario: Assert that "Then the :meta_name meta tag should not contain any HTML tags" fails when meta tag contains HTML
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -76,7 +76,7 @@ Feature: Check that MetatagTrait works
       """
 
   @trait:MetatagTrait
-  Scenario: Assert that "Then the :metaName meta tag should not contain any HTML tags" fails when meta tag does not exist
+  Scenario: Assert that "Then the :meta_name meta tag should not contain any HTML tags" fails when meta tag does not exist
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """

--- a/tests/behat/features/path.feature
+++ b/tests/behat/features/path.feature
@@ -213,7 +213,7 @@ Feature: Check that PathTrait works
     Then the path should be "/user/login"
 
   @api
-  Scenario: Assert "When the basic authentication has the username :username and the password :password"
+  Scenario: Assert "Given the basic authentication has the username :username and the password :password"
     Given the following users:
       | name       | mail               | pass       |
       | admin-test | admin-test@bar.com | admin-test |

--- a/tests/behat/features/path.feature
+++ b/tests/behat/features/path.feature
@@ -125,18 +125,18 @@ Feature: Check that PathTrait works
   Scenario: Assert that URL has query parameter with a specific value
     Given I am logged in as a user with the "administrator" role
     When I visit "/admin/content?status=1&type=article"
-    Then current url should have the "status" parameter
-    And current url should have the "status" parameter with the "1" value
-    And current url should have the "type" parameter
-    And current url should have the "type" parameter with the "article" value
+    Then the current URL should have the "status" parameter
+    And the current URL should have the "status" parameter with the value "1"
+    And the current URL should have the "type" parameter
+    And the current URL should have the "type" parameter with the value "article"
 
   @api
   Scenario: Assert that URL does not have query parameter with specific value
     Given I am logged in as a user with the "administrator" role
     When I visit "/admin/content?status=1&type=article"
-    Then current url should not have the "status" parameter with the "0" value
-    And current url should not have the "other" parameter
-    And current url should not have the "type" parameter with the "page" value
+    Then the current URL should not have the "status" parameter with the value "0"
+    And the current URL should not have the "other" parameter
+    And the current URL should not have the "type" parameter with the value "page"
 
   @trait:PathTrait
   Scenario: Assert failure when URL should have parameter but doesn't
@@ -145,7 +145,7 @@ Feature: Check that PathTrait works
       """
       Given I am logged in as a user with the "administrator" role
       When I visit "/admin/content?status=1&type=article"
-      Then current url should have the "filter" parameter with the "recent" value
+      Then the current URL should have the "filter" parameter with the value "recent"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -160,7 +160,7 @@ Feature: Check that PathTrait works
       """
       Given I am logged in as a user with the "administrator" role
       When I visit "/admin/content?status=1&type=article"
-      Then current url should have the "status" parameter with the "2" value
+      Then the current URL should have the "status" parameter with the value "2"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -175,7 +175,7 @@ Feature: Check that PathTrait works
       """
       Given I am logged in as a user with the "administrator" role
       When I visit "/admin/content?status=1&type=article"
-      Then current url should not have the "status" parameter with the "1" value
+      Then the current URL should not have the "status" parameter with the value "1"
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -190,7 +190,7 @@ Feature: Check that PathTrait works
       """
       Given I am logged in as a user with the "administrator" role
       When I visit "/admin/content?status=1&type=article"
-      Then current url should not have the "status" parameter
+      Then the current URL should not have the "status" parameter
       """
     When I run "behat --no-colors"
     Then it should fail with an error:
@@ -202,7 +202,7 @@ Feature: Check that PathTrait works
   Scenario: Assert URL parameter with value doesn't exist when parameter is absent
     Given I am logged in as a user with the "administrator" role
     When I visit "/admin/content?status=1"
-    Then current url should not have the "nonexistent" parameter with the "value" value
+    Then the current URL should not have the "nonexistent" parameter with the value "value"
 
   @api
   Scenario: Assert "When I go back" navigates to the previous page
@@ -213,7 +213,7 @@ Feature: Check that PathTrait works
     Then the path should be "/user/login"
 
   @api
-  Scenario: Assert "When the basic authentication with the username :username and the password :password"
+  Scenario: Assert "When the basic authentication has the username :username and the password :password"
     Given the following users:
       | name       | mail               | pass       |
       | admin-test | admin-test@bar.com | admin-test |
@@ -226,6 +226,6 @@ Feature: Check that PathTrait works
     And I go to "/mysite_core/test-basic-auth"
     Then I should get a "403" HTTP response
 
-    When the basic authentication with the username "admin-test" and the password "admin-test"
+    When the basic authentication has the username "admin-test" and the password "admin-test"
     And I go to "/mysite_core/test-basic-auth"
     Then I should get a "200" HTTP response

--- a/tests/behat/features/response.feature
+++ b/tests/behat/features/response.feature
@@ -4,12 +4,12 @@ Feature: Check that ResponseTrait works
   So that users can test server configuration and content delivery
 
   @phpserver
-  Scenario: Assert "Then the response should contain the header :header_name" works
+  Scenario: Assert "Then the response should contain the header :name" works
     When I go to "http://cli:8888/elements.html"
     Then the response should contain the header "Content-Type"
 
   @trait:ResponseTrait
-  Scenario: Assert that negative assertion for "Then the response should contain the header :header_name" fails with an error
+  Scenario: Assert that negative assertion for "Then the response should contain the header :name" fails with an error
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -23,12 +23,12 @@ Feature: Check that ResponseTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the response should not contain the header :header_name" works
+  Scenario: Assert "Then the response should not contain the header :name" works
     When I go to "http://cli:8888/elements.html"
     Then the response should not contain the header "NonExistingHeader"
 
   @trait:ResponseTrait
-  Scenario: Assert that negative assertion for "Then the response should not contain the header :header_name" fails with an error
+  Scenario: Assert that negative assertion for "Then the response should not contain the header :name" fails with an error
     Given some behat configuration
     And scenario steps:
       """
@@ -42,12 +42,12 @@ Feature: Check that ResponseTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the response header :header_name should contain the value :header_value" works
+  Scenario: Assert "Then the response header :name should contain the value :value" works
     When I go to "http://cli:8888/elements.html"
     Then the response header "Content-Type" should contain the value "text/html"
 
   @trait:ResponseTrait
-  Scenario: Assert that negative assertion for "Then the response header :header_name should contain the value :header_value" fails with an error for missing header
+  Scenario: Assert that negative assertion for "Then the response header :name should contain the value :value" fails with an error for missing header
     Given some behat configuration
     And scenario steps:
       """
@@ -61,7 +61,7 @@ Feature: Check that ResponseTrait works
       """
 
   @trait:ResponseTrait
-  Scenario: Assert that negative assertion for "Then the response header :header_name should contain the value :header_value" fails with an error for invalid header value
+  Scenario: Assert that negative assertion for "Then the response header :name should contain the value :value" fails with an error for invalid header value
     Given some behat configuration
     And scenario steps:
       """
@@ -75,12 +75,12 @@ Feature: Check that ResponseTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the response header :header_name should not contain the value :header_value" works
+  Scenario: Assert "Then the response header :name should not contain the value :value" works
     When I go to "http://cli:8888/elements.html"
     Then the response header "Content-Type" should not contain the value "nonexistingvalue"
 
   @trait:ResponseTrait
-  Scenario: Assert that negative assertion for "Then the response header :header_name should not contain the value :header_value" fails with an error for missing header
+  Scenario: Assert that negative assertion for "Then the response header :name should not contain the value :value" fails with an error for missing header
     Given some behat configuration
     And scenario steps:
       """
@@ -94,7 +94,7 @@ Feature: Check that ResponseTrait works
       """
 
   @trait:ResponseTrait
-  Scenario: Assert that negative assertion for "Then the response header :header_name should not contain the value :header_value" fails with an error for invalid header value
+  Scenario: Assert that negative assertion for "Then the response header :name should not contain the value :value" fails with an error for invalid header value
     Given some behat configuration
     And scenario steps:
       """

--- a/tests/behat/features/responsive.feature
+++ b/tests/behat/features/responsive.feature
@@ -120,7 +120,7 @@ Feature: Check that ResponsiveTrait works
 
   @javascript @phpserver
   Scenario: Custom breakpoints can be registered and used
-    Given the following responsive breakpoints:
+    Given the following responsive breakpoints exist:
       | name       | dimensions |
       | iphone_12  | 390x844    |
       | 4k_display | 3840x2160  |
@@ -133,7 +133,7 @@ Feature: Check that ResponsiveTrait works
     Given some behat configuration
     And scenario steps tagged with "@javascript @phpserver":
       """
-      Given the following responsive breakpoints:
+      Given the following responsive breakpoints exist:
         | name     | dimensions |
         | invalid  | 1920-1080  |
       When I am on "http://cli:8888/javascript_clean1.html"
@@ -149,7 +149,7 @@ Feature: Check that ResponsiveTrait works
     Given some behat configuration
     And scenario steps tagged with "@javascript @phpserver":
       """
-      Given the following responsive breakpoints:
+      Given the following responsive breakpoints exist:
         | name     | dimensions |
         | invalid  | 1920xABC   |
       When I am on "http://cli:8888/javascript_clean1.html"
@@ -162,7 +162,7 @@ Feature: Check that ResponsiveTrait works
 
   @javascript @phpserver
   Scenario: Custom breakpoint overrides default breakpoint
-    Given the following responsive breakpoints:
+    Given the following responsive breakpoints exist:
       | name            | dimensions |
       | mobile_portrait | 375x812    |
     When I am on "http://cli:8888/javascript_clean1.html"

--- a/tests/behat/features/rest.feature
+++ b/tests/behat/features/rest.feature
@@ -3,13 +3,13 @@ Feature: Check that RestTrait works
   I want to provide tools for REST API testing
   So that users can send HTTP requests and assert responses
 
-  Scenario: Assert "Given a REST header :name with value :value" and "When I send a REST :method request to :url" work
-    Given a REST header "Accept" with value "text/html"
+  Scenario: Assert "Given the REST header :name has the value :value" and "When I send a REST :method request to :url" work
+    Given the REST header "Accept" has the value "text/html"
     When I send a REST "GET" request to "/"
     Then the REST response status code should be 200
 
   Scenario: Assert "When I send a REST :method request to :url with body:" works
-    Given a REST header "Content-Type" with value "text/plain"
+    Given the REST header "Content-Type" has the value "text/plain"
     When I send a REST "POST" request to "/" with body:
       """
       test body content
@@ -17,8 +17,8 @@ Feature: Check that RestTrait works
     Then the REST response status code should be 200
 
   Scenario: Assert multiple headers can be set
-    Given a REST header "Accept" with value "text/html"
-    And a REST header "X-Custom-Header" with value "custom-value"
+    Given the REST header "Accept" has the value "text/html"
+    And the REST header "X-Custom-Header" has the value "custom-value"
     When I send a REST "GET" request to "/"
     Then the REST response status code should be 200
 

--- a/tests/behat/features/table.feature
+++ b/tests/behat/features/table.feature
@@ -237,7 +237,7 @@ Feature: Check that TableTrait works
   # Row text.
 
   @phpserver
-  Scenario: Assert "Then the :rowText row should contain the following:" works as expected
+  Scenario: Assert "Then the :row_text row should contain the following:" works as expected
     Given I am an anonymous user
     When I visit "http://cli:8888/table.html"
     Then the "Alpha item" row should contain the following:
@@ -245,7 +245,7 @@ Feature: Check that TableTrait works
       | Active  |
 
   @trait:TableTrait
-  Scenario: Assert "Then the :rowText row should contain the following:" fails when row not found
+  Scenario: Assert "Then the :row_text row should contain the following:" fails when row not found
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -261,7 +261,7 @@ Feature: Check that TableTrait works
       """
 
   @trait:TableTrait
-  Scenario: Assert "Then the :rowText row should contain the following:" fails when text not found in row
+  Scenario: Assert "Then the :row_text row should contain the following:" fails when text not found in row
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """

--- a/tests/behat/features/xml.feature
+++ b/tests/behat/features/xml.feature
@@ -16,13 +16,13 @@ Feature: Check that XmlTrait works
   @phpserver
   Scenario: Assert "Then the response should be in XML format" honours content set from a fixture file over the page content
     When I go to "http://cli:8888/xml_invalid.xml"
-    And the response content from the file "xml_valid.xml"
+    And the response XML is loaded from the file "xml_valid.xml"
     Then the response should be in XML format
 
   @phpserver
   Scenario: Assert "Then the response should be in XML format" honours content set from a PyString over the page content
     When I go to "http://cli:8888/xml_invalid.xml"
-    And the response content is the following:
+    And the response XML is the following:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <catalog>
@@ -53,7 +53,7 @@ Feature: Check that XmlTrait works
   @phpserver
   Scenario: Assert "Then the response should not be in XML format" honours content set from a fixture file over the page content
     When I go to "http://cli:8888/xml_valid.xml"
-    And the response content from the file "xml_invalid.xml"
+    And the response XML is loaded from the file "xml_invalid.xml"
     Then the response should not be in XML format
 
   @trait:XmlTrait
@@ -119,12 +119,12 @@ Feature: Check that XmlTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the XML element :element should be equal to :text" works
+  Scenario: Assert "Then the XML element :element should be equal to :value" works
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/title" should be equal to "The Great Adventure"
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML element :element should be equal to :text" fails with an error for missing element
+  Scenario: Assert that negative assertion for "Then the XML element :element should be equal to :value" fails with an error for missing element
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -138,7 +138,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML element :element should be equal to :text" fails with an error for wrong content
+  Scenario: Assert that negative assertion for "Then the XML element :element should be equal to :value" fails with an error for wrong content
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -152,12 +152,12 @@ Feature: Check that XmlTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the XML element :element should not be equal to :text" works
+  Scenario: Assert "Then the XML element :element should not be equal to :value" works
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/title" should not be equal to "Wrong Title"
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML element :element should not be equal to :text" fails with an error
+  Scenario: Assert that negative assertion for "Then the XML element :element should not be equal to :value" fails with an error
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -171,12 +171,12 @@ Feature: Check that XmlTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the XML element :element should contain :text" works
+  Scenario: Assert "Then the XML element :element should contain :value" works
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/description" should contain "sample book"
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML element :element should contain :text" fails with an error for missing element
+  Scenario: Assert that negative assertion for "Then the XML element :element should contain :value" fails with an error for missing element
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -190,7 +190,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML element :element should contain :text" fails with an error for missing text
+  Scenario: Assert that negative assertion for "Then the XML element :element should contain :value" fails with an error for missing text
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -204,12 +204,12 @@ Feature: Check that XmlTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the XML element :element should not contain :text" works
+  Scenario: Assert "Then the XML element :element should not contain :value" works
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML element "//book[@id='123']/title" should not contain "nonexistent"
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML element :element should not contain :text" fails with an error
+  Scenario: Assert that negative assertion for "Then the XML element :element should not contain :value" fails with an error
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -275,17 +275,17 @@ Feature: Check that XmlTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the XML attribute :attribute on element :element should be equal to :text" works
+  Scenario: Assert "Then the XML attribute :attribute on element :element should be equal to :value" works
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "id" on element "//book[@id='123']" should be equal to "123"
 
   @phpserver
-  Scenario: Assert "Then the XML attribute :attribute on element :element should be equal to :text" works with category
+  Scenario: Assert "Then the XML attribute :attribute on element :element should be equal to :value" works with category
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "category" on element "//book[@id='123']" should be equal to "fiction"
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should be equal to :text" fails with an error for missing element
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should be equal to :value" fails with an error for missing element
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -299,7 +299,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should be equal to :text" fails with an error for missing attribute
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should be equal to :value" fails with an error for missing attribute
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -313,7 +313,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should be equal to :text" fails with an error for wrong value
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should be equal to :value" fails with an error for wrong value
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -327,12 +327,12 @@ Feature: Check that XmlTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the XML attribute :attribute on element :element should not be equal to :text" works
+  Scenario: Assert "Then the XML attribute :attribute on element :element should not be equal to :value" works
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "id" on element "//book[@id='123']" should not be equal to "999"
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should not be equal to :text" fails with an error
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should not be equal to :value" fails with an error
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -437,7 +437,7 @@ Feature: Check that XmlTrait works
     Then the XML element "//book[@id='123']/title" should be equal to "The Great Adventure"
 
   @trait:XmlTrait
-  Scenario: Assert that "Then the XML element :element should not be equal to :text" fails with an error for missing element
+  Scenario: Assert that "Then the XML element :element should not be equal to :value" fails with an error for missing element
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -451,7 +451,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that "Then the XML element :element should not contain :text" fails with an error for missing element
+  Scenario: Assert that "Then the XML element :element should not contain :value" fails with an error for missing element
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -479,7 +479,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that "Then the XML attribute :attribute on element :element should not be equal to :text" fails with an error for missing element
+  Scenario: Assert that "Then the XML attribute :attribute on element :element should not be equal to :value" fails with an error for missing element
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -493,7 +493,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that "Then the XML attribute :attribute on element :element should not be equal to :text" fails with an error for missing attribute
+  Scenario: Assert that "Then the XML attribute :attribute on element :element should not be equal to :value" fails with an error for missing attribute
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -506,20 +506,20 @@ Feature: Check that XmlTrait works
       The XML attribute "nonexistent" on element "//book[@id='123']" was not found.
       """
 
-  Scenario: Assert "Given the response content from the file :filename" works
-    Given the response content from the file "xml_valid.xml"
+  Scenario: Assert "Given the response XML is loaded from the file :filename" works
+    Given the response XML is loaded from the file "xml_valid.xml"
     Then the XML element "//book[@id='123']/title" should be equal to "The Great Adventure"
 
-  Scenario: Assert "Given the response content from the file :filename" works with attribute assertions
-    Given the response content from the file "xml_valid.xml"
+  Scenario: Assert "Given the response XML is loaded from the file :filename" works with attribute assertions
+    Given the response XML is loaded from the file "xml_valid.xml"
     Then the XML attribute "category" on element "//book[@id='123']" should be equal to "fiction"
 
   @trait:XmlTrait
-  Scenario: Assert that "Given the response content from the file :filename" fails with an exception for missing file
+  Scenario: Assert that "Given the response XML is loaded from the file :filename" fails with an exception for missing file
     Given some behat configuration
     And scenario steps:
       """
-      Given the response content from the file "nonexistent.xml"
+      Given the response XML is loaded from the file "nonexistent.xml"
       Then the XML element "//book" should exist
       """
     When I run "behat --no-colors"
@@ -528,8 +528,8 @@ Feature: Check that XmlTrait works
       does not exist
       """
 
-  Scenario: Assert "Given the response content is the following:" works with direct PyString content
-    Given the response content is the following:
+  Scenario: Assert "Given the response XML is the following:" works with direct PyString content
+    Given the response XML is the following:
       """
       <?xml version="1.0" encoding="UTF-8"?>
       <catalog>
@@ -544,11 +544,11 @@ Feature: Check that XmlTrait works
     And the XML attribute "type" on element "//product[@id='p1']" should be equal to "widget"
 
   @trait:XmlTrait
-  Scenario: Assert that "Given the response content is the following:" fails with an exception for invalid XML
+  Scenario: Assert that "Given the response XML is the following:" fails with an exception for invalid XML
     Given some behat configuration
     And scenario steps:
       """
-      Given the response content is the following:
+      Given the response XML is the following:
         '''
         this is not valid xml <<<
         '''
@@ -561,17 +561,17 @@ Feature: Check that XmlTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the XML attribute :attribute_name on element :element should contain :text" works
+  Scenario: Assert "Then the XML attribute :attribute on element :element should contain :value" works
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "category" on element "//book[@id='123']" should contain "fic"
 
   @phpserver
-  Scenario: Assert "Then the XML attribute :attribute_name on element :element should contain :text" works with id attribute
+  Scenario: Assert "Then the XML attribute :attribute on element :element should contain :value" works with id attribute
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "id" on element "//book[@id='123']" should contain "12"
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should contain :text" fails with an error for missing element
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should contain :value" fails with an error for missing element
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -585,7 +585,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should contain :text" fails with an error for missing attribute
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should contain :value" fails with an error for missing attribute
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -599,7 +599,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should contain :text" fails with an error for text not found
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should contain :value" fails with an error for text not found
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -613,12 +613,12 @@ Feature: Check that XmlTrait works
       """
 
   @phpserver
-  Scenario: Assert "Then the XML attribute :attribute_name on element :element should not contain :text" works
+  Scenario: Assert "Then the XML attribute :attribute on element :element should not contain :value" works
     When I go to "http://cli:8888/xml_valid.xml"
     Then the XML attribute "category" on element "//book[@id='123']" should not contain "science"
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should not contain :text" fails with an error for missing element
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should not contain :value" fails with an error for missing element
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -632,7 +632,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should not contain :text" fails with an error for missing attribute
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should not contain :value" fails with an error for missing attribute
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -646,7 +646,7 @@ Feature: Check that XmlTrait works
       """
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the XML attribute :attribute_name on element :element should not contain :text" fails with an error when text is found
+  Scenario: Assert that negative assertion for "Then the XML attribute :attribute on element :element should not contain :value" fails with an error when text is found
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -660,7 +660,7 @@ Feature: Check that XmlTrait works
       """
 
   Scenario: Assert "When I print last XML response" works
-    Given the response content from the file "xml_valid.xml"
+    Given the response XML is loaded from the file "xml_valid.xml"
     When I print last XML response
 
   @trait:XmlTrait
@@ -677,7 +677,7 @@ Feature: Check that XmlTrait works
       """
 
   Scenario: Assert "Then the response should match the following XSD schema:" works
-    Given the response content is the following:
+    Given the response XML is the following:
       """
       <?xml version="1.0"?><note><to>World</to></note>
       """
@@ -729,7 +729,7 @@ Feature: Check that XmlTrait works
       """
 
   Scenario: Assert "Then the response should match the following DTD:" works
-    Given the response content is the following:
+    Given the response XML is the following:
       """
       <?xml version="1.0"?><note>Hello</note>
       """
@@ -758,7 +758,7 @@ Feature: Check that XmlTrait works
       """
 
   Scenario: Assert "Then the response should match the following RelaxNG schema:" works
-    Given the response content is the following:
+    Given the response XML is the following:
       """
       <?xml version="1.0"?><note>Hello</note>
       """
@@ -799,7 +799,7 @@ Feature: Check that XmlTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I go to "http://cli:8888/xml_valid.xml"
-      And the response content is the following:
+      And the response XML is the following:
         '''
         <?xml version="1.0"?><catalog></catalog>
         '''
@@ -817,7 +817,7 @@ Feature: Check that XmlTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I go to "http://cli:8888/xml_valid.xml"
-      And the response content is the following:
+      And the response XML is the following:
         '''
         <?xml version="1.0"?><rss version="1.0"><channel><title>t</title><link>l</link><description>d</description></channel></rss>
         '''
@@ -835,7 +835,7 @@ Feature: Check that XmlTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I go to "http://cli:8888/xml_valid.xml"
-      And the response content is the following:
+      And the response XML is the following:
         '''
         <?xml version="1.0"?><rss version="2.0"></rss>
         '''
@@ -853,7 +853,7 @@ Feature: Check that XmlTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I go to "http://cli:8888/xml_valid.xml"
-      And the response content is the following:
+      And the response XML is the following:
         '''
         <?xml version="1.0"?><rss version="2.0"><channel><title>t</title><link>l</link></channel></rss>
         '''
@@ -871,7 +871,7 @@ Feature: Check that XmlTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I go to "http://cli:8888/xml_valid.xml"
-      And the response content is the following:
+      And the response XML is the following:
         '''
         <?xml version="1.0"?><rss version="2.0"><channel><title>t</title><link>l</link><description>d</description><item><link>x</link></item></channel></rss>
         '''
@@ -894,7 +894,7 @@ Feature: Check that XmlTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I go to "http://cli:8888/xml_valid.xml"
-      And the response content is the following:
+      And the response XML is the following:
         '''
         <?xml version="1.0"?><feed><id>x</id><title>t</title><updated>u</updated></feed>
         '''
@@ -912,7 +912,7 @@ Feature: Check that XmlTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I go to "http://cli:8888/xml_valid.xml"
-      And the response content is the following:
+      And the response XML is the following:
         '''
         <?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><id>x</id><title>t</title></feed>
         '''
@@ -930,7 +930,7 @@ Feature: Check that XmlTrait works
     And scenario steps tagged with "@phpserver":
       """
       When I go to "http://cli:8888/xml_valid.xml"
-      And the response content is the following:
+      And the response XML is the following:
         '''
         <?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom" xmlns:other="http://example.com/other"><id>x</id><title>t</title><updated>u</updated><entry><id>e</id><title>et</title><other:updated>2024</other:updated></entry></feed>
         '''


### PR DESCRIPTION
Closes #712

## Summary

73 of the library's 373 registered steps now carry renamed placeholders, method parameters, or step wording across 25 traits, with the complete before/after mapping grouped by trait in `MIGRATION.md`; any consumer `.feature` file or context override that references the old step text or the old parameter name needs the new spelling once it upgrades to `4.x`.

Before this, the same concept answered to several names depending on which trait wrote it - `XmlTrait` used `:attribute` in 4 steps and `:attribute_name` in 2, `TaxonomyTrait` used `:vocabulary`, `:vocabulary_machine_name` and `:machine_name` for the same bundle value - and three methods took a parameter that didn't match their placeholder at all, so Behat resolved the argument through positional fallback instead of by name: `MediaTrait::mediaRemoveType(string $type)` for `:media_type`, `SearchApiTrait::searchApiIndexContent(string $type)` for `:content_type`, and `searchApiDoIndex(string|int $limit)` for `:count`.

After merge, every placeholder in `STEPS.md` follows the conventions now recorded in `CLAUDE.md` - one name per concept, an article on every noun, `:value` for named-target comparisons versus `:text` reserved for whole-body asserts - and the three mismatched parameters above are renamed to match their placeholder; step families that already read as a present-tense condition, like `QueueTrait`'s `the :queue queue is empty` and `BlockTrait`'s `the block :label is enabled`, are untouched, and there's no deprecated-alias layer since `docs.php::validate()` only allows one step attribute per method.

## Before / After

```
── BEFORE ── one idea, several spellings ────────────────────────────────

  XmlTrait        attribute is :attribute (x4) or :attribute_name (x2); compared value is :text
  TaxonomyTrait   vocabulary is :vocabulary, :vocabulary_machine_name, or :machine_name
  MediaTrait      word order for :media_type mixed step to step (no clear rule)

                                    │
                                    ▼

── AFTER ── one name per concept ─────────────────────────────────────────

  XmlTrait        attribute is :attribute (one name, 8 steps); value is :value; :text free for whole-body asserts
  TaxonomyTrait   vocabulary is :vocabulary (one name, 9 steps)
  MediaTrait      :media_type before the noun when qualifying, after "media type" as subject


── PLACEHOLDER → PARAMETER BINDING ───────────────────────────────────────

  BEFORE:  #[Given(':media_type media type does not exist')]
           function mediaRemoveType(string $type)          ← :media_type lands on $type by position

  AFTER:   #[Given('the media type :media_type does not exist')]
           function mediaRemoveType(string $media_type)    ← :media_type binds to $media_type by name
```

## Changes

- **Placeholders**: unified across 25 traits per the conventions in `CLAUDE.md` - target-vs-value, entity-named bundles, articles, word order, `snake_case` - full mapping in `MIGRATION.md`.
- **Parameter renames**: `MediaTrait::mediaRemoveType()` (`$type` to `$media_type`), `SearchApiTrait::searchApiIndexContent()` (`$type` to `$content_type`) and `searchApiDoIndex()` (`$limit` to `$count`) now bind by name instead of resolving through Behat's positional fallback.
- **CacheTrait**: moved the `has been cleared` family to `is empty` (`cacheClearPagePath()`, `cacheClearPagePathWildcard()`, `cacheClearRender()`), since the perfect tense described an action rather than the prerequisite state a scenario sets up.
- **Left unchanged**: `QueueTrait`'s `the :queue queue is empty` and `BlockTrait`'s `the block :label is enabled` / `is disabled`, since `is` plus an adjective already reads as a present-tense condition that mirrors the `should be empty` / `should be enabled` assertion it pairs with, and the issue proposed no replacement wording for either.
- **ResponseTrait**: kept `:name` / `:value` instead of renaming to `:header_name` / `:header_value`, because `:name` / `:value` matches `the state :name has the value :value` and `a cookie with the name :name and the value :value`, and a `header_` prefix would only repeat the noun the step text already has.
- **Docs**: added the mapping table and conventions to `MIGRATION.md`, recorded the same conventions plus the `Given` present-tense rule in `CLAUDE.md`, and regenerated `STEPS.md` from source via `docs.php`.
- **Tests**: updated every `tests/behat/features/*.feature` file to the new step text and renamed the scenarios whose titles echoed the old wording so each still describes the step it exercises.
- **Out of scope**: `ElementTrait` keeps two `Given I ...` steps that read against the documented "avoid `Given I`" rule; `FieldTrait`'s checkbox/radio/select `:selector` arguments stay as `findField()` id|name|label lookups rather than becoming real CSS selectors; a `docs.php::validate()` guard that would assert every placeholder is bound by a parameter of the same name isn't added, so a future mismatch like the three fixed here won't be caught automatically.
