### PR TITLE
[#733] Distinguished an absent query parameter from an empty or zero one.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -277,3 +277,20 @@ Gherkin step text is unchanged, so feature files need no edit for the renames ab
 | `@behat-steps-skip:entityCleanupAfterScenario` | `@behat-steps-skip:helperEntityCleanupAfterScenario` |
 
 `Drupal\OverrideTrait::createNodes()`, `::createUsers()`, `::iAmLoggedInAsUserWithRole()` and `Drupal\TaxonomyTrait::createTerms()` override Drupal Extension context methods and keep their names.
+
+## Query parameter presence
+
+`PathTrait` tested for a query parameter with `empty()`, which reads a parameter carrying `0` or an empty string as absent. Presence is now `array_key_exists()`, so `?page=0` and `?debug=` are parameters that are in the URL, and their value is compared separately.
+
+| Step | `?filter=0` before | `?filter=0` after |
+| --- | --- | --- |
+| `Then the current URL should have the :param parameter` | fails | passes |
+| `Then the current URL should have the :param parameter with the value :value` | fails | passes for the value `0` |
+| `Then the current URL should not have the :param parameter` | passes | fails |
+| `Then the current URL should not have the :param parameter with the value :value` | passes | fails for the value `0` |
+
+A scenario that asserted a falsy parameter away with `Then the current URL should not have the "filter" parameter` now needs to name the value it excludes:
+
+```gherkin
+Then the current URL should not have the "filter" parameter with the value "recent"
+```

--- a/STEPS.md
+++ b/STEPS.md
@@ -2720,7 +2720,7 @@ Then the path should not be "<front>"
   <summary><code>@Then the current URL should have the :param parameter</code></summary>
 
 <br/>
-Assert that current URL has a query parameter with a non-empty value
+Assert that current URL has a query parameter
 <br/><br/>
 
 ```gherkin
@@ -2748,7 +2748,7 @@ Then the current URL should have the "filter" parameter with the value "recent"
   <summary><code>@Then the current URL should not have the :param parameter</code></summary>
 
 <br/>
-Assert that current URL has no query parameter with a non-empty value
+Assert that current URL has no query parameter
 <br/><br/>
 
 ```gherkin

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -91,9 +91,7 @@ trait PathTrait {
   }
 
   /**
-   * Assert that current URL has a query parameter with a non-empty value.
-   *
-   * A parameter carrying an empty string or "0" counts as absent.
+   * Assert that current URL has a query parameter.
    *
    * @code
    * Then the current URL should have the "filter" parameter
@@ -103,15 +101,13 @@ trait PathTrait {
   public function pathAssertUrlHasParameter(string $param): void {
     $query = $this->pathGetCurrentUrlQuery();
 
-    if (empty($query[$param])) {
+    if (!array_key_exists($param, $query)) {
       throw new ExpectationException(sprintf('The parameter "%s" is not in the URL.', $param), $this->getSession()->getDriver());
     }
   }
 
   /**
    * Assert that current URL has a query parameter with a specific value.
-   *
-   * A parameter carrying an empty string or "0" counts as absent.
    *
    * @code
    * Then the current URL should have the "filter" parameter with the value "recent"
@@ -131,9 +127,7 @@ trait PathTrait {
   }
 
   /**
-   * Assert that current URL has no query parameter with a non-empty value.
-   *
-   * A parameter carrying an empty string or "0" counts as absent.
+   * Assert that current URL has no query parameter.
    *
    * @code
    * Then the current URL should not have the "filter" parameter
@@ -143,7 +137,7 @@ trait PathTrait {
   public function pathAssertUrlHasNoParameter(string $param): void {
     $query = $this->pathGetCurrentUrlQuery();
 
-    if (!empty($query[$param])) {
+    if (array_key_exists($param, $query)) {
       throw new ExpectationException(sprintf('The parameter "%s" is in the URL but should not be.', $param), $this->getSession()->getDriver());
     }
   }
@@ -151,7 +145,7 @@ trait PathTrait {
   /**
    * Assert that current URL does not have a query parameter with a value.
    *
-   * A parameter carrying an empty string or "0" counts as absent.
+   * An absent parameter satisfies the assertion.
    *
    * @code
    * Then the current URL should not have the "filter" parameter with the value "recent"
@@ -161,7 +155,7 @@ trait PathTrait {
   public function pathAssertUrlHasNoParameterWithValue(string $param, string $value): void {
     $query = $this->pathGetCurrentUrlQuery();
 
-    if (empty($query[$param])) {
+    if (!array_key_exists($param, $query)) {
       return;
     }
 

--- a/tests/behat/features/path.feature
+++ b/tests/behat/features/path.feature
@@ -205,6 +205,79 @@ Feature: Check that PathTrait works
     Then the current URL should not have the "nonexistent" parameter with the value "value"
 
   @api
+  Scenario: Assert that a URL parameter with a zero or empty value counts as present
+    Given I am an anonymous user
+    When I visit "/user/login?filter=0&empty=&keyword=recent"
+    Then the current URL should have the "filter" parameter
+    And the current URL should have the "filter" parameter with the value "0"
+    And the current URL should have the "empty" parameter
+    And the current URL should have the "empty" parameter with the value ""
+    And the current URL should have the "keyword" parameter with the value "recent"
+    And the current URL should not have the "missing" parameter
+    And the current URL should not have the "missing" parameter with the value "0"
+    And the current URL should not have the "filter" parameter with the value "1"
+
+  @trait:PathTrait
+  Scenario: Assert failure when URL parameter with a zero value should not exist
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I visit "/user/login?filter=0"
+      Then the current URL should not have the "filter" parameter
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The parameter "filter" is in the URL but should not be
+      """
+
+  @trait:PathTrait
+  Scenario: Assert failure when URL parameter with an empty value should not exist
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I visit "/user/login?empty="
+      Then the current URL should not have the "empty" parameter
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The parameter "empty" is in the URL but should not be
+      """
+
+  @trait:PathTrait
+  Scenario: Assert failure when URL parameter should not have the zero value it carries
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I visit "/user/login?filter=0"
+      Then the current URL should not have the "filter" parameter with the value "0"
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The parameter "filter" with value "0" is in the URL but should not be
+      """
+
+  @trait:PathTrait
+  Scenario: Assert failure when URL parameter should not have the empty value it carries
+    Given some behat configuration
+    And scenario steps:
+      """
+      Given I am an anonymous user
+      When I visit "/user/login?empty="
+      Then the current URL should not have the "empty" parameter with the value ""
+      """
+    When I run "behat --no-colors"
+    Then it should fail with an error:
+      """
+      The parameter "empty" with value "" is in the URL but should not be
+      """
+
+  @api
   Scenario: Assert "When I go back" navigates to the previous page
     Given I am an anonymous user
     When I go to "/user/login"


### PR DESCRIPTION
Closes #733

## Summary

`PathTrait::pathAssertUrlHasParameter()` and `pathAssertUrlHasNoParameter()` now decide query-parameter presence with `array_key_exists($param, $query)` instead of `empty($query[$param])`, and the early-return guard inside `pathAssertUrlHasNoParameterWithValue()` follows the same change.

`empty()` returns true for the string `"0"` and for the empty string, so `parse_str('filter=0&empty=', $q)` produces `$q['filter'] === '0'` and `$q['empty'] === ''`, both of which `empty($query[$param])` reported as absent even though the parameter appeared in the URL.

After merge, `?filter=0` and `?empty=` satisfy `the current URL should have the :param parameter` and fail `the current URL should not have the :param parameter`, while the `===` value comparison in `pathAssertUrlHasParameterWithValue()` and `pathAssertUrlHasNoParameterWithValue()` is untouched and error message strings are unchanged.

## Before / After

```
                     ?filter=0&empty=&keyword=recent
                                    │
                                    ▼
    parse_str() → ['filter' => '0', 'empty' => '', 'keyword' => 'recent']
                                    │
            ┌───────────────────────┴───────────────────────┐
            ▼                                               ▼
┌───────────────────────────────────┐   ┌───────────────────────────────────┐
│ Before: empty($query[$param])     │   │ After: array_key_exists(...)      │
├───────────────────────────────────┤   ├───────────────────────────────────┤
│ filter=0    → empty('0')  = true  │   │ filter=0    → key exists = true   │
│              → reported ABSENT    │   │              → reported PRESENT   │
│ empty=      → empty('')   = true  │   │ empty=      → key exists = true   │
│              → reported ABSENT    │   │              → reported PRESENT   │
│ keyword=x   → empty('x')  = false │   │ keyword=x   → key exists = true   │
│              → reported PRESENT   │   │              → reported PRESENT   │
└───────────────────────────────────┘   └───────────────────────────────────┘
```

## Changes

- `src/PathTrait.php`: replaced `empty($query[$param])` with `array_key_exists($param, $query)` in `pathAssertUrlHasParameter()`, `pathAssertUrlHasNoParameter()`, and the early-return guard in `pathAssertUrlHasNoParameterWithValue()`; `pathAssertUrlHasParameterWithValue()` inherits the fix through its delegation to `pathAssertUrlHasParameter()`.
- `src/PathTrait.php` docblocks: removed the four `A parameter carrying an empty string or "0" counts as absent.` lines, reworded the two summary lines from "with a non-empty value" to plain presence assertions, and added `An absent parameter satisfies the assertion.` to `pathAssertUrlHasNoParameterWithValue()`.
- `STEPS.md`: regenerated with `ahoy update-docs` to match the reworded docblock summaries.
- `MIGRATION.md`: added a `## Query parameter presence` section documenting the breaking change and the before/after step outcomes for `?filter=0`.
- `tests/behat/features/path.feature`: added an `@api` scenario visiting `/user/login?filter=0&empty=&keyword=recent` covering presence and value assertions for falsy parameters and absence for a missing one, plus four `@trait:PathTrait` scenarios proving the negation steps now fail for `?filter=0` and `?empty=`.
