### PR TITLE
[#713] Prefixed every trait method with its trait name.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ of tests. Follow these guidelines:
   - Avoid optional words like `(the|a)`. Provide a single form instead to ensure
     consistency.
   - Omit unnecessary suffixes like `on the page` since it is implied.
-  - All method names should begin with the trait name: `userAssertHasRoles()`
-    for `UserTrait`.
+  - All method names should begin with the trait name: `userAssertHasRoles()` for `UserTrait`. The prefix is the trait name minus its `Trait` suffix with the first letter lowercased, and the character after it is uppercase: `menuLoadByLabel()`, not `loadMenuByLabel()`. The prefix is not also the verb: `waitSeconds()`, not `waitWaitForSeconds()`. It applies to every member a trait mixes into the context - steps, helpers, properties and constants - since any of them can collide with another trait's. `tests/phpunit/src/TraitMethodNamingTest.php` enforces it.
+  - A method that overrides a Drupal Extension context method, such as `OverrideTrait::createNodes()` or `TaxonomyTrait::createTerms()`, is the one exception: an override binds by name, so it keeps the parent's. List it in `PARENT_OVERRIDES` in `TraitMethodNamingTest` instead of renaming it.
 
 - **`Given`**:
   - Defines test prerequisites—conditions or data that must exist before the

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -230,7 +230,7 @@ composer require --dev drupal/drupal-extension dmore/behat-chrome-extension
 
 ## Unified entity cleanup
 
-Traits that create Drupal entities now register them in a single shared registry and delete them in reverse creation order through one `entityCleanupAfterScenario` hook, instead of each trait running its own after-scenario cleanup.
+Traits that create Drupal entities now register them in a single shared registry and delete them in reverse creation order through one `helperEntityCleanupAfterScenario` hook, instead of each trait running its own after-scenario cleanup.
 
 The per-trait cleanup skip tags have been removed. Replace them as follows:
 
@@ -245,6 +245,35 @@ The per-trait cleanup skip tags have been removed. Replace them as follows:
 | `@behat-steps-skip:blockAfterScenario`         | `@behat-steps-entity-cleanup-skip:block`                                                             |
 | `@behat-steps-skip:webformAfterScenario`       | `@behat-steps-entity-cleanup-skip:webform`                                                           |
 
-To skip cleanup of every registered entity at once, use `@behat-steps-skip:entityCleanupAfterScenario`.
+To skip cleanup of every registered entity at once, use `@behat-steps-skip:helperEntityCleanupAfterScenario`.
 
 `FileTrait` keeps its own `@behat-steps-skip:fileAfterScenario` tag, which now covers only unmanaged files; managed file entities it creates are cleaned up by the shared registry and can be kept with `@behat-steps-entity-cleanup-skip:file`.
+
+## Trait methods prefixed with their trait name
+
+Every method a trait contributes now begins with the trait's own name, so that traits mixed into one context cannot collide. Rename any call or override in a consumer context:
+
+| Trait | Old | New |
+| --- | --- | --- |
+| `Drupal\DraggableviewsTrait` | `draggableViewsSaveBundleOrder()` | `draggableviewsSaveBundleOrder()` |
+| `Drupal\DraggableviewsTrait` | `draggableViewsFindNode()` | `draggableviewsFindNode()` |
+| `Drupal\HelperTrait` | `entityRegister()` | `helperEntityRegister()` |
+| `Drupal\HelperTrait` | `entityRegisterId()` | `helperEntityRegisterId()` |
+| `Drupal\HelperTrait` | `entityCleanupAfterScenario()` | `helperEntityCleanupAfterScenario()` |
+| `Drupal\HelperTrait` | `entityCleanupRun()` | `helperEntityCleanupRun()` |
+| `Drupal\HelperTrait` | `entityCleanupDelete()` | `helperEntityCleanupDelete()` |
+| `Drupal\HelperTrait` | `entityCleanupSkippedTypes()` | `helperEntityCleanupSkippedTypes()` |
+| `Drupal\HelperTrait` | `$entityRegistry` | `$helperEntityRegistry` |
+| `Drupal\HelperTrait` | `ENTITY_CLEANUP_EXCLUDED_TYPES` | `HELPER_ENTITY_CLEANUP_EXCLUDED_TYPES` |
+| `Drupal\MenuTrait` | `loadMenuByLabel()` | `menuLoadByLabel()` |
+| `Drupal\MenuTrait` | `loadMenuLinkByTitle()` | `menuLoadLinkByTitle()` |
+| `WaitTrait` | `waitWaitForSeconds()` | `waitSeconds()` |
+| `WaitTrait` | `waitForAjaxToFinish()` | `waitForAjax()` |
+
+Gherkin step text is unchanged, so feature files need no edit for the renames above. One tag does change, because it names the hook method it skips:
+
+| Old tag | New tag |
+| --- | --- |
+| `@behat-steps-skip:entityCleanupAfterScenario` | `@behat-steps-skip:helperEntityCleanupAfterScenario` |
+
+`Drupal\OverrideTrait::createNodes()`, `::createUsers()`, `::iAmLoggedInAsUserWithRole()` and `Drupal\TaxonomyTrait::createTerms()` override Drupal Extension context methods and keep their names.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ are cleaned up by the base Drupal Extension and are never registered here, so
 there is no double-deletion.
 
 To keep **all** registered entities after a scenario, add
-`@behat-steps-skip:entityCleanupAfterScenario` to the scenario or feature.
+`@behat-steps-skip:helperEntityCleanupAfterScenario` to the scenario or feature.
 
 To keep only entities of a **named type**, add
 `@behat-steps-entity-cleanup-skip:ENTITY_TYPE_ID` (for example

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -69,7 +69,7 @@ trait BlockTrait {
 
     $this->blockConfigure($admin_label, $fields);
 
-    $this->entityRegister($block);
+    $this->helperEntityRegister($block);
   }
 
   /**

--- a/src/Drupal/ContentBlockTrait.php
+++ b/src/Drupal/ContentBlockTrait.php
@@ -189,7 +189,7 @@ trait ContentBlockTrait {
     $entity = BlockContent::create($stub->getValues());
     $entity->save();
 
-    $this->entityRegister($entity);
+    $this->helperEntityRegister($entity);
 
     return $entity;
   }

--- a/src/Drupal/DraggableviewsTrait.php
+++ b/src/Drupal/DraggableviewsTrait.php
@@ -29,13 +29,13 @@ trait DraggableviewsTrait {
    * @endcode
    */
   #[When('I save the draggable views items of the view :view_id and the display :view_display_id for the :content_type content in the following order:')]
-  public function draggableViewsSaveBundleOrder(string $view_id, string $view_display_id, string $content_type, TableNode $order_table): void {
+  public function draggableviewsSaveBundleOrder(string $view_id, string $view_display_id, string $content_type, TableNode $order_table): void {
     $this->helperAssertModuleEnabled('draggableviews', 'drupal/draggableviews');
 
     $database = Database::getConnection();
 
     foreach ($order_table->getColumn(0) as $weight => $title) {
-      $node = $this->draggableViewsFindNode($content_type, ['title' => $title]);
+      $node = $this->draggableviewsFindNode($content_type, ['title' => $title]);
 
       if (empty($node)) {
         throw new \RuntimeException(sprintf('Unable to find the node "%s".', $title));
@@ -78,7 +78,7 @@ trait DraggableviewsTrait {
    * @return \Drupal\node\NodeInterface|null
    *   The found node or NULL.
    */
-  protected function draggableViewsFindNode(string $type, array $conditions): ?NodeInterface {
+  protected function draggableviewsFindNode(string $type, array $conditions): ?NodeInterface {
     $query = \Drupal::entityQuery('node')
       ->accessCheck(FALSE)
       ->condition('type', $type);

--- a/src/Drupal/EckTrait.php
+++ b/src/Drupal/EckTrait.php
@@ -172,7 +172,7 @@ trait EckTrait {
 
     $saved = $stub->getSavedEntity();
     if ($saved instanceof EntityInterface) {
-      $this->entityRegister($saved);
+      $this->helperEntityRegister($saved);
     }
   }
 

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -114,7 +114,7 @@ trait FileTrait {
 
     $entity = $this->fileCreateEntity($path, $stub, $uri);
 
-    $this->entityRegister($entity);
+    $this->helperEntityRegister($entity);
 
     return $entity;
   }

--- a/src/Drupal/HelperTrait.php
+++ b/src/Drupal/HelperTrait.php
@@ -26,7 +26,8 @@ use Drupal\Driver\Entity\EntityStubInterface;
  * taxonomy_term, user_role, language, configurable_language) are never
  * registered here, so there is no double-deletion.
  *
- * Skip all cleanup with tag: `@behat-steps-skip:entityCleanupAfterScenario`
+ * Skip all cleanup with tag:
+ * `@behat-steps-skip:helperEntityCleanupAfterScenario`
  * Skip cleanup for one entity type with tag:
  * `@behat-steps-entity-cleanup-skip:media`
  *
@@ -42,7 +43,7 @@ trait HelperTrait {
    * Never deleted by this trait to avoid double-deletion with the base
    * extension (re-deleting a user or language throws, unlike nodes/terms).
    */
-  const ENTITY_CLEANUP_EXCLUDED_TYPES = [
+  const HELPER_ENTITY_CLEANUP_EXCLUDED_TYPES = [
     'node',
     'user',
     'taxonomy_term',
@@ -60,7 +61,7 @@ trait HelperTrait {
    *
    * @var array<int, array{0: string, 1: int|string}>
    */
-  protected array $entityRegistry = [];
+  protected array $helperEntityRegistry = [];
 
   /**
    * Register a saved entity.
@@ -68,11 +69,11 @@ trait HelperTrait {
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The saved entity to register.
    */
-  protected function entityRegister(EntityInterface $entity): void {
+  protected function helperEntityRegister(EntityInterface $entity): void {
     $id = $entity->id();
 
     if ($id !== NULL) {
-      $this->entityRegisterId($entity->getEntityTypeId(), $id);
+      $this->helperEntityRegisterId($entity->getEntityTypeId(), $id);
     }
   }
 
@@ -84,43 +85,43 @@ trait HelperTrait {
    * @param int|string $entity_id
    *   The entity id.
    */
-  protected function entityRegisterId(string $entity_type_id, int|string $entity_id): void {
-    $this->entityRegistry[] = [$entity_type_id, $entity_id];
+  protected function helperEntityRegisterId(string $entity_type_id, int|string $entity_id): void {
+    $this->helperEntityRegistry[] = [$entity_type_id, $entity_id];
   }
 
   /**
    * Delete registered entities in reverse creation order at scenario teardown.
    */
   #[AfterScenario('@api')]
-  public function entityCleanupAfterScenario(AfterScenarioScope $scope): void {
+  public function helperEntityCleanupAfterScenario(AfterScenarioScope $scope): void {
     $scenario = $scope->getScenario();
 
     if ($scenario->hasTag('behat-steps-skip:' . __FUNCTION__)) {
       return;
     }
 
-    $this->entityCleanupRun($this->entityCleanupSkippedTypes($scenario->getTags()));
+    $this->helperEntityCleanupRun($this->helperEntityCleanupSkippedTypes($scenario->getTags()));
   }
 
   /**
    * Delete registered entities in reverse creation order, then reset.
    *
-   * Entity types in self::ENTITY_CLEANUP_EXCLUDED_TYPES (owned by the base
-   * Drupal Extension) or in $skip_types are left in place.
+   * Entity types in self::HELPER_ENTITY_CLEANUP_EXCLUDED_TYPES (owned by the
+   * base Drupal Extension) or in $skip_types are left in place.
    *
    * @param array<int, string> $skip_types
    *   Entity type ids to leave in place.
    */
-  protected function entityCleanupRun(array $skip_types): void {
-    foreach (array_reverse($this->entityRegistry) as [$entity_type_id, $entity_id]) {
-      if (in_array($entity_type_id, self::ENTITY_CLEANUP_EXCLUDED_TYPES, TRUE) || in_array($entity_type_id, $skip_types, TRUE)) {
+  protected function helperEntityCleanupRun(array $skip_types): void {
+    foreach (array_reverse($this->helperEntityRegistry) as [$entity_type_id, $entity_id]) {
+      if (in_array($entity_type_id, self::HELPER_ENTITY_CLEANUP_EXCLUDED_TYPES, TRUE) || in_array($entity_type_id, $skip_types, TRUE)) {
         continue;
       }
 
-      $this->entityCleanupDelete($entity_type_id, $entity_id);
+      $this->helperEntityCleanupDelete($entity_type_id, $entity_id);
     }
 
-    $this->entityRegistry = [];
+    $this->helperEntityRegistry = [];
   }
 
   /**
@@ -131,7 +132,7 @@ trait HelperTrait {
    * @param int|string $entity_id
    *   The entity id.
    */
-  protected function entityCleanupDelete(string $entity_type_id, int|string $entity_id): void {
+  protected function helperEntityCleanupDelete(string $entity_type_id, int|string $entity_id): void {
     $entity = \Drupal::entityTypeManager()->getStorage($entity_type_id)->load($entity_id);
     $entity?->delete();
   }
@@ -146,7 +147,7 @@ trait HelperTrait {
    *   Entity type ids to skip, parsed from
    *   'behat-steps-entity-cleanup-skip:<entity_type_id>' tags.
    */
-  protected function entityCleanupSkippedTypes(array $tags): array {
+  protected function helperEntityCleanupSkippedTypes(array $tags): array {
     $prefix = 'behat-steps-entity-cleanup-skip:';
     $types = [];
 

--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -266,7 +266,7 @@ trait MediaTrait {
   protected function mediaCreateSingle(EntityStub $stub): MediaInterface {
     $this->parseEntityFields($stub);
     $entity = $this->mediaCreateEntity($stub);
-    $this->entityRegister($entity);
+    $this->helperEntityRegister($entity);
 
     return $entity;
   }

--- a/src/Drupal/MenuTrait.php
+++ b/src/Drupal/MenuTrait.php
@@ -33,7 +33,7 @@ trait MenuTrait {
    */
   #[Given('the menu :menu_name does not exist')]
   public function menuDeleteSingle(string $menu_name): void {
-    $menu = $this->loadMenuByLabel($menu_name);
+    $menu = $this->menuLoadByLabel($menu_name);
     if ($menu instanceof MenuInterface) {
       $menu->delete();
     }
@@ -68,7 +68,7 @@ trait MenuTrait {
       $menu = Menu::create($menu_hash);
       $menu->save();
 
-      $this->entityRegister($menu);
+      $this->helperEntityRegister($menu);
     }
   }
 
@@ -90,7 +90,7 @@ trait MenuTrait {
     $this->helperAssertModuleEnabled('menu_link_content');
 
     foreach ($table->getColumn(0) as $title) {
-      $menu_link = $this->loadMenuLinkByTitle($title, $menu_name);
+      $menu_link = $this->menuLoadLinkByTitle($title, $menu_name);
       if ($menu_link instanceof MenuLinkContent) {
         $menu_link->delete();
       }
@@ -111,7 +111,7 @@ trait MenuTrait {
   public function menuLinksCreate(string $menu_name, TableNode $table): void {
     $this->helperAssertModuleEnabled('menu_link_content');
 
-    $menu = $this->loadMenuByLabel($menu_name);
+    $menu = $this->menuLoadByLabel($menu_name);
 
     // @codeCoverageIgnoreStart
     if (!$menu instanceof MenuInterface) {
@@ -126,7 +126,7 @@ trait MenuTrait {
         unset($menu_link_hash['uri']);
       }
       if (!empty($menu_link_hash['parent']) && is_string($menu_link_hash['parent'])) {
-        $parent_link = $this->loadMenuLinkByTitle($menu_link_hash['parent'], $menu_name);
+        $parent_link = $this->menuLoadLinkByTitle($menu_link_hash['parent'], $menu_name);
         if ($parent_link instanceof MenuLinkContent) {
           $menu_link_hash['parent'] = 'menu_link_content:' . $parent_link->uuid();
         }
@@ -141,7 +141,7 @@ trait MenuTrait {
       }
       $menu_link = MenuLinkContent::create($menu_link_hash);
       $menu_link->save();
-      $this->entityRegister($menu_link);
+      $this->helperEntityRegister($menu_link);
     }
   }
 
@@ -154,7 +154,7 @@ trait MenuTrait {
    * @return \Drupal\system\MenuInterface|null
    *   The menu or NULL if not found.
    */
-  protected function loadMenuByLabel(string $label): ?MenuInterface {
+  protected function menuLoadByLabel(string $label): ?MenuInterface {
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
     $entity_type_manager = \Drupal::entityTypeManager();
     $menu_ids = $entity_type_manager->getStorage('menu')->getQuery()
@@ -182,8 +182,8 @@ trait MenuTrait {
    * @return \Drupal\menu_link_content\Entity\MenuLinkContent|null
    *   The menu link or NULL if not found.
    */
-  protected function loadMenuLinkByTitle(string $title, string $menu_name): ?MenuLinkContent {
-    $menu = $this->loadMenuByLabel($menu_name);
+  protected function menuLoadLinkByTitle(string $title, string $menu_name): ?MenuLinkContent {
+    $menu = $this->menuLoadByLabel($menu_name);
 
     // @codeCoverageIgnoreStart
     if (!$menu instanceof MenuInterface) {

--- a/src/Drupal/ParagraphsTrait.php
+++ b/src/Drupal/ParagraphsTrait.php
@@ -89,7 +89,7 @@ trait ParagraphsTrait {
       $parent_entity->save();
     }
 
-    $this->entityRegister($paragraph);
+    $this->helperEntityRegister($paragraph);
 
     return $paragraph;
   }

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -81,7 +81,7 @@ trait RedirectTrait {
       $redirect->setRedirect($to);
       $redirect->save();
 
-      $this->entityRegister($redirect);
+      $this->helperEntityRegister($redirect);
     }
   }
 

--- a/src/Drupal/WebformTrait.php
+++ b/src/Drupal/WebformTrait.php
@@ -72,7 +72,7 @@ trait WebformTrait {
     $clone->set('template', FALSE);
     $clone->save();
 
-    $this->entityRegister($clone);
+    $this->helperEntityRegister($clone);
   }
 
   /**

--- a/src/WaitTrait.php
+++ b/src/WaitTrait.php
@@ -22,7 +22,7 @@ trait WaitTrait {
    * @endcode
    */
   #[When('I wait for :seconds second(s)')]
-  public function waitWaitForSeconds(string|int $seconds): void {
+  public function waitSeconds(string|int $seconds): void {
     sleep((int) $seconds);
   }
 
@@ -37,7 +37,7 @@ trait WaitTrait {
    * @endcode
    */
   #[When('I wait for :seconds second(s) for AJAX to finish')]
-  public function waitForAjaxToFinish(string|int $seconds): void {
+  public function waitForAjax(string|int $seconds): void {
     $seconds = (int) $seconds;
 
     if (!$this->helperIsJavascriptSupported()) {

--- a/tests/behat/features/drupal_entity_cleanup.feature
+++ b/tests/behat/features/drupal_entity_cleanup.feature
@@ -23,7 +23,7 @@ Feature: Check that automatic entity cleanup works
     Then the following redirects should not exist:
       | /entity-cleanup-auto |
 
-  @api @behat-steps-skip:entityCleanupAfterScenario
+  @api @behat-steps-skip:helperEntityCleanupAfterScenario
   Scenario: The cleanup skip tag keeps all registered entities
     Given the following redirects exist:
       | from                     | to          |

--- a/tests/phpunit/src/Drupal/HelperTraitTest.php
+++ b/tests/phpunit/src/Drupal/HelperTraitTest.php
@@ -402,8 +402,7 @@ class HelperTraitTestImplementation {
   public ?DrupalDriverInterface $driver = NULL;
 
   /**
-   * Records [type, id] pairs passed to the overridden
-   * helperEntityCleanupDelete().
+   * Records [type, id] pairs passed to the overridden helperEntityCleanupDelete().
    *
    * @var array<int, array{0: string, 1: int|string}>
    */

--- a/tests/phpunit/src/Drupal/HelperTraitTest.php
+++ b/tests/phpunit/src/Drupal/HelperTraitTest.php
@@ -60,43 +60,43 @@ class HelperTraitTest extends UnitTestCase {
   }
 
   public function testEntityRegisterId(): void {
-    $this->testObject->callEntityRegisterId('media', 7);
-    $this->testObject->callEntityRegisterId('block_content', 'custom_id');
+    $this->testObject->callHelperEntityRegisterId('media', 7);
+    $this->testObject->callHelperEntityRegisterId('block_content', 'custom_id');
 
-    $this->assertSame([['media', 7], ['block_content', 'custom_id']], $this->testObject->getEntityRegistry());
+    $this->assertSame([['media', 7], ['block_content', 'custom_id']], $this->testObject->getHelperEntityRegistry());
   }
 
   public function testEntityCleanupRunDeletesInReverseOrderAndResets(): void {
-    $this->testObject->callEntityRegisterId('redirect', 1);
-    $this->testObject->callEntityRegisterId('media', 2);
-    $this->testObject->callEntityRegisterId('block', 3);
+    $this->testObject->callHelperEntityRegisterId('redirect', 1);
+    $this->testObject->callHelperEntityRegisterId('media', 2);
+    $this->testObject->callHelperEntityRegisterId('block', 3);
 
-    $this->testObject->callEntityCleanupRun([]);
+    $this->testObject->callHelperEntityCleanupRun([]);
 
     $this->assertSame([['block', 3], ['media', 2], ['redirect', 1]], $this->testObject->deleted);
-    $this->assertSame([], $this->testObject->getEntityRegistry());
+    $this->assertSame([], $this->testObject->getHelperEntityRegistry());
   }
 
   public function testEntityCleanupRunExcludesBaseOwnedTypes(): void {
-    $this->testObject->callEntityRegisterId('node', 1);
-    $this->testObject->callEntityRegisterId('redirect', 2);
-    $this->testObject->callEntityRegisterId('user', 3);
-    $this->testObject->callEntityRegisterId('configurable_language', 'en');
+    $this->testObject->callHelperEntityRegisterId('node', 1);
+    $this->testObject->callHelperEntityRegisterId('redirect', 2);
+    $this->testObject->callHelperEntityRegisterId('user', 3);
+    $this->testObject->callHelperEntityRegisterId('configurable_language', 'en');
 
-    $this->testObject->callEntityCleanupRun([]);
+    $this->testObject->callHelperEntityCleanupRun([]);
 
     $this->assertSame([['redirect', 2]], $this->testObject->deleted);
-    $this->assertSame([], $this->testObject->getEntityRegistry());
+    $this->assertSame([], $this->testObject->getHelperEntityRegistry());
   }
 
   public function testEntityCleanupRunSkipsNamedTypes(): void {
-    $this->testObject->callEntityRegisterId('media', 1);
-    $this->testObject->callEntityRegisterId('redirect', 2);
+    $this->testObject->callHelperEntityRegisterId('media', 1);
+    $this->testObject->callHelperEntityRegisterId('redirect', 2);
 
-    $this->testObject->callEntityCleanupRun(['media']);
+    $this->testObject->callHelperEntityCleanupRun(['media']);
 
     $this->assertSame([['redirect', 2]], $this->testObject->deleted);
-    $this->assertSame([], $this->testObject->getEntityRegistry());
+    $this->assertSame([], $this->testObject->getHelperEntityRegistry());
   }
 
   /**
@@ -109,13 +109,13 @@ class HelperTraitTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderEntityCleanupSkippedTypes')]
   public function testEntityCleanupSkippedTypes(array $tags, array $expected): void {
-    $this->assertSame($expected, $this->testObject->callEntityCleanupSkippedTypes($tags));
+    $this->assertSame($expected, $this->testObject->callHelperEntityCleanupSkippedTypes($tags));
   }
 
   public static function dataProviderEntityCleanupSkippedTypes(): array {
     return [
       'no tags' => [[], []],
-      'unrelated tags ignored' => [['api', 'behat-steps-skip:entityCleanupAfterScenario'], []],
+      'unrelated tags ignored' => [['api', 'behat-steps-skip:helperEntityCleanupAfterScenario'], []],
       'single type' => [['behat-steps-entity-cleanup-skip:media'], ['media']],
       'multiple types' => [
         ['api', 'behat-steps-entity-cleanup-skip:media', 'behat-steps-entity-cleanup-skip:block_content'],
@@ -402,7 +402,8 @@ class HelperTraitTestImplementation {
   public ?DrupalDriverInterface $driver = NULL;
 
   /**
-   * Records [type, id] pairs passed to the overridden entityCleanupDelete().
+   * Records [type, id] pairs passed to the overridden
+   * helperEntityCleanupDelete().
    *
    * @var array<int, array{0: string, 1: int|string}>
    */
@@ -420,12 +421,12 @@ class HelperTraitTestImplementation {
     $this->helperExpandEntityFieldsFixtures($entity_type, $stub);
   }
 
-  public function callEntityRegisterId(string $entity_type_id, int|string $entity_id): void {
-    $this->entityRegisterId($entity_type_id, $entity_id);
+  public function callHelperEntityRegisterId(string $entity_type_id, int|string $entity_id): void {
+    $this->helperEntityRegisterId($entity_type_id, $entity_id);
   }
 
   /**
-   * Expose entityCleanupSkippedTypes() for testing.
+   * Expose helperEntityCleanupSkippedTypes() for testing.
    *
    * @param array<int, string> $tags
    *   Scenario tag names.
@@ -433,8 +434,8 @@ class HelperTraitTestImplementation {
    * @return array<int, string>
    *   Entity type ids to skip.
    */
-  public function callEntityCleanupSkippedTypes(array $tags): array {
-    return $this->entityCleanupSkippedTypes($tags);
+  public function callHelperEntityCleanupSkippedTypes(array $tags): array {
+    return $this->helperEntityCleanupSkippedTypes($tags);
   }
 
   /**
@@ -443,8 +444,8 @@ class HelperTraitTestImplementation {
    * @return array<int, array{0: string, 1: int|string}>
    *   The registered entities.
    */
-  public function getEntityRegistry(): array {
-    return $this->entityRegistry;
+  public function getHelperEntityRegistry(): array {
+    return $this->helperEntityRegistry;
   }
 
   /**
@@ -453,8 +454,8 @@ class HelperTraitTestImplementation {
    * @param array<int, string> $skip_types
    *   Entity type ids to leave in place.
    */
-  public function callEntityCleanupRun(array $skip_types): void {
-    $this->entityCleanupRun($skip_types);
+  public function callHelperEntityCleanupRun(array $skip_types): void {
+    $this->helperEntityCleanupRun($skip_types);
   }
 
   /**
@@ -462,7 +463,7 @@ class HelperTraitTestImplementation {
    *
    * Overridden to record deletions instead of touching Drupal.
    */
-  protected function entityCleanupDelete(string $entity_type_id, int|string $entity_id): void {
+  protected function helperEntityCleanupDelete(string $entity_type_id, int|string $entity_id): void {
     $this->deleted[] = [$entity_type_id, $entity_id];
   }
 

--- a/tests/phpunit/src/TraitMethodNamingTest.php
+++ b/tests/phpunit/src/TraitMethodNamingTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests;
+
+use DrevOps\BehatSteps\Drupal\OverrideTrait;
+use DrevOps\BehatSteps\Drupal\TaxonomyTrait;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Asserts that every trait method is prefixed with its trait's name.
+ *
+ * Traits are mixed into a single consumer context, so an unprefixed method
+ * name can collide with a method of the same name from another trait.
+ */
+#[CoversNothing]
+class TraitMethodNamingTest extends UnitTestCase {
+
+  /**
+   * Methods that override a Drupal Extension context method.
+   *
+   * An override binds by name, so these cannot carry the trait prefix.
+   *
+   * @var array<class-string, array<int, string>>
+   */
+  const PARENT_OVERRIDES = [
+    OverrideTrait::class => ['createNodes', 'createUsers', 'iAmLoggedInAsUserWithRole'],
+    TaxonomyTrait::class => ['createTerms'],
+  ];
+
+  #[DataProvider('dataProviderTraits')]
+  public function testMethodNamesArePrefixedWithTraitName(string $trait, string $file): void {
+    $reflection = new \ReflectionClass($trait);
+    $prefix = self::traitPrefix($reflection->getShortName());
+    $allowed = self::PARENT_OVERRIDES[$trait] ?? [];
+
+    $violations = [];
+    foreach ($reflection->getMethods() as $method) {
+      // A trait that composes another trait reports the composed methods
+      // too; the file each method is declared in tells them apart.
+      if (realpath((string) $method->getFileName()) !== $file) {
+        continue;
+      }
+
+      $name = $method->getName();
+
+      if (in_array($name, $allowed, TRUE) || self::hasPrefix($name, $prefix)) {
+        continue;
+      }
+
+      $violations[] = $name;
+    }
+
+    $this->assertSame([], $violations, sprintf('Methods in %s must be prefixed with "%s".', $reflection->getShortName(), $prefix));
+  }
+
+  public static function dataProviderTraits(): array {
+    $root = realpath(__DIR__ . '/../../../src');
+    $files = [];
+
+    $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator((string) $root));
+    foreach ($iterator as $file) {
+      if (!$file instanceof \SplFileInfo || $file->getExtension() !== 'php') {
+        continue;
+      }
+
+      $path = (string) $file->getRealPath();
+      $relative = substr($path, strlen((string) $root) + 1);
+      $trait = 'DrevOps\\BehatSteps\\' . str_replace(DIRECTORY_SEPARATOR, '\\', substr($relative, 0, -strlen('.php')));
+
+      $files[$relative] = [$trait, $path];
+    }
+
+    ksort($files);
+
+    return $files;
+  }
+
+  /**
+   * The allowlist is not a place to retire a method that no longer exists.
+   */
+  public function testParentOverrideAllowlistIsCurrent(): void {
+    foreach (self::PARENT_OVERRIDES as $trait => $methods) {
+      $reflection = new \ReflectionClass($trait);
+
+      foreach ($methods as $method) {
+        $this->assertTrue($reflection->hasMethod($method), sprintf('%s::%s() is allowlisted but does not exist.', $reflection->getShortName(), $method));
+        $this->assertFalse(self::hasPrefix($method, self::traitPrefix($reflection->getShortName())), sprintf('%s::%s() is allowlisted but already conforms; remove the entry.', $reflection->getShortName(), $method));
+      }
+    }
+  }
+
+  /**
+   * Derive the method prefix a trait requires from its short name.
+   */
+  protected static function traitPrefix(string $short_name): string {
+    return lcfirst(substr($short_name, 0, -strlen('Trait')));
+  }
+
+  /**
+   * Check that a method name opens with the prefix as a whole word.
+   *
+   * The character after the prefix must be uppercase so that a name which
+   * merely starts with the same letters, such as 'waiting' against 'wait',
+   * is not accepted.
+   */
+  protected static function hasPrefix(string $method, string $prefix): bool {
+    if ($method === $prefix) {
+      return TRUE;
+    }
+
+    return str_starts_with($method, $prefix) && ctype_upper($method[strlen($prefix)]);
+  }
+
+}

--- a/tests/phpunit/src/TraitMethodNamingTest.php
+++ b/tests/phpunit/src/TraitMethodNamingTest.php
@@ -44,8 +44,10 @@ class TraitMethodNamingTest extends UnitTestCase {
     $prefix = self::traitPrefix($reflection->getShortName());
     $allowed = self::PARENT_OVERRIDES[$trait] ?? [];
 
+    $methods = $reflection->getMethods();
+
     $violations = [];
-    foreach ($reflection->getMethods() as $method) {
+    foreach ($methods as $method) {
       // A trait that composes another trait reports the composed methods
       // too; the file each method is declared in tells them apart.
       if (realpath((string) $method->getFileName()) !== $file) {

--- a/tests/phpunit/src/TraitMethodNamingTest.php
+++ b/tests/phpunit/src/TraitMethodNamingTest.php
@@ -30,8 +30,16 @@ class TraitMethodNamingTest extends UnitTestCase {
     TaxonomyTrait::class => ['createTerms'],
   ];
 
-  #[DataProvider('dataProviderTraits')]
-  public function testMethodNamesArePrefixedWithTraitName(string $trait, string $file): void {
+  /**
+   * Assert that every method a trait declares carries the trait's prefix.
+   *
+   * @param class-string $trait
+   *   The trait to check.
+   * @param string $file
+   *   The absolute path to the file declaring the trait.
+   */
+  #[DataProvider('dataProviderMethodsArePrefixed')]
+  public function testMethodsArePrefixed(string $trait, string $file): void {
     $reflection = new \ReflectionClass($trait);
     $prefix = self::traitPrefix($reflection->getShortName());
     $allowed = self::PARENT_OVERRIDES[$trait] ?? [];
@@ -56,7 +64,7 @@ class TraitMethodNamingTest extends UnitTestCase {
     $this->assertSame([], $violations, sprintf('Methods in %s must be prefixed with "%s".', $reflection->getShortName(), $prefix));
   }
 
-  public static function dataProviderTraits(): array {
+  public static function dataProviderMethodsArePrefixed(): array {
     $root = realpath(__DIR__ . '/../../../src');
     $files = [];
 


### PR DESCRIPTION
Closes #713

## Summary

Every method a trait contributes to the composed context now begins with that trait's name: `MenuTrait::menuLoadByLabel()`, `WaitTrait::waitSeconds()`, `DraggableviewsTrait::draggableviewsSaveBundleOrder()`, and the six entity-registry members of `Drupal\HelperTrait` as `helperEntity*`. `tests/phpunit/src/TraitMethodNamingTest.php` reflects all 51 traits in `src/` and fails the build when a method breaks the rule.

Fourteen members broke a convention that `CONTRIBUTING.md` stated but nothing checked, which is how they accumulated unnoticed. `Drupal\HelperTrait` was the worst case: it mixed a `helper*` family with an `entity*` family in one file, and because traits flatten into a single class, an unprefixed name such as `entityRegister()` collides with any same-named method another trait or the consumer context defines. `waitWaitForSeconds()` doubled its prefix as the verb and `waitForAjaxToFinish()` fused the prefix into the phrase.

Consumer contexts that call or override any renamed member must update to the new name, and `MIGRATION.md` carries the full mapping. Gherkin step text is unchanged, so feature files need no edit except for one tag: `@behat-steps-skip:entityCleanupAfterScenario` becomes `@behat-steps-skip:helperEntityCleanupAfterScenario`, because the hook derives that tag from its own method name. `Drupal\OverrideTrait::createNodes()`, `::createUsers()`, `::iAmLoggedInAsUserWithRole()` and `Drupal\TaxonomyTrait::createTerms()` override Drupal Extension context methods, bind by name, and keep theirs; they are listed in `PARENT_OVERRIDES` rather than left looking like violations.

## Before / After

```
BEFORE - two prefix families in one trait, colliding in the composed context

  FeatureContext
  ├── use Drupal\HelperTrait ──┬── helperExpandEntityFieldsFixtures()   helper*
  │                            ├── helperManagedFileExists()            helper*
  │                            ├── entityRegister()          ◄── entity*  collides
  │                            ├── entityRegisterId()        ◄── entity*
  │                            └── entityCleanupAfterScenario() ◄── entity*
  ├── use Drupal\MenuTrait ────┬── menuCreate()
  │                            ├── loadMenuByLabel()         ◄── no prefix at all
  │                            └── loadMenuLinkByTitle()     ◄── no prefix at all
  └── use WaitTrait ───────────┬── waitWaitForSeconds()      ◄── prefix doubled as verb
                               └── waitForAjaxToFinish()     ◄── prefix fused into phrase

  CONTRIBUTING.md states the rule ─────► nothing enforces it


AFTER - one prefix family per trait, enforced

  FeatureContext
  ├── use Drupal\HelperTrait ──┬── helperExpandEntityFieldsFixtures()
  │                            ├── helperManagedFileExists()
  │                            ├── helperEntityRegister()
  │                            ├── helperEntityRegisterId()
  │                            └── helperEntityCleanupAfterScenario()
  ├── use Drupal\MenuTrait ────┬── menuCreate()
  │                            ├── menuLoadByLabel()
  │                            └── menuLoadLinkByTitle()
  └── use WaitTrait ───────────┬── waitSeconds()
                               └── waitForAjax()

  CONTRIBUTING.md states the rule ─────► TraitMethodNamingTest enforces it
                                          │
                                          ├── 51 traits reflected
                                          ├── prefix must end on an uppercase boundary
                                          └── PARENT_OVERRIDES allowlists the 4 overrides
```

## Changes

**Renames** - `src/Drupal/MenuTrait.php`, `src/Drupal/HelperTrait.php`, `src/Drupal/DraggableviewsTrait.php`, `src/WaitTrait.php`:

| Trait | Old | New |
| --- | --- | --- |
| `Drupal\MenuTrait` | `loadMenuByLabel()` | `menuLoadByLabel()` |
| `Drupal\MenuTrait` | `loadMenuLinkByTitle()` | `menuLoadLinkByTitle()` |
| `Drupal\HelperTrait` | `entityRegister()` | `helperEntityRegister()` |
| `Drupal\HelperTrait` | `entityRegisterId()` | `helperEntityRegisterId()` |
| `Drupal\HelperTrait` | `entityCleanupAfterScenario()` | `helperEntityCleanupAfterScenario()` |
| `Drupal\HelperTrait` | `entityCleanupRun()` | `helperEntityCleanupRun()` |
| `Drupal\HelperTrait` | `entityCleanupDelete()` | `helperEntityCleanupDelete()` |
| `Drupal\HelperTrait` | `entityCleanupSkippedTypes()` | `helperEntityCleanupSkippedTypes()` |
| `Drupal\HelperTrait` | `$entityRegistry` | `$helperEntityRegistry` |
| `Drupal\HelperTrait` | `ENTITY_CLEANUP_EXCLUDED_TYPES` | `HELPER_ENTITY_CLEANUP_EXCLUDED_TYPES` |
| `Drupal\DraggableviewsTrait` | `draggableViewsSaveBundleOrder()` | `draggableviewsSaveBundleOrder()` |
| `Drupal\DraggableviewsTrait` | `draggableViewsFindNode()` | `draggableviewsFindNode()` |
| `WaitTrait` | `waitWaitForSeconds()` | `waitSeconds()` |
| `WaitTrait` | `waitForAjaxToFinish()` | `waitForAjax()` |

The property and constant move with the six methods because they are the same misprefixed `entity*` family; leaving them would put `$this->entityRegistry` inside `helperEntityRegister()` and keep two unprefixed members on every consumer context. `draggableviews` lowercases rather than renaming the trait, since the trait name matches the Drupal module machine name.

**Call sites** - `src/Drupal/{Block,ContentBlock,Eck,File,Media,Menu,Paragraphs,Redirect,Webform}Trait.php`: the nine `$this->entityRegister()` calls become `$this->helperEntityRegister()`.

**Enforcement** - `tests/phpunit/src/TraitMethodNamingTest.php` (new): a data provider yields one case per trait file under `src/`. Each case reflects the trait and keeps only methods whose declaring file is that trait's own, so members inherited from a composed trait are not double-checked. A name passes when it equals the prefix or continues with an uppercase character, so `waiting` cannot pass for `wait`. `testParentOverrideAllowlistIsCurrent()` fails if an allowlisted method stops existing or starts conforming, so the allowlist cannot rot.

**Documentation** - `CONTRIBUTING.md` spells out how the prefix is derived and records the parent-override exception; `MIGRATION.md` gains the full rename mapping and the tag change; `README.md` updates the skip tag in the automatic-entity-cleanup section.

**Tests** - `tests/phpunit/src/Drupal/HelperTraitTest.php` follows the renames, including its harness accessors (`callHelperEntityRegisterId()`, `getHelperEntityRegistry()`), and `tests/behat/features/drupal_entity_cleanup.feature` uses the new skip tag. That scenario is the executable proof the tag still works.

## Verification

CI covers the suite across the full matrix. Two things it does not show:

- `TraitMethodNamingTest` was checked against an injected violation, not only against clean code: renaming `waitSeconds()` to `sleepSeconds()` fails the `WaitTrait.php` data set with `Methods in WaitTrait must be prefixed with "wait"`, naming the offending method.
- `docs.php` renders `camel_to_snake()` over trait names only, never method names, so `STEPS.md` does not reflow. `ahoy lint-docs` confirms it is unchanged.
