### PR TITLE
[#715] Tidied public-surface visibility, constants, property types, and hook signatures across traits.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -333,3 +333,76 @@ If your project catches an exception from one of these steps, update the type:
 | `the option :option should not exist within the select element :selector` | `Element "..." is not found.` / `Option "..." is found in select "...", but should not.` | `Select with id\|name\|label "..." not found.` / `The option "..." was found in the select "..." on the page ..., but should not exist.` |
 
 Behat reports every one of these as a failed step either way, so a scenario that simply runs to a failure behaves the same. Only code that catches a specific type, or asserts on the message text, needs changing.
+
+## Tightened public surface
+
+A handful of trait members exposed more than the surrounding code intended. Each one is reachable from a consuming context, so they're grouped here as breaking changes rather than fixed quietly. A `PublicSurfaceTest` now holds each of these conventions, so the surface stays deliberate from here on.
+
+### Internal helpers are now `protected`
+
+Neither method is a step or a hook, and both were only ever called from step methods in their own trait. Calling them from outside the context object no longer works; calling them from inside it is unchanged.
+
+| Method | Was | Now |
+| --- | --- | --- |
+| `KeyboardTrait::keyboardPressKeyOnElementSingle()` | `public` | `protected` |
+| `FileDownloadTrait::fileDownloadAssertLinkPresent()` | `public` | `protected` |
+
+`DateTrait::dateRelativeProcessValue()` and `ResponsiveTrait::responsiveSetBreakpoints()` stay public and are now documented as API in their docblocks. `DateTrait` also stays static on purpose: `dateNow()` is the supported seam for pinning the clock, and overriding it in your `FeatureContext` still works exactly as before.
+
+### Constants carry their trait prefix
+
+PHP treats two composed traits declaring the same constant name as a fatal error, so a generic name like `IMPACT_CRITICAL` is a collision waiting to happen in someone else's context.
+
+| Constant | Replacement |
+| --- | --- |
+| `AccessibilityTrait::IMPACT_CRITICAL` | `AccessibilityTrait::ACCESSIBILITY_IMPACT_CRITICAL` |
+| `AccessibilityTrait::IMPACT_SERIOUS` | `AccessibilityTrait::ACCESSIBILITY_IMPACT_SERIOUS` |
+| `AccessibilityTrait::IMPACT_MODERATE` | `AccessibilityTrait::ACCESSIBILITY_IMPACT_MODERATE` |
+| `AccessibilityTrait::IMPACT_MINOR` | `AccessibilityTrait::ACCESSIBILITY_IMPACT_MINOR` |
+| `Drupal\BigPipeTrait::DEFAULT_WAIT_TIMEOUT` | `Drupal\BigPipeTrait::BIG_PIPE_DEFAULT_WAIT_TIMEOUT` |
+
+`Drupal\HelperTrait::HELPER_ENTITY_CLEANUP_EXCLUDED_TYPES`, renamed in the section above, is also now explicitly `protected` instead of implicitly public.
+
+### `FieldTrait` no longer re-exports the keyboard steps
+
+`FieldTrait` composed `KeyboardTrait` without calling it, so a context composing only `FieldTrait` silently received every keyboard step. That composition is gone. If your context relies on those steps, compose the trait directly:
+
+```php
+use DrevOps\BehatSteps\KeyboardTrait;
+
+class FeatureContext extends DrupalContext {
+
+  use FieldTrait;
+  use KeyboardTrait;
+
+}
+```
+
+### Hooks declare their scope parameter
+
+Hook methods used to come in 3 shapes: taking and using the scope, taking and ignoring it, or declaring no parameter at all. They all declare it now, used or not, so there's one signature to match when you override one. If you override any of these in your `FeatureContext`, add the parameter:
+
+| Hook | New signature |
+| --- | --- |
+| `AccessibilityTrait::accessibilityAggregateRender()` | `(AfterSuiteScope $scope)` |
+| `AccessibilityTrait::accessibilityAggregateReset()` | `(BeforeSuiteScope $scope)` |
+| `AccessibilityTrait::accessibilityCaptureBaseDir()` | `(BeforeSuiteScope $scope)` |
+| `CommandTrait::commandAfterScenario()` | `(AfterScenarioScope $scope)` |
+| `CommandTrait::commandBeforeScenario()` | `(BeforeScenarioScope $scope)` |
+| `Drupal\BigPipeTrait::bigPipeWaitBeforeStep()` | `(BeforeStepScope $scope)` |
+| `JsonTrait::jsonAfterScenario()` | `(AfterScenarioScope $scope)` |
+| `JsonTrait::jsonBeforeScenario()` | `(BeforeScenarioScope $scope)` |
+| `XmlTrait::xmlAfterScenario()` | `(AfterScenarioScope $scope)` |
+| `XmlTrait::xmlBeforeScenario()` | `(BeforeScenarioScope $scope)` |
+
+### Properties declare native types
+
+5 properties relied on a `@var` docblock with no native type. They're typed now, which narrows what a subclass may assign to them.
+
+| Property | Type |
+| --- | --- |
+| `Drupal\FileTrait::$filesUnmanagedUris` | `array` |
+| `Drupal\RedirectTrait::$redirectAllowedStatusCodes` | `array` |
+| `Drupal\WatchdogTrait::$watchdogMessageTypes` | `array` |
+| `Drupal\WatchdogTrait::$watchdogScenarioStartTime` | `?int` |
+| `FileDownloadTrait::$fileDownloadDownloadedFileInfo` | `array` |

--- a/STEPS.md
+++ b/STEPS.md
@@ -487,6 +487,11 @@ Then a cookie with a name containing "user" and a value containing "guest" shoul
 >  Examples:
 >  - `[relative:-1 day]` converted to `1893456000`
 >  - `[relative:-1 day#Y-m-d]` converted to `2017-11-5`
+>  
+>  `dateRelativeProcessValue()` is public API. It and its helpers are static so
+>  a token resolves without a context instance. Late static binding routes the
+>  resolution through a `dateNow()` override in the composing context, which is
+>  the supported seam for pinning the clock.
 
 
 ## DiagnosticsTrait

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -14,6 +14,8 @@ use Behat\Hook\BeforeScenario;
 use Behat\Hook\BeforeSuite;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Step\Then;
+use Behat\Testwork\Hook\Scope\AfterSuiteScope;
+use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 
 /**
  * Assess accessibility of rendered pages.
@@ -59,13 +61,13 @@ trait AccessibilityTrait {
    * shape. Threshold tags (`@accessibility:critical`, `@accessibility:serious`
    * etc.) and the gate-filter logic both compare against these values.
    */
-  public const IMPACT_CRITICAL = 'critical';
+  public const ACCESSIBILITY_IMPACT_CRITICAL = 'critical';
 
-  public const IMPACT_SERIOUS = 'serious';
+  public const ACCESSIBILITY_IMPACT_SERIOUS = 'serious';
 
-  public const IMPACT_MODERATE = 'moderate';
+  public const ACCESSIBILITY_IMPACT_MODERATE = 'moderate';
 
-  public const IMPACT_MINOR = 'minor';
+  public const ACCESSIBILITY_IMPACT_MINOR = 'minor';
 
   /**
    * In-memory cache for the engine JavaScript source, fetched once per process.
@@ -155,7 +157,7 @@ trait AccessibilityTrait {
    * Capture the working directory once, before any scenario can chdir().
    */
   #[BeforeSuite]
-  public static function accessibilityCaptureBaseDir(): void {
+  public static function accessibilityCaptureBaseDir(BeforeSuiteScope $scope): void {
     if (self::$accessibilityBaseDir === NULL) {
       $cwd = getcwd();
       // Leave the base unset when getcwd() fails so
@@ -174,7 +176,7 @@ trait AccessibilityTrait {
    * second suite in the same process from inheriting the first one's results.
    */
   #[BeforeSuite]
-  public static function accessibilityAggregateReset(): void {
+  public static function accessibilityAggregateReset(BeforeSuiteScope $scope): void {
     self::$accessibilityAggregate = [];
     self::$accessibilityAggregateReportDir = NULL;
   }
@@ -327,7 +329,7 @@ trait AccessibilityTrait {
    * Render the single cross-page report after the whole suite has run.
    */
   #[AfterSuite]
-  public static function accessibilityAggregateRender(): void {
+  public static function accessibilityAggregateRender(AfterSuiteScope $scope): void {
     static::accessibilityWriteAggregateReport();
   }
 
@@ -480,9 +482,9 @@ trait AccessibilityTrait {
   /**
    * Return the canonical impact levels in descending severity order.
    *
-   * Default: the four `IMPACT_*` constants on this trait. Engines with a
-   * different severity vocabulary map to these constants inside
-   * `accessibilityNormalizeResults()`.
+   * Default: the four `ACCESSIBILITY_IMPACT_*` constants on this trait.
+   * Engines with a different severity vocabulary map to these constants
+   * inside `accessibilityNormalizeResults()`.
    *
    * @return array<int, string>
    *   Impact identifiers ordered from most severe to least.
@@ -502,10 +504,10 @@ trait AccessibilityTrait {
    */
   protected static function accessibilityGetDefaultImpacts(): array {
     return [
-      self::IMPACT_CRITICAL,
-      self::IMPACT_SERIOUS,
-      self::IMPACT_MODERATE,
-      self::IMPACT_MINOR,
+      self::ACCESSIBILITY_IMPACT_CRITICAL,
+      self::ACCESSIBILITY_IMPACT_SERIOUS,
+      self::ACCESSIBILITY_IMPACT_MODERATE,
+      self::ACCESSIBILITY_IMPACT_MINOR,
     ];
   }
 
@@ -580,19 +582,19 @@ trait AccessibilityTrait {
         $impact = strtolower((string) ($issue['impact'] ?? ''));
         switch ($impact) {
           case 'critical':
-            $impact = self::IMPACT_CRITICAL;
+            $impact = self::ACCESSIBILITY_IMPACT_CRITICAL;
             break;
 
           case 'serious':
-            $impact = self::IMPACT_SERIOUS;
+            $impact = self::ACCESSIBILITY_IMPACT_SERIOUS;
             break;
 
           case 'moderate':
-            $impact = self::IMPACT_MODERATE;
+            $impact = self::ACCESSIBILITY_IMPACT_MODERATE;
             break;
 
           default:
-            $impact = self::IMPACT_MINOR;
+            $impact = self::ACCESSIBILITY_IMPACT_MINOR;
         }
 
         $nodes = [];
@@ -1170,7 +1172,7 @@ HTML;
 
     foreach ($pages as $url => $page) {
       foreach ($page['violations'] ?? [] as $violation) {
-        $impact = (string) ($violation['impact'] ?? self::IMPACT_MINOR);
+        $impact = (string) ($violation['impact'] ?? self::ACCESSIBILITY_IMPACT_MINOR);
         $totals[$impact] = ($totals[$impact] ?? 0) + 1;
 
         $rule_id = (string) ($violation['id'] ?? 'unknown');
@@ -1232,7 +1234,7 @@ HTML;
       foreach ($page['violations'] ?? [] as $violation) {
         $chips[] = [
           'id' => (string) ($violation['id'] ?? 'unknown'),
-          'impact' => strtolower((string) ($violation['impact'] ?? self::IMPACT_MINOR)),
+          'impact' => strtolower((string) ($violation['impact'] ?? self::ACCESSIBILITY_IMPACT_MINOR)),
           'count' => count($violation['nodes'] ?? []),
         ];
       }
@@ -1249,7 +1251,7 @@ HTML;
     foreach ($rollup['rules'] as $rule_id => $rule) {
       $rules[] = [
         'id' => (string) $rule_id,
-        'impact' => (string) ($rule['impact'] ?? self::IMPACT_MINOR),
+        'impact' => (string) ($rule['impact'] ?? self::ACCESSIBILITY_IMPACT_MINOR),
         'help' => (string) ($rule['help'] ?? ''),
         'helpUrl' => (string) ($rule['helpUrl'] ?? ''),
         'page_count' => count($rule['pages'] ?? []),
@@ -1370,17 +1372,17 @@ HTML;
       . sprintf('<div class="card "><span class="num">%d</span><span class="lbl">pages assessed</span></div>', (int) ($data['page_count'] ?? 0))
       . sprintf('<div class="card "><span class="num">%d</span><span class="lbl">scenarios</span></div>', (int) ($data['scenario_count'] ?? 0))
       . sprintf('<div class="card %s"><span class="num">%d</span><span class="lbl">violations</span></div>', $state, (int) ($data['total_violations'] ?? 0))
-      . sprintf('<div class="card crit"><span class="num">%d</span><span class="lbl">critical</span></div>', (int) ($totals[self::IMPACT_CRITICAL] ?? 0))
-      . sprintf('<div class="card ser"><span class="num">%d</span><span class="lbl">serious</span></div>', (int) ($totals[self::IMPACT_SERIOUS] ?? 0))
-      . sprintf('<div class="card mod"><span class="num">%d</span><span class="lbl">moderate</span></div>', (int) ($totals[self::IMPACT_MODERATE] ?? 0))
-      . sprintf('<div class="card min"><span class="num">%d</span><span class="lbl">minor</span></div>', (int) ($totals[self::IMPACT_MINOR] ?? 0))
+      . sprintf('<div class="card crit"><span class="num">%d</span><span class="lbl">critical</span></div>', (int) ($totals[self::ACCESSIBILITY_IMPACT_CRITICAL] ?? 0))
+      . sprintf('<div class="card ser"><span class="num">%d</span><span class="lbl">serious</span></div>', (int) ($totals[self::ACCESSIBILITY_IMPACT_SERIOUS] ?? 0))
+      . sprintf('<div class="card mod"><span class="num">%d</span><span class="lbl">moderate</span></div>', (int) ($totals[self::ACCESSIBILITY_IMPACT_MODERATE] ?? 0))
+      . sprintf('<div class="card min"><span class="num">%d</span><span class="lbl">minor</span></div>', (int) ($totals[self::ACCESSIBILITY_IMPACT_MINOR] ?? 0))
       . '</section>';
 
     $rows = [];
     foreach ($data['pages'] ?? [] as $page) {
       $chips = [];
       foreach ($page['violations'] ?? [] as $chip) {
-        $chips[] = sprintf('<span class="vtype %s">%s <b>%d</b></span>', htmlspecialchars((string) ($chip['impact'] ?? self::IMPACT_MINOR), ENT_QUOTES), htmlspecialchars((string) ($chip['id'] ?? 'unknown'), ENT_QUOTES), (int) ($chip['count'] ?? 0));
+        $chips[] = sprintf('<span class="vtype %s">%s <b>%d</b></span>', htmlspecialchars((string) ($chip['impact'] ?? self::ACCESSIBILITY_IMPACT_MINOR), ENT_QUOTES), htmlspecialchars((string) ($chip['id'] ?? 'unknown'), ENT_QUOTES), (int) ($chip['count'] ?? 0));
       }
       $vtypes = $chips === [] ? '<span class="muted">&mdash;</span>' : implode('', $chips);
       $rows[] = sprintf('<tr class="%s"><td class="url">%s</td><td class="vtypes">%s</td><td class="n">%d</td><td class="n">%d</td><td class="muted">%s</td></tr>', $chips === [] ? 'good' : 'bad', htmlspecialchars((string) ($page['url'] ?? ''), ENT_QUOTES), $vtypes, (int) ($page['incomplete'] ?? 0), (int) ($page['passes'] ?? 0), htmlspecialchars((string) ($page['scenarios'] ?? ''), ENT_QUOTES));
@@ -1399,7 +1401,7 @@ HTML;
         foreach ($rule['nodes'] ?? [] as $node) {
           $nodes[] = sprintf('<div class="node"><div class="where"><code>%s</code> &middot; <span class="muted">%s</span></div><pre>%s</pre></div>', htmlspecialchars((string) ($node['target'] ?? ''), ENT_QUOTES), htmlspecialchars((string) ($node['url'] ?? ''), ENT_QUOTES), htmlspecialchars((string) ($node['html'] ?? ''), ENT_QUOTES));
         }
-        $impact = htmlspecialchars((string) ($rule['impact'] ?? self::IMPACT_MINOR), ENT_QUOTES);
+        $impact = htmlspecialchars((string) ($rule['impact'] ?? self::ACCESSIBILITY_IMPACT_MINOR), ENT_QUOTES);
         $docs = ((string) ($rule['helpUrl'] ?? '')) !== '' ? sprintf(' &middot; <a href="%s" target="_blank" rel="noopener">docs</a>', htmlspecialchars((string) $rule['helpUrl'], ENT_QUOTES)) : '';
         $blocks[] = sprintf('<div class="rule"><h3><span class="impact %s">%s</span> <span class="rule-id">%s</span></h3><p class="meta">%s &middot; affects %d page(s) &middot; %d element(s)%s</p>%s</div>', $impact, $impact, htmlspecialchars((string) ($rule['id'] ?? 'unknown'), ENT_QUOTES), htmlspecialchars((string) ($rule['help'] ?? ''), ENT_QUOTES), (int) ($rule['page_count'] ?? 0), count($rule['nodes'] ?? []), $docs, implode('', $nodes));
       }

--- a/src/CommandTrait.php
+++ b/src/CommandTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Step\Then;
@@ -48,7 +50,7 @@ trait CommandTrait {
    * Clear captured command state before each scenario.
    */
   #[BeforeScenario]
-  public function commandBeforeScenario(): void {
+  public function commandBeforeScenario(BeforeScenarioScope $scope): void {
     $this->commandResetState();
   }
 
@@ -56,7 +58,7 @@ trait CommandTrait {
    * Clear captured command state after each scenario.
    */
   #[AfterScenario]
-  public function commandAfterScenario(): void {
+  public function commandAfterScenario(AfterScenarioScope $scope): void {
     $this->commandResetState();
   }
 

--- a/src/DateTrait.php
+++ b/src/DateTrait.php
@@ -23,6 +23,11 @@ use Behat\Transformation\Transform;
  * Examples:
  * - `[relative:-1 day]` converted to `1893456000`
  * - `[relative:-1 day#Y-m-d]` converted to `2017-11-5`
+ *
+ * `dateRelativeProcessValue()` is public API. It and its helpers are static so
+ * a token resolves without a context instance. Late static binding routes the
+ * resolution through a `dateNow()` override in the composing context, which is
+ * the supported seam for pinning the clock.
  */
 trait DateTrait {
 
@@ -67,6 +72,9 @@ trait DateTrait {
 
   /**
    * Process date values to convert relative timestamps to actual values.
+   *
+   * Public API: a composing context may call this directly to resolve a token
+   * outside a step.
    *
    * Possible formats:
    * [relative:OFFSET]

--- a/src/Drupal/BigPipeTrait.php
+++ b/src/Drupal/BigPipeTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps\Drupal;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Hook\BeforeScenario;
 use Behat\Hook\BeforeStep;
 use Behat\Mink\Exception\DriverException;
@@ -35,7 +36,7 @@ trait BigPipeTrait {
   /**
    * Default maximum time to wait for BigPipe placeholders, in milliseconds.
    */
-  protected const DEFAULT_WAIT_TIMEOUT = 10000;
+  protected const BIG_PIPE_DEFAULT_WAIT_TIMEOUT = 10000;
 
   /**
    * Whether the automatic BigPipe wait is active for the current scenario.
@@ -45,7 +46,7 @@ trait BigPipeTrait {
   /**
    * Maximum time to wait for BigPipe placeholders to be replaced, in milliseconds.
    */
-  protected int $bigPipeWaitTimeout = self::DEFAULT_WAIT_TIMEOUT;
+  protected int $bigPipeWaitTimeout = self::BIG_PIPE_DEFAULT_WAIT_TIMEOUT;
 
   /**
    * Resolve whether the automatic BigPipe wait applies to this scenario.
@@ -70,7 +71,7 @@ trait BigPipeTrait {
    * `bigPipeBeforeStep()` hook, inherited through `DrupalContext`.
    */
   #[BeforeStep]
-  public function bigPipeWaitBeforeStep(): void {
+  public function bigPipeWaitBeforeStep(BeforeStepScope $scope): void {
     if (!$this->bigPipeAutoWaitEnabled) {
       return;
     }

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -37,7 +37,7 @@ trait FileTrait {
    *
    * @var array<int, string>
    */
-  protected $filesUnmanagedUris = [];
+  protected array $filesUnmanagedUris = [];
 
   /**
    * Ensure private and temp directories exist.

--- a/src/Drupal/HelperTrait.php
+++ b/src/Drupal/HelperTrait.php
@@ -43,7 +43,7 @@ trait HelperTrait {
    * Never deleted by this trait to avoid double-deletion with the base
    * extension (re-deleting a user or language throws, unlike nodes/terms).
    */
-  const HELPER_ENTITY_CLEANUP_EXCLUDED_TYPES = [
+  protected const HELPER_ENTITY_CLEANUP_EXCLUDED_TYPES = [
     'node',
     'user',
     'taxonomy_term',

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -32,7 +32,7 @@ trait RedirectTrait {
    *
    * @var int[]
    */
-  protected static $redirectAllowedStatusCodes = [301, 302, 303, 307, 308];
+  protected static array $redirectAllowedStatusCodes = [301, 302, 303, 307, 308];
 
   /**
    * Create one or more redirects.

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -34,17 +34,15 @@ trait WatchdogTrait {
 
   /**
    * Start time for each scenario.
-   *
-   * @var int|null
    */
-  protected $watchdogScenarioStartTime;
+  protected ?int $watchdogScenarioStartTime = NULL;
 
   /**
    * Array of watchdog message types.
    *
    * @var array<int, string>
    */
-  protected $watchdogMessageTypes = [];
+  protected array $watchdogMessageTypes = [];
 
   /**
    * Title of the current scenario.

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -32,7 +32,6 @@ use Behat\Step\When;
 trait FieldTrait {
 
   use HelperTrait;
-  use KeyboardTrait;
 
   /**
    * Registry of form selectors that should have validation disabled.

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -38,7 +38,7 @@ trait FileDownloadTrait {
    *
    * @var array<string, mixed>
    */
-  protected $fileDownloadDownloadedFileInfo;
+  protected array $fileDownloadDownloadedFileInfo = [];
 
   /**
    * Prepare scenario to work with this trait.
@@ -157,7 +157,7 @@ trait FileDownloadTrait {
   /**
    * Assert that an HTML link is present on the page.
    */
-  public function fileDownloadAssertLinkPresent(string $link): NodeElement {
+  protected function fileDownloadAssertLinkPresent(string $link): NodeElement {
     $page = $this->getSession()->getPage();
     $link_element = $page->findLink($link);
 

--- a/src/JsonTrait.php
+++ b/src/JsonTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
@@ -52,7 +54,7 @@ trait JsonTrait {
    * Clear cached JSON state before each scenario.
    */
   #[BeforeScenario]
-  public function jsonBeforeScenario(): void {
+  public function jsonBeforeScenario(BeforeScenarioScope $scope): void {
     $this->jsonResetState();
   }
 
@@ -60,7 +62,7 @@ trait JsonTrait {
    * Clear cached JSON state after each scenario.
    */
   #[AfterScenario]
-  public function jsonAfterScenario(): void {
+  public function jsonAfterScenario(AfterScenarioScope $scope): void {
     $this->jsonResetState();
   }
 

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -91,7 +91,7 @@ trait KeyboardTrait {
    * @throws \Behat\Mink\Exception\UnsupportedDriverActionException
    *   If method is used for invalid driver.
    */
-  public function keyboardPressKeyOnElementSingle(string $char, ?string $selector): void {
+  protected function keyboardPressKeyOnElementSingle(string $char, ?string $selector): void {
     $driver = $this->getSession()->getDriver();
 
     if ($driver instanceof BrowserKitDriver) {

--- a/src/ResponsiveTrait.php
+++ b/src/ResponsiveTrait.php
@@ -88,6 +88,9 @@ trait ResponsiveTrait {
   /**
    * Set custom breakpoints.
    *
+   * Public API: a composing context may call this directly to register
+   * breakpoints outside a step.
+   *
    * Custom breakpoints override default breakpoints with the same name.
    *
    * @param array<string, string> $breakpoints

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps;
 
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
@@ -48,7 +50,7 @@ trait XmlTrait {
    * Enable internal XML error handling before each scenario.
    */
   #[BeforeScenario]
-  public function xmlBeforeScenario(): void {
+  public function xmlBeforeScenario(BeforeScenarioScope $scope): void {
     libxml_use_internal_errors(TRUE);
     libxml_clear_errors();
 
@@ -64,7 +66,7 @@ trait XmlTrait {
    * Ensures fresh document parsing for each scenario.
    */
   #[AfterScenario]
-  public function xmlAfterScenario(): void {
+  public function xmlAfterScenario(AfterScenarioScope $scope): void {
     $this->xmlDocument = NULL;
     $this->xmlXpath = NULL;
     $this->xmlContentHash = NULL;

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -165,7 +165,7 @@ class FeatureContext extends DrupalContext {
    */
   #[BeforeScenario]
   public function bigPipeSetWaitTimeout(BeforeScenarioScope $scope): void {
-    $this->bigPipeWaitTimeout = $scope->getScenario()->hasTag('test-bigpipe-timeout') ? 2000 : self::DEFAULT_WAIT_TIMEOUT;
+    $this->bigPipeWaitTimeout = $scope->getScenario()->hasTag('test-bigpipe-timeout') ? 2000 : self::BIG_PIPE_DEFAULT_WAIT_TIMEOUT;
   }
 
 }

--- a/tests/phpunit/src/AccessibilityTraitTest.php
+++ b/tests/phpunit/src/AccessibilityTraitTest.php
@@ -27,7 +27,7 @@ class AccessibilityTraitTest extends UnitTestCase {
 
     $this->testObject = new AccessibilityTraitTestImplementation();
     AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
-    AccessibilityTraitTestImplementation::accessibilityAggregateReset();
+    AccessibilityTraitTestImplementation::accessibilityAggregateReset($this->createBeforeSuiteScope());
   }
 
   /**
@@ -35,7 +35,7 @@ class AccessibilityTraitTest extends UnitTestCase {
    */
   protected function tearDown(): void {
     AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
-    AccessibilityTraitTestImplementation::accessibilityAggregateReset();
+    AccessibilityTraitTestImplementation::accessibilityAggregateReset($this->createBeforeSuiteScope());
 
     parent::tearDown();
   }
@@ -91,7 +91,7 @@ class AccessibilityTraitTest extends UnitTestCase {
   public function testCaptureBaseDirSetsWhenUnset(): void {
     AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
 
-    AccessibilityTraitTestImplementation::accessibilityCaptureBaseDir();
+    AccessibilityTraitTestImplementation::accessibilityCaptureBaseDir($this->createBeforeSuiteScope());
 
     $this->assertSame(getcwd(), AccessibilityTraitTestImplementation::testGetBaseDir());
   }
@@ -99,7 +99,7 @@ class AccessibilityTraitTest extends UnitTestCase {
   public function testCaptureBaseDirDoesNotOverwrite(): void {
     AccessibilityTraitTestImplementation::testSetBaseDir('/sentinel/base');
 
-    AccessibilityTraitTestImplementation::accessibilityCaptureBaseDir();
+    AccessibilityTraitTestImplementation::accessibilityCaptureBaseDir($this->createBeforeSuiteScope());
 
     $this->assertSame('/sentinel/base', AccessibilityTraitTestImplementation::testGetBaseDir());
   }
@@ -220,7 +220,7 @@ class AccessibilityTraitTest extends UnitTestCase {
     AccessibilityTraitTestImplementation::testSetAggregate(static::createSampleAggregate());
     AccessibilityTraitTestImplementation::testSetAggregateReportDir($dir);
 
-    AccessibilityTraitTestImplementation::accessibilityAggregateRender();
+    AccessibilityTraitTestImplementation::accessibilityAggregateRender($this->createAfterSuiteScope());
 
     $this->assertNotEmpty(glob($dir . '/accessibility_report_*.html') ?: []);
   }
@@ -320,7 +320,7 @@ class AccessibilityTraitTest extends UnitTestCase {
     AccessibilityTraitTestImplementation::testSetAggregate(static::createSampleAggregate());
     AccessibilityTraitTestImplementation::testSetAggregateReportDir('/sentinel');
 
-    AccessibilityTraitTestImplementation::accessibilityAggregateReset();
+    AccessibilityTraitTestImplementation::accessibilityAggregateReset($this->createBeforeSuiteScope());
 
     $this->assertSame([], AccessibilityTraitTestImplementation::testGetAggregate());
     $this->assertNull(AccessibilityTraitTestImplementation::testGetAggregateReportDir());

--- a/tests/phpunit/src/CommandTraitTest.php
+++ b/tests/phpunit/src/CommandTraitTest.php
@@ -78,7 +78,7 @@ class CommandTraitTest extends UnitTestCase {
 
   public function testBeforeScenarioResetsState(): void {
     $this->testObject->commandRun('echo hello');
-    $this->testObject->commandBeforeScenario();
+    $this->testObject->commandBeforeScenario($this->createBeforeScenarioScope());
 
     $this->assertNull($this->testObject->exitCode());
     $this->assertSame('', $this->testObject->stdout());
@@ -86,7 +86,7 @@ class CommandTraitTest extends UnitTestCase {
 
   public function testAfterScenarioResetsState(): void {
     $this->testObject->commandRun('echo hello');
-    $this->testObject->commandAfterScenario();
+    $this->testObject->commandAfterScenario($this->createAfterScenarioScope());
 
     $this->assertNull($this->testObject->exitCode());
     $this->assertSame('', $this->testObject->stdout());

--- a/tests/phpunit/src/PublicSurfaceTest.php
+++ b/tests/phpunit/src/PublicSurfaceTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests;
+
+use Behat\Hook\AfterFeature;
+use Behat\Hook\AfterScenario;
+use Behat\Hook\AfterStep;
+use Behat\Hook\AfterSuite;
+use Behat\Hook\BeforeFeature;
+use Behat\Hook\BeforeScenario;
+use Behat\Hook\BeforeStep;
+use Behat\Hook\BeforeSuite;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+use Behat\Transformation\Transform;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for the shape of the library's public surface.
+ *
+ * Every trait member reachable from a consuming context is API, so a member
+ * that exposes more than the surrounding code intends cannot be narrowed
+ * before the next major. These tests hold the four conventions that keep the
+ * surface deliberate.
+ */
+#[CoversNothing]
+class PublicSurfaceTest extends UnitTestCase {
+
+  /**
+   * Attributes that mark a method as a step or a value transformation.
+   */
+  protected const STEP_ATTRIBUTES = [
+    Given::class,
+    Then::class,
+    Transform::class,
+    When::class,
+  ];
+
+  /**
+   * Hook attributes mapped to the scope class the hook method receives.
+   */
+  protected const HOOK_SCOPES = [
+    AfterFeature::class => 'Behat\Behat\Hook\Scope\AfterFeatureScope',
+    AfterScenario::class => 'Behat\Behat\Hook\Scope\AfterScenarioScope',
+    AfterStep::class => 'Behat\Behat\Hook\Scope\AfterStepScope',
+    AfterSuite::class => 'Behat\Testwork\Hook\Scope\AfterSuiteScope',
+    BeforeFeature::class => 'Behat\Behat\Hook\Scope\BeforeFeatureScope',
+    BeforeScenario::class => 'Behat\Behat\Hook\Scope\BeforeScenarioScope',
+    BeforeStep::class => 'Behat\Behat\Hook\Scope\BeforeStepScope',
+    BeforeSuite::class => 'Behat\Testwork\Hook\Scope\BeforeSuiteScope',
+    'Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate' => 'Drupal\DrupalExtension\Hook\Scope\BeforeNodeCreateScope',
+  ];
+
+  /**
+   * Public methods that carry no step or hook attribute, and why.
+   */
+  protected const ALLOWED_PUBLIC_METHODS = [
+    'DrevOps\BehatSteps\DateTrait::dateRelativeProcessValue' => 'Documented utility that resolves a relative date token outside a step.',
+    'DrevOps\BehatSteps\Drupal\OverrideTrait::createNodes' => 'Overrides a public Drupal Extension method.',
+    'DrevOps\BehatSteps\Drupal\OverrideTrait::createUsers' => 'Overrides a public Drupal Extension method.',
+    'DrevOps\BehatSteps\Drupal\OverrideTrait::iAmLoggedInAsUserWithRole' => 'Overrides a public Drupal Extension method.',
+    'DrevOps\BehatSteps\Drupal\TaxonomyTrait::createTerms' => 'Overrides a public Drupal Extension method.',
+    'DrevOps\BehatSteps\ResponsiveTrait::responsiveSetBreakpoints' => 'Documented utility that registers breakpoints outside a step.',
+  ];
+
+  /**
+   * Constants whose name does not start with the trait prefix, and why.
+   */
+  protected const ALLOWED_CONSTANTS = [
+    'DrevOps\BehatSteps\Drupal\HelperTrait::ENTITY_CLEANUP_EXCLUDED_TYPES' => 'Named for the entityCleanup* member family it configures.',
+  ];
+
+  #[DataProvider('dataProviderTraits')]
+  public function testPublicMethodsAreStepsOrHooks(string $trait): void {
+    $violations = [];
+
+    foreach (static::traitOwnMethods($trait) as $method) {
+      $identifier = $trait . '::' . $method->getName();
+
+      if (!$method->isPublic() || array_key_exists($identifier, static::ALLOWED_PUBLIC_METHODS)) {
+        continue;
+      }
+
+      if (static::methodBehatAttributes($method) === []) {
+        $violations[] = $identifier;
+      }
+    }
+
+    $this->assertSame([], $violations, 'A public method that is neither a step nor a hook is API by accident. Make it protected, or add it to ALLOWED_PUBLIC_METHODS with the reason it is API.');
+  }
+
+  #[DataProvider('dataProviderTraits')]
+  public function testHookMethodsDeclareTheirScope(string $trait): void {
+    $violations = [];
+
+    foreach (static::traitOwnMethods($trait) as $method) {
+      foreach (static::methodBehatAttributes($method) as $attribute) {
+        if (in_array($attribute, static::STEP_ATTRIBUTES, TRUE)) {
+          continue;
+        }
+
+        $expected = static::HOOK_SCOPES[$attribute];
+        $parameters = $method->getParameters();
+        $type = count($parameters) === 1 ? $parameters[0]->getType() : NULL;
+
+        if (!$type instanceof \ReflectionNamedType || $type->getName() !== $expected) {
+          $violations[] = sprintf('%s::%s() must declare one parameter typed %s.', $trait, $method->getName(), $expected);
+        }
+      }
+    }
+
+    $this->assertSame([], $violations, 'Every hook declares its scope parameter, used or not, so a subclass overriding one has a single signature to match.');
+  }
+
+  #[DataProvider('dataProviderTraits')]
+  public function testPropertiesDeclareNativeTypes(string $trait): void {
+    $reflection = new \ReflectionClass($trait);
+    $composed = static::composedPropertyNames($reflection);
+    $violations = [];
+
+    foreach ($reflection->getProperties() as $property) {
+      if (in_array($property->getName(), $composed, TRUE)) {
+        continue;
+      }
+
+      if (!$property->hasType()) {
+        $violations[] = $trait . '::$' . $property->getName();
+      }
+    }
+
+    $this->assertSame([], $violations, 'A docblock alone does not constrain what a subclass may assign, so every property declares a native type.');
+  }
+
+  #[DataProvider('dataProviderTraits')]
+  public function testConstantsDeclareVisibilityAndPrefix(string $trait): void {
+    $reflection = new \ReflectionClass($trait);
+    $composed = static::composedConstantNames($reflection);
+    $prefix = static::traitConstantPrefix($trait);
+    $violations = [];
+
+    foreach ($reflection->getReflectionConstants() as $constant) {
+      if (in_array($constant->getName(), $composed, TRUE)) {
+        continue;
+      }
+
+      $identifier = $trait . '::' . $constant->getName();
+
+      if (preg_match('/(^|\s)(public|protected|private)\s+const\s/', static::constantDeclaration($reflection, $constant->getName())) !== 1) {
+        $violations[] = $identifier . ' declares no visibility.';
+      }
+
+      if (!array_key_exists($identifier, static::ALLOWED_CONSTANTS) && !str_starts_with($constant->getName(), $prefix . '_')) {
+        $violations[] = $identifier . ' is not prefixed with "' . $prefix . '_".';
+      }
+    }
+
+    $this->assertSame([], $violations, 'A context composing two traits that declare the same constant name fails to compile, so every constant carries its trait prefix and an explicit visibility. Document an exception in ALLOWED_CONSTANTS.');
+  }
+
+  public static function dataProviderTraits(): array {
+    $root = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'src';
+    $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS));
+
+    $traits = [];
+    foreach ($files as $file) {
+      if (!$file instanceof \SplFileInfo || $file->getExtension() !== 'php') {
+        continue;
+      }
+
+      $relative = substr($file->getPathname(), strlen($root) + 1, -strlen('.php'));
+      $trait = 'DrevOps\BehatSteps\\' . str_replace(DIRECTORY_SEPARATOR, '\\', $relative);
+      $traits[$trait] = [$trait];
+    }
+
+    ksort($traits);
+
+    return $traits;
+  }
+
+  /**
+   * Return the methods a trait declares itself.
+   *
+   * @param string $trait
+   *   Fully qualified trait name.
+   *
+   * @return array<int, \ReflectionMethod>
+   *   Methods declared by the trait, excluding those it composes.
+   */
+  protected static function traitOwnMethods(string $trait): array {
+    $reflection = new \ReflectionClass($trait);
+
+    $composed = [];
+    foreach ($reflection->getTraits() as $used) {
+      foreach ($used->getMethods() as $method) {
+        $composed[] = $method->getName();
+      }
+    }
+
+    return array_values(array_filter($reflection->getMethods(), static fn(\ReflectionMethod $method): bool => !in_array($method->getName(), $composed, TRUE)));
+  }
+
+  /**
+   * Return the names of properties a trait receives from composed traits.
+   *
+   * Reflection flattens a composed trait's members into the composing trait
+   * and reports the composing trait as their declaring class, so the origin is
+   * resolved by name against the composed traits instead.
+   *
+   * @param \ReflectionClass<object> $reflection
+   *   Reflection of the trait.
+   *
+   * @return array<int, string>
+   *   Property names that originate in a composed trait.
+   */
+  protected static function composedPropertyNames(\ReflectionClass $reflection): array {
+    $names = [];
+
+    foreach ($reflection->getTraits() as $used) {
+      foreach ($used->getProperties() as $property) {
+        $names[] = $property->getName();
+      }
+    }
+
+    return $names;
+  }
+
+  /**
+   * Return the names of constants a trait receives from composed traits.
+   *
+   * @param \ReflectionClass<object> $reflection
+   *   Reflection of the trait.
+   *
+   * @return array<int, string>
+   *   Constant names that originate in a composed trait.
+   */
+  protected static function composedConstantNames(\ReflectionClass $reflection): array {
+    $names = [];
+
+    foreach ($reflection->getTraits() as $used) {
+      foreach ($used->getReflectionConstants() as $constant) {
+        $names[] = $constant->getName();
+      }
+    }
+
+    return $names;
+  }
+
+  /**
+   * Return the Behat step and hook attributes a method carries.
+   *
+   * @param \ReflectionMethod $method
+   *   Method to inspect.
+   *
+   * @return array<int, string>
+   *   Fully qualified attribute names.
+   *
+   * @throws \RuntimeException
+   *   If the method carries a hook attribute absent from HOOK_SCOPES.
+   */
+  protected static function methodBehatAttributes(\ReflectionMethod $method): array {
+    $found = [];
+
+    foreach ($method->getAttributes() as $attribute) {
+      $name = $attribute->getName();
+
+      if (in_array($name, static::STEP_ATTRIBUTES, TRUE) || array_key_exists($name, static::HOOK_SCOPES)) {
+        $found[] = $name;
+        continue;
+      }
+
+      // @codeCoverageIgnoreStart
+      if (str_contains($name, '\\Hook\\')) {
+        throw new \RuntimeException(sprintf('Hook attribute "%s" on %s::%s() is missing from HOOK_SCOPES.', $name, $method->getDeclaringClass()->getName(), $method->getName()));
+      }
+      // @codeCoverageIgnoreEnd
+    }
+
+    return $found;
+  }
+
+  /**
+   * Return the constant prefix derived from the trait name.
+   *
+   * @param string $trait
+   *   Fully qualified trait name.
+   *
+   * @return string
+   *   Upper snake case form of the trait name without its "Trait" suffix.
+   */
+  protected static function traitConstantPrefix(string $trait): string {
+    $short = (string) preg_replace('/Trait$/', '', (new \ReflectionClass($trait))->getShortName());
+
+    return strtoupper((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $short));
+  }
+
+  /**
+   * Return the source line that declares a constant.
+   *
+   * Reflection reports an implicitly public constant and an explicitly public
+   * one identically, so the modifier is read from the source.
+   *
+   * @param \ReflectionClass<object> $reflection
+   *   Reflection of the trait.
+   * @param string $name
+   *   Constant name.
+   *
+   * @return string
+   *   The declaring line, or an empty string when it cannot be located.
+   */
+  protected static function constantDeclaration(\ReflectionClass $reflection, string $name): string {
+    $file = $reflection->getFileName();
+
+    // @codeCoverageIgnoreStart
+    if ($file === FALSE) {
+      return '';
+    }
+    // @codeCoverageIgnoreEnd
+    foreach (file($file) ?: [] as $line) {
+      if (preg_match('/(^|\s)const\s+' . preg_quote($name, '/') . '\s*=/', $line) === 1) {
+        return $line;
+      }
+    }
+
+    // @codeCoverageIgnoreStart
+    return '';
+    // @codeCoverageIgnoreEnd
+  }
+
+}

--- a/tests/phpunit/src/PublicSurfaceTest.php
+++ b/tests/phpunit/src/PublicSurfaceTest.php
@@ -202,6 +202,9 @@ class PublicSurfaceTest extends UnitTestCase {
   /**
    * Return every trait shipped in the library, keyed by name.
    *
+   * The conventions below describe traits mixed into a consuming context, so
+   * classes under `src` are outside their scope.
+   *
    * @return array<string, array{string}>
    *   Fully qualified trait names, as data provider rows.
    */
@@ -217,6 +220,11 @@ class PublicSurfaceTest extends UnitTestCase {
 
       $relative = substr($file->getPathname(), strlen($root) + 1, -strlen('.php'));
       $trait = 'DrevOps\BehatSteps\\' . str_replace(DIRECTORY_SEPARATOR, '\\', $relative);
+
+      if (!trait_exists($trait)) {
+        continue;
+      }
+
       $traits[$trait] = [$trait];
     }
 

--- a/tests/phpunit/src/PublicSurfaceTest.php
+++ b/tests/phpunit/src/PublicSurfaceTest.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace DrevOps\BehatSteps\Tests;
 
+use Behat\Behat\Hook\Scope\AfterFeatureScope;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Behat\Hook\Scope\BeforeFeatureScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Hook\AfterFeature;
 use Behat\Hook\AfterScenario;
 use Behat\Hook\AfterStep;
@@ -15,7 +21,16 @@ use Behat\Hook\BeforeSuite;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
+use Behat\Testwork\Hook\Scope\AfterSuiteScope;
+use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use Behat\Transformation\Transform;
+use DrevOps\BehatSteps\DateTrait;
+use DrevOps\BehatSteps\Drupal\HelperTrait;
+use DrevOps\BehatSteps\Drupal\OverrideTrait;
+use DrevOps\BehatSteps\Drupal\TaxonomyTrait;
+use DrevOps\BehatSteps\ResponsiveTrait;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate;
+use Drupal\DrupalExtension\Hook\Scope\BeforeNodeCreateScope;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -26,6 +41,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * that exposes more than the surrounding code intends cannot be narrowed
  * before the next major. These tests hold the four conventions that keep the
  * surface deliberate.
+ *
+ * Each loop reads its subject into a variable first: a foreach directly over a
+ * method call is rewritten by Rector to a camel case value variable, which the
+ * snake case coding standard then rewrites back.
  */
 #[CoversNothing]
 class PublicSurfaceTest extends UnitTestCase {
@@ -44,41 +63,42 @@ class PublicSurfaceTest extends UnitTestCase {
    * Hook attributes mapped to the scope class the hook method receives.
    */
   protected const HOOK_SCOPES = [
-    AfterFeature::class => 'Behat\Behat\Hook\Scope\AfterFeatureScope',
-    AfterScenario::class => 'Behat\Behat\Hook\Scope\AfterScenarioScope',
-    AfterStep::class => 'Behat\Behat\Hook\Scope\AfterStepScope',
-    AfterSuite::class => 'Behat\Testwork\Hook\Scope\AfterSuiteScope',
-    BeforeFeature::class => 'Behat\Behat\Hook\Scope\BeforeFeatureScope',
-    BeforeScenario::class => 'Behat\Behat\Hook\Scope\BeforeScenarioScope',
-    BeforeStep::class => 'Behat\Behat\Hook\Scope\BeforeStepScope',
-    BeforeSuite::class => 'Behat\Testwork\Hook\Scope\BeforeSuiteScope',
-    'Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate' => 'Drupal\DrupalExtension\Hook\Scope\BeforeNodeCreateScope',
+    AfterFeature::class => AfterFeatureScope::class,
+    AfterScenario::class => AfterScenarioScope::class,
+    AfterStep::class => AfterStepScope::class,
+    AfterSuite::class => AfterSuiteScope::class,
+    BeforeFeature::class => BeforeFeatureScope::class,
+    BeforeScenario::class => BeforeScenarioScope::class,
+    BeforeStep::class => BeforeStepScope::class,
+    BeforeSuite::class => BeforeSuiteScope::class,
+    BeforeNodeCreate::class => BeforeNodeCreateScope::class,
   ];
 
   /**
    * Public methods that carry no step or hook attribute, and why.
    */
   protected const ALLOWED_PUBLIC_METHODS = [
-    'DrevOps\BehatSteps\DateTrait::dateRelativeProcessValue' => 'Documented utility that resolves a relative date token outside a step.',
-    'DrevOps\BehatSteps\Drupal\OverrideTrait::createNodes' => 'Overrides a public Drupal Extension method.',
-    'DrevOps\BehatSteps\Drupal\OverrideTrait::createUsers' => 'Overrides a public Drupal Extension method.',
-    'DrevOps\BehatSteps\Drupal\OverrideTrait::iAmLoggedInAsUserWithRole' => 'Overrides a public Drupal Extension method.',
-    'DrevOps\BehatSteps\Drupal\TaxonomyTrait::createTerms' => 'Overrides a public Drupal Extension method.',
-    'DrevOps\BehatSteps\ResponsiveTrait::responsiveSetBreakpoints' => 'Documented utility that registers breakpoints outside a step.',
+    DateTrait::class . '::dateRelativeProcessValue' => 'Documented utility that resolves a relative date token outside a step.',
+    OverrideTrait::class . '::createNodes' => 'Overrides a public Drupal Extension method.',
+    OverrideTrait::class . '::createUsers' => 'Overrides a public Drupal Extension method.',
+    OverrideTrait::class . '::iAmLoggedInAsUserWithRole' => 'Overrides a public Drupal Extension method.',
+    TaxonomyTrait::class . '::createTerms' => 'Overrides a public Drupal Extension method.',
+    ResponsiveTrait::class . '::responsiveSetBreakpoints' => 'Documented utility that registers breakpoints outside a step.',
   ];
 
   /**
    * Constants whose name does not start with the trait prefix, and why.
    */
   protected const ALLOWED_CONSTANTS = [
-    'DrevOps\BehatSteps\Drupal\HelperTrait::ENTITY_CLEANUP_EXCLUDED_TYPES' => 'Named for the entityCleanup* member family it configures.',
+    HelperTrait::class . '::ENTITY_CLEANUP_EXCLUDED_TYPES' => 'Named for the entityCleanup* member family it configures.',
   ];
 
   #[DataProvider('dataProviderPublicMethodsAreStepsOrHooks')]
   public function testPublicMethodsAreStepsOrHooks(string $trait): void {
+    $methods = static::traitOwnMethods($trait);
     $violations = [];
 
-    foreach (static::traitOwnMethods($trait) as $method) {
+    foreach ($methods as $method) {
       $identifier = $trait . '::' . $method->getName();
 
       if (!$method->isPublic() || array_key_exists($identifier, static::ALLOWED_PUBLIC_METHODS)) {
@@ -99,10 +119,13 @@ class PublicSurfaceTest extends UnitTestCase {
 
   #[DataProvider('dataProviderHookMethodsDeclareTheirScope')]
   public function testHookMethodsDeclareTheirScope(string $trait): void {
+    $methods = static::traitOwnMethods($trait);
     $violations = [];
 
-    foreach (static::traitOwnMethods($trait) as $method) {
-      foreach (static::methodBehatAttributes($method) as $attribute) {
+    foreach ($methods as $method) {
+      $attributes = static::methodBehatAttributes($method);
+
+      foreach ($attributes as $attribute) {
         if (in_array($attribute, static::STEP_ATTRIBUTES, TRUE)) {
           continue;
         }
@@ -128,9 +151,10 @@ class PublicSurfaceTest extends UnitTestCase {
   public function testPropertiesDeclareNativeTypes(string $trait): void {
     $reflection = static::reflect($trait);
     $composed = static::composedPropertyNames($reflection);
+    $properties = $reflection->getProperties();
     $violations = [];
 
-    foreach ($reflection->getProperties() as $property) {
+    foreach ($properties as $property) {
       if (in_array($property->getName(), $composed, TRUE)) {
         continue;
       }
@@ -152,9 +176,10 @@ class PublicSurfaceTest extends UnitTestCase {
     $reflection = static::reflect($trait);
     $composed = static::composedConstantNames($reflection);
     $prefix = static::traitConstantPrefix($trait);
+    $constants = $reflection->getReflectionConstants();
     $violations = [];
 
-    foreach ($reflection->getReflectionConstants() as $constant) {
+    foreach ($constants as $constant) {
       if (in_array($constant->getName(), $composed, TRUE)) {
         continue;
       }
@@ -228,15 +253,19 @@ class PublicSurfaceTest extends UnitTestCase {
    */
   protected static function traitOwnMethods(string $trait): array {
     $reflection = static::reflect($trait);
+    $used_traits = $reflection->getTraits();
+    $own = $reflection->getMethods();
 
     $composed = [];
-    foreach ($reflection->getTraits() as $used) {
-      foreach ($used->getMethods() as $method) {
+    foreach ($used_traits as $used_trait) {
+      $methods = $used_trait->getMethods();
+
+      foreach ($methods as $method) {
         $composed[] = $method->getName();
       }
     }
 
-    return array_values(array_filter($reflection->getMethods(), static fn(\ReflectionMethod $method): bool => !in_array($method->getName(), $composed, TRUE)));
+    return array_values(array_filter($own, static fn(\ReflectionMethod $method): bool => !in_array($method->getName(), $composed, TRUE)));
   }
 
   /**
@@ -253,10 +282,13 @@ class PublicSurfaceTest extends UnitTestCase {
    *   Property names that originate in a composed trait.
    */
   protected static function composedPropertyNames(\ReflectionClass $reflection): array {
+    $used_traits = $reflection->getTraits();
     $names = [];
 
-    foreach ($reflection->getTraits() as $used) {
-      foreach ($used->getProperties() as $property) {
+    foreach ($used_traits as $used_trait) {
+      $properties = $used_trait->getProperties();
+
+      foreach ($properties as $property) {
         $names[] = $property->getName();
       }
     }
@@ -274,10 +306,13 @@ class PublicSurfaceTest extends UnitTestCase {
    *   Constant names that originate in a composed trait.
    */
   protected static function composedConstantNames(\ReflectionClass $reflection): array {
+    $used_traits = $reflection->getTraits();
     $names = [];
 
-    foreach ($reflection->getTraits() as $used) {
-      foreach ($used->getReflectionConstants() as $constant) {
+    foreach ($used_traits as $used_trait) {
+      $constants = $used_trait->getReflectionConstants();
+
+      foreach ($constants as $constant) {
         $names[] = $constant->getName();
       }
     }
@@ -298,9 +333,10 @@ class PublicSurfaceTest extends UnitTestCase {
    *   If the method carries a hook attribute absent from HOOK_SCOPES.
    */
   protected static function methodBehatAttributes(\ReflectionMethod $method): array {
+    $attributes = $method->getAttributes();
     $found = [];
 
-    foreach ($method->getAttributes() as $attribute) {
+    foreach ($attributes as $attribute) {
       $name = $attribute->getName();
 
       if (in_array($name, static::STEP_ATTRIBUTES, TRUE) || array_key_exists($name, static::HOOK_SCOPES)) {
@@ -355,7 +391,9 @@ class PublicSurfaceTest extends UnitTestCase {
       return '';
     }
     // @codeCoverageIgnoreEnd
-    foreach (file($file) ?: [] as $line) {
+    $lines = file($file) ?: [];
+
+    foreach ($lines as $line) {
       if (preg_match('/(^|\s)const\s+' . preg_quote($name, '/') . '\s*=/', $line) === 1) {
         return $line;
       }

--- a/tests/phpunit/src/PublicSurfaceTest.php
+++ b/tests/phpunit/src/PublicSurfaceTest.php
@@ -25,7 +25,6 @@ use Behat\Testwork\Hook\Scope\AfterSuiteScope;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use Behat\Transformation\Transform;
 use DrevOps\BehatSteps\DateTrait;
-use DrevOps\BehatSteps\Drupal\HelperTrait;
 use DrevOps\BehatSteps\Drupal\OverrideTrait;
 use DrevOps\BehatSteps\Drupal\TaxonomyTrait;
 use DrevOps\BehatSteps\ResponsiveTrait;
@@ -89,9 +88,7 @@ class PublicSurfaceTest extends UnitTestCase {
   /**
    * Constants whose name does not start with the trait prefix, and why.
    */
-  protected const ALLOWED_CONSTANTS = [
-    HelperTrait::class . '::ENTITY_CLEANUP_EXCLUDED_TYPES' => 'Named for the entityCleanup* member family it configures.',
-  ];
+  protected const ALLOWED_CONSTANTS = [];
 
   #[DataProvider('dataProviderPublicMethodsAreStepsOrHooks')]
   public function testPublicMethodsAreStepsOrHooks(string $trait): void {

--- a/tests/phpunit/src/PublicSurfaceTest.php
+++ b/tests/phpunit/src/PublicSurfaceTest.php
@@ -74,7 +74,7 @@ class PublicSurfaceTest extends UnitTestCase {
     'DrevOps\BehatSteps\Drupal\HelperTrait::ENTITY_CLEANUP_EXCLUDED_TYPES' => 'Named for the entityCleanup* member family it configures.',
   ];
 
-  #[DataProvider('dataProviderTraits')]
+  #[DataProvider('dataProviderPublicMethodsAreStepsOrHooks')]
   public function testPublicMethodsAreStepsOrHooks(string $trait): void {
     $violations = [];
 
@@ -93,7 +93,11 @@ class PublicSurfaceTest extends UnitTestCase {
     $this->assertSame([], $violations, 'A public method that is neither a step nor a hook is API by accident. Make it protected, or add it to ALLOWED_PUBLIC_METHODS with the reason it is API.');
   }
 
-  #[DataProvider('dataProviderTraits')]
+  public static function dataProviderPublicMethodsAreStepsOrHooks(): array {
+    return static::discoverTraits();
+  }
+
+  #[DataProvider('dataProviderHookMethodsDeclareTheirScope')]
   public function testHookMethodsDeclareTheirScope(string $trait): void {
     $violations = [];
 
@@ -116,9 +120,13 @@ class PublicSurfaceTest extends UnitTestCase {
     $this->assertSame([], $violations, 'Every hook declares its scope parameter, used or not, so a subclass overriding one has a single signature to match.');
   }
 
-  #[DataProvider('dataProviderTraits')]
+  public static function dataProviderHookMethodsDeclareTheirScope(): array {
+    return static::discoverTraits();
+  }
+
+  #[DataProvider('dataProviderPropertiesDeclareNativeTypes')]
   public function testPropertiesDeclareNativeTypes(string $trait): void {
-    $reflection = new \ReflectionClass($trait);
+    $reflection = static::reflect($trait);
     $composed = static::composedPropertyNames($reflection);
     $violations = [];
 
@@ -135,9 +143,13 @@ class PublicSurfaceTest extends UnitTestCase {
     $this->assertSame([], $violations, 'A docblock alone does not constrain what a subclass may assign, so every property declares a native type.');
   }
 
-  #[DataProvider('dataProviderTraits')]
+  public static function dataProviderPropertiesDeclareNativeTypes(): array {
+    return static::discoverTraits();
+  }
+
+  #[DataProvider('dataProviderConstantsDeclareVisibilityAndPrefix')]
   public function testConstantsDeclareVisibilityAndPrefix(string $trait): void {
-    $reflection = new \ReflectionClass($trait);
+    $reflection = static::reflect($trait);
     $composed = static::composedConstantNames($reflection);
     $prefix = static::traitConstantPrefix($trait);
     $violations = [];
@@ -161,7 +173,17 @@ class PublicSurfaceTest extends UnitTestCase {
     $this->assertSame([], $violations, 'A context composing two traits that declare the same constant name fails to compile, so every constant carries its trait prefix and an explicit visibility. Document an exception in ALLOWED_CONSTANTS.');
   }
 
-  public static function dataProviderTraits(): array {
+  public static function dataProviderConstantsDeclareVisibilityAndPrefix(): array {
+    return static::discoverTraits();
+  }
+
+  /**
+   * Return every trait shipped in the library, keyed by name.
+   *
+   * @return array<string, array{string}>
+   *   Fully qualified trait names, as data provider rows.
+   */
+  protected static function discoverTraits(): array {
     $root = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'src';
     $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS));
 
@@ -182,6 +204,20 @@ class PublicSurfaceTest extends UnitTestCase {
   }
 
   /**
+   * Reflect a trait discovered by path.
+   *
+   * @param string $trait
+   *   Fully qualified trait name.
+   *
+   * @return \ReflectionClass<object>
+   *   Reflection of the trait.
+   */
+  protected static function reflect(string $trait): \ReflectionClass {
+    /** @var class-string $trait */
+    return new \ReflectionClass($trait);
+  }
+
+  /**
    * Return the methods a trait declares itself.
    *
    * @param string $trait
@@ -191,7 +227,7 @@ class PublicSurfaceTest extends UnitTestCase {
    *   Methods declared by the trait, excluding those it composes.
    */
   protected static function traitOwnMethods(string $trait): array {
-    $reflection = new \ReflectionClass($trait);
+    $reflection = static::reflect($trait);
 
     $composed = [];
     foreach ($reflection->getTraits() as $used) {
@@ -292,7 +328,7 @@ class PublicSurfaceTest extends UnitTestCase {
    *   Upper snake case form of the trait name without its "Trait" suffix.
    */
   protected static function traitConstantPrefix(string $trait): string {
-    $short = (string) preg_replace('/Trait$/', '', (new \ReflectionClass($trait))->getShortName());
+    $short = (string) preg_replace('/Trait$/', '', static::reflect($trait)->getShortName());
 
     return strtoupper((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $short));
   }

--- a/tests/phpunit/src/UnitTestCase.php
+++ b/tests/phpunit/src/UnitTestCase.php
@@ -27,28 +27,28 @@ abstract class UnitTestCase extends UpstreamUnitTestCase {
    * Build a scope for a BeforeSuite hook.
    */
   protected function createBeforeSuiteScope(): BeforeSuiteScope {
-    return new BeforeSuiteScope($this->createMock(Environment::class), $this->createMock(SpecificationIterator::class));
+    return new BeforeSuiteScope($this->createStub(Environment::class), $this->createStub(SpecificationIterator::class));
   }
 
   /**
    * Build a scope for an AfterSuite hook.
    */
   protected function createAfterSuiteScope(): AfterSuiteScope {
-    return new AfterSuiteScope($this->createMock(Environment::class), $this->createMock(SpecificationIterator::class), $this->createMock(TestResult::class));
+    return new AfterSuiteScope($this->createStub(Environment::class), $this->createStub(SpecificationIterator::class), $this->createStub(TestResult::class));
   }
 
   /**
    * Build a scope for a BeforeScenario hook.
    */
   protected function createBeforeScenarioScope(): BeforeScenarioScope {
-    return new BeforeScenarioScope($this->createMock(Environment::class), $this->createMock(FeatureNode::class), $this->createMock(ScenarioInterface::class));
+    return new BeforeScenarioScope($this->createStub(Environment::class), $this->createStub(FeatureNode::class), $this->createStub(ScenarioInterface::class));
   }
 
   /**
    * Build a scope for an AfterScenario hook.
    */
   protected function createAfterScenarioScope(): AfterScenarioScope {
-    return new AfterScenarioScope($this->createMock(Environment::class), $this->createMock(FeatureNode::class), $this->createMock(ScenarioInterface::class), $this->createMock(TestResult::class));
+    return new AfterScenarioScope($this->createStub(Environment::class), $this->createStub(FeatureNode::class), $this->createStub(ScenarioInterface::class), $this->createStub(TestResult::class));
   }
 
 }

--- a/tests/phpunit/src/UnitTestCase.php
+++ b/tests/phpunit/src/UnitTestCase.php
@@ -5,10 +5,50 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps\Tests;
 
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase as UpstreamUnitTestCase;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioInterface;
+use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\Hook\Scope\AfterSuiteScope;
+use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
+use Behat\Testwork\Specification\SpecificationIterator;
+use Behat\Testwork\Tester\Result\TestResult;
 
 /**
  * Base class for unit tests.
+ *
+ * The hook scope classes are final, so a test that invokes a hook directly
+ * builds a real scope over stubbed collaborators rather than mocking it.
  */
 abstract class UnitTestCase extends UpstreamUnitTestCase {
+
+  /**
+   * Build a scope for a BeforeSuite hook.
+   */
+  protected function createBeforeSuiteScope(): BeforeSuiteScope {
+    return new BeforeSuiteScope($this->createMock(Environment::class), $this->createMock(SpecificationIterator::class));
+  }
+
+  /**
+   * Build a scope for an AfterSuite hook.
+   */
+  protected function createAfterSuiteScope(): AfterSuiteScope {
+    return new AfterSuiteScope($this->createMock(Environment::class), $this->createMock(SpecificationIterator::class), $this->createMock(TestResult::class));
+  }
+
+  /**
+   * Build a scope for a BeforeScenario hook.
+   */
+  protected function createBeforeScenarioScope(): BeforeScenarioScope {
+    return new BeforeScenarioScope($this->createMock(Environment::class), $this->createMock(FeatureNode::class), $this->createMock(ScenarioInterface::class));
+  }
+
+  /**
+   * Build a scope for an AfterScenario hook.
+   */
+  protected function createAfterScenarioScope(): AfterScenarioScope {
+    return new AfterScenarioScope($this->createMock(Environment::class), $this->createMock(FeatureNode::class), $this->createMock(ScenarioInterface::class), $this->createMock(TestResult::class));
+  }
 
 }


### PR DESCRIPTION
Closes #715

## Summary

`KeyboardTrait::keyboardPressKeyOnElementSingle()` and `FileDownloadTrait::fileDownloadAssertLinkPresent()` are now `protected`, `AccessibilityTrait::IMPACT_CRITICAL|SERIOUS|MODERATE|MINOR` are renamed to `ACCESSIBILITY_IMPACT_*` and `Drupal\BigPipeTrait::DEFAULT_WAIT_TIMEOUT` to `BIG_PIPE_DEFAULT_WAIT_TIMEOUT`, five properties across `Drupal\FileTrait`, `Drupal\RedirectTrait`, `Drupal\WatchdogTrait`, and `FileDownloadTrait` declare native types, eight hook methods across `CommandTrait`, `JsonTrait`, `XmlTrait`, and `Drupal\BigPipeTrait` declare their scope parameter, and `FieldTrait` no longer composes `KeyboardTrait`.

Each of those methods carried no step or hook attribute yet stayed callable from any composing `FeatureContext`, the two constant groups collide the instant a context composes two traits that declare the same constant name, the five properties exposed only a `@var` docblock so a subclass could assign any value, the eight hooks silently dropped the scope object Behat already passes to every hook invocation, and `FieldTrait` pulled in `KeyboardTrait` through transitive composition despite containing no `keyboard*` call site of its own.

After merge, calling a narrowed method from outside its own trait raises a visibility error and referencing a renamed constant raises an undefined-constant error, both guarded by `tests/phpunit/src/PublicSurfaceTest.php`, which reflects over all 51 traits in `src/` to hold the four conventions in place going forward; step behavior, hook timing, and the public static APIs of `DateTrait` and `ResponsiveTrait` are unchanged.

## Before / After

```
┌───────────────────────────────┬──────────────────────────┬───────────────────────────────┐
│ Surface                       │ Before                   │ After                         │
├───────────────────────────────┼──────────────────────────┼───────────────────────────────┤
│ KeyboardTrait method          │ public                   │ protected                     │
│ FileDownloadTrait method      │ public                   │ protected                     │
│ Accessibility IMPACT_* consts │ IMPACT_CRITICAL..MINOR   │ ACCESSIBILITY_IMPACT_*        │
│ BigPipe timeout const         │ DEFAULT_WAIT_TIMEOUT     │ BIG_PIPE_DEFAULT_WAIT_TIMEOUT │
│ Helper cleanup const          │ implicit public          │ explicit protected            │
│ 5 typed properties            │ @var docblock only       │ native array / ?int           │
│ 8 hook methods                │ scope param omitted      │ scope param declared          │
│ FieldTrait composition        │ + KeyboardTrait (unused) │ HelperTrait only              │
└───────────────────────────────┴──────────────────────────┴───────────────────────────────┘
```

## Changes

- **Visibility narrowed to `protected`**: `KeyboardTrait::keyboardPressKeyOnElementSingle()` and `FileDownloadTrait::fileDownloadAssertLinkPresent()` are called only from step methods within their own trait, so neither needs to be reachable from outside the context.
- **Constants prefixed with their trait name**: `AccessibilityTrait::IMPACT_CRITICAL`, `IMPACT_SERIOUS`, `IMPACT_MODERATE`, and `IMPACT_MINOR` become `ACCESSIBILITY_IMPACT_*`; `Drupal\BigPipeTrait::DEFAULT_WAIT_TIMEOUT` becomes `BIG_PIPE_DEFAULT_WAIT_TIMEOUT`; `Drupal\HelperTrait::HELPER_ENTITY_CLEANUP_EXCLUDED_TYPES` is now explicitly `protected` instead of implicitly public.
- **Properties declare native types**: `Drupal\FileTrait::$filesUnmanagedUris`, `Drupal\RedirectTrait::$redirectAllowedStatusCodes`, and `Drupal\WatchdogTrait::$watchdogMessageTypes` are typed `array`; `Drupal\WatchdogTrait::$watchdogScenarioStartTime` is typed `?int`; `FileDownloadTrait::$fileDownloadDownloadedFileInfo` is typed `array` and defaults to `[]`.
- **Hooks declare their scope parameter**: both `CommandTrait` hooks, both `XmlTrait` hooks, both `JsonTrait` hooks, `Drupal\BigPipeTrait::bigPipeWaitBeforeStep()`, and `AccessibilityTrait`'s three static suite hooks now take the scope type Behat already passes them.
- **`FieldTrait` no longer composes `KeyboardTrait`**: the trait had no `keyboard*` call site, so a context composing only `FieldTrait` was silently receiving every keyboard step through transitive trait composition.
- **`DateTrait` and `ResponsiveTrait` documented as API**: `DateTrait::dateRelativeProcessValue()` and `ResponsiveTrait::responsiveSetBreakpoints()` stay `public` on purpose; their docblocks now say so, and `DateTrait`'s docblock documents `dateNow()` as the supported clock-pinning seam for the static resolution path.
- **New `tests/phpunit/src/PublicSurfaceTest.php`**: reflects over all 51 traits in `src/` and asserts four conventions across 204 assertions: every public method is a step or a hook (or allowlisted with a stated reason), every hook declares its matching scope type, every property has a native type, and every constant declares a visibility and carries its trait prefix. Classes under `src/` are outside the conventions' scope, so discovery filters on `trait_exists()`.
- **`tests/phpunit/src/UnitTestCase.php` gained four scope factory helpers**: `createBeforeSuiteScope()`, `createAfterSuiteScope()`, `createBeforeScenarioScope()`, and `createAfterScenarioScope()` build a real scope over stubbed collaborators, because the Behat hook scope classes are `final` and cannot be mocked.
- **`MIGRATION.md`** documents every breaking change above with before/after tables.
