### PR TITLE
[#716] Unified the exception type thrown by assertion steps.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,24 @@ ahoy copy-files
   - Avoid using `Then I`
   - Methods should include the `Assert` prefix
 
+## Exception Types
+
+Which exception a step throws is part of the public contract - consumers catch on it, and the `@trait:` harness asserts on it. Pick the type by what failed, never by what the surrounding code happens to use:
+
+| Failure | Throw |
+| --- | --- |
+| An assertion failed and the trait has a Mink session | `Behat\Mink\Exception\ExpectationException`, with `$this->getSession()->getDriver()` as the second argument |
+| An expected element, field, link or selector is missing | `Behat\Mink\Exception\ElementNotFoundException` (a subclass of `ExpectationException`) |
+| An assertion failed and the trait has no Mink session | `DrevOps\BehatSteps\Exception\AssertionException` |
+| Not an assertion: an invalid step argument, an unmet prerequisite, an infrastructure error | `\RuntimeException` |
+| The current driver lacks a required capability | `Behat\Mink\Exception\UnsupportedDriverActionException` |
+
+Never throw plain `\Exception` or `\InvalidArgumentException` from `src/`.
+
+A trait without a Mink session is one that never calls `$this->getSession()` - `CommandTrait`, `Drupal\ConfigTrait`, `Drupal\ModuleTrait`, `Drupal\StateTrait` and `Drupal\RedirectTrait`. Do not add a session to a trait just to reach `ExpectationException`.
+
+In `@trait:` scenarios, `Then it should fail with an error:` asserts an assertion exception and `Then it should fail with an exception:` asserts a `\RuntimeException`. Use `Then it should fail with a "<class>" exception:` only when the specific class matters.
+
 ## Common Behat Step Patterns
 - Block assertions:
   - `I should see the block with label "..."`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -294,3 +294,41 @@ A scenario that asserted a falsy parameter away with `Then the current URL shoul
 ```gherkin
 Then the current URL should not have the "filter" parameter with the value "recent"
 ```
+## Unified assertion exceptions
+
+Assertion steps used to throw whatever their trait happened to reach for: `ExpectationException` in most places, plain `\Exception` in 8 traits, `\RuntimeException` in `XmlTrait`'s format check, and `\InvalidArgumentException` in 2 select-option steps. The type is part of the contract - consumers catch on it - so it now follows one rule.
+
+| Failure | Exception |
+| --- | --- |
+| An assertion fails and the step can reach the page | `Behat\Mink\Exception\ExpectationException` |
+| An assertion fails and the step has no Mink session | `DrevOps\BehatSteps\Exception\AssertionException` |
+| An expected element, field, link or selector is missing | `Behat\Mink\Exception\ElementNotFoundException` (a subclass of `ExpectationException`) |
+| Anything that is not an assertion - an invalid step argument, an unmet prerequisite, an infrastructure error | `\RuntimeException` |
+| A step needs a driver capability the current driver lacks | `Behat\Mink\Exception\UnsupportedDriverActionException` |
+
+`ExpectationException` requires a Mink driver as its second constructor argument, so traits that never touch the browser cannot construct it. Those traits throw `AssertionException` instead, which carries the same meaning without the dependency.
+
+If your project catches an exception from one of these steps, update the type:
+
+| Trait | Was | Now |
+| --- | --- | --- |
+| `CommandTrait` (all `Then` steps) | `\Exception` | `AssertionException` |
+| `Drupal\ConfigTrait` (all `Then` steps) | `\Exception` | `AssertionException` |
+| `Drupal\ModuleTrait` (all `Then` steps) | `\Exception` | `AssertionException` |
+| `Drupal\StateTrait` (all `Then` steps) | `\Exception` | `AssertionException` |
+| `Drupal\RedirectTrait` (`the following redirects should (not) exist:`) | `\Exception` | `AssertionException` |
+| `MetatagTrait` (all `Then` steps) | `\Exception` | `ExpectationException` |
+| `XmlTrait` (`the response should be in XML format`) | `\RuntimeException` | `ExpectationException` |
+| `FieldTrait` (`the option ... should (not) exist within the select element ...`) | `\InvalidArgumentException` | `ElementNotFoundException` for a missing select, `ExpectationException` for the option |
+| `Drupal\CacheTrait` (`the page cache for the path(s) ... is empty`) | `\InvalidArgumentException` | `\RuntimeException` |
+| `KeyboardTrait` (`I press the key(s) ...`) | `\InvalidArgumentException` | `\RuntimeException` |
+
+3 failure messages changed along with their type:
+
+| Step | Was | Now |
+| --- | --- | --- |
+| `the response should be in XML format` | `Failed to load XML. Errors: ...` | `The response is not valid XML: ...` |
+| `the option :option should exist within the select element :selector` | `Element "..." is not found.` / `Option "..." is not found in select "...".` | `Select with id\|name\|label "..." not found.` / `The option "..." was not found in the select "..." on the page ....` |
+| `the option :option should not exist within the select element :selector` | `Element "..." is not found.` / `Option "..." is found in select "...", but should not.` | `Select with id\|name\|label "..." not found.` / `The option "..." was found in the select "..." on the page ..., but should not exist.` |
+
+Behat reports every one of these as a failed step either way, so a scenario that simply runs to a failure behaves the same. Only code that catches a specific type, or asserts on the message text, needs changing.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -294,6 +294,7 @@ A scenario that asserted a falsy parameter away with `Then the current URL shoul
 ```gherkin
 Then the current URL should not have the "filter" parameter with the value "recent"
 ```
+
 ## Unified assertion exceptions
 
 Assertion steps used to throw whatever their trait happened to reach for: `ExpectationException` in most places, plain `\Exception` in 8 traits, `\RuntimeException` in `XmlTrait`'s format check, and `\InvalidArgumentException` in 2 select-option steps. The type is part of the contract - consumers catch on it - so it now follows one rule.

--- a/README.md
+++ b/README.md
@@ -175,9 +175,7 @@ your host - as long as that browser can reach your site's `base_url`.
 
 ### Exceptions
 
-This library uses [Mink exception classes](https://mink.behat.org/en/latest/)
-for
-consistent error handling:
+This library reports failures with a small, fixed set of exception types, mostly [Mink's](https://mink.behat.org/en/latest/):
 
 | Exception                          | When thrown                                          |
 |------------------------------------|------------------------------------------------------|
@@ -187,13 +185,9 @@ consistent error handling:
 | `UnsupportedDriverActionException` | Feature requires specific driver (e.g., Selenium)    |
 | `\RuntimeException`                | Invalid input or processing error (not an assertion) |
 
-`ElementNotFoundException` extends `ExpectationException`, so catching
-`ExpectationException` covers both.
+`ElementNotFoundException` extends `ExpectationException`, so catching `ExpectationException` covers both.
 
-`DrevOps\BehatSteps\Exception\AssertionException` is thrown by traits that
-never touch the browser, such as `CommandTrait` and `Drupal\ConfigTrait`.
-`ExpectationException` needs a Mink driver, which those traits do not have, so
-they report a failed assertion with this instead.
+`DrevOps\BehatSteps\Exception\AssertionException` is thrown by traits that never touch the browser, such as `CommandTrait` and `Drupal\ConfigTrait`. `ExpectationException` needs a Mink driver, which those traits do not have, so they report a failed assertion with this instead.
 
 Example error messages:
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,17 @@ consistent error handling:
 |------------------------------------|------------------------------------------------------|
 | `ElementNotFoundException`         | Element, field, link, or selector not found on page  |
 | `ExpectationException`             | Assertion fails (value mismatch, state verification) |
+| `AssertionException`               | Assertion fails in a step with no Mink session       |
 | `UnsupportedDriverActionException` | Feature requires specific driver (e.g., Selenium)    |
 | `\RuntimeException`                | Invalid input or processing error (not an assertion) |
+
+`ElementNotFoundException` extends `ExpectationException`, so catching
+`ExpectationException` covers both.
+
+`DrevOps\BehatSteps\Exception\AssertionException` is thrown by traits that
+never touch the browser, such as `CommandTrait` and `Drupal\ConfigTrait`.
+`ExpectationException` needs a Mink driver, which those traits do not have, so
+they report a failed assertion with this instead.
 
 Example error messages:
 

--- a/docs.php
+++ b/docs.php
@@ -137,10 +137,8 @@ function extract_info(string $class_name, array $exclude = [], string $base_path
     $files = scandir($traits_path) ?: [];
     foreach ($files as $file) {
       $file_path = $traits_path . DIRECTORY_SEPARATOR . $file;
-      if (is_file($file_path)) {
-        if (file_declares_trait($file_path)) {
-          $traits_files[] = basename($file, '.php');
-        }
+      if (is_file($file_path) && file_declares_trait($file_path)) {
+        $traits_files[] = basename($file, '.php');
       }
       elseif (is_dir($file_path) && $file !== '.' && $file !== '..') {
         $subdir_files = scandir($file_path) ?: [];

--- a/docs.php
+++ b/docs.php
@@ -97,6 +97,21 @@ function main(array $options = []): void {
 // @codeCoverageIgnoreEnd
 
 /**
+ * Check whether a PHP file declares a trait.
+ *
+ * @param string $file_path
+ *   Path to the PHP file.
+ *
+ * @return bool
+ *   TRUE when the file declares a trait.
+ */
+function file_declares_trait(string $file_path): bool {
+  $contents = file_get_contents($file_path);
+
+  return $contents !== FALSE && preg_match('/^\s*trait\s+\w+/m', $contents) === 1;
+}
+
+/**
  * Parse info from the class.
  *
  * @param class-string $class_name
@@ -123,12 +138,15 @@ function extract_info(string $class_name, array $exclude = [], string $base_path
     foreach ($files as $file) {
       $file_path = $traits_path . DIRECTORY_SEPARATOR . $file;
       if (is_file($file_path)) {
-        $traits_files[] = basename($file, '.php');
+        if (file_declares_trait($file_path)) {
+          $traits_files[] = basename($file, '.php');
+        }
       }
       elseif (is_dir($file_path) && $file !== '.' && $file !== '..') {
         $subdir_files = scandir($file_path) ?: [];
         foreach ($subdir_files as $subdir_file) {
-          if (is_file($file_path . DIRECTORY_SEPARATOR . $subdir_file)) {
+          $subdir_file_path = $file_path . DIRECTORY_SEPARATOR . $subdir_file;
+          if (is_file($subdir_file_path) && file_declares_trait($subdir_file_path)) {
             $traits_files[] = basename($subdir_file, '.php');
           }
         }

--- a/src/CommandTrait.php
+++ b/src/CommandTrait.php
@@ -8,6 +8,7 @@ use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Step\Then;
 use Behat\Step\When;
+use DrevOps\BehatSteps\Exception\AssertionException;
 
 /**
  * Run local shell commands and assert on their result.
@@ -168,7 +169,7 @@ trait CommandTrait {
     $exit_code = (int) $this->commandExitCode;
 
     if ($exit_code !== 0) {
-      throw new \Exception(sprintf('Expected the command to succeed, but it exited with code %d. Error output: %s.', $exit_code, $this->commandStderr));
+      throw new AssertionException(sprintf('Expected the command to succeed, but it exited with code %d. Error output: %s.', $exit_code, $this->commandStderr));
     }
   }
 
@@ -185,7 +186,7 @@ trait CommandTrait {
     $this->commandAssertHasRun();
 
     if ((int) $this->commandExitCode === 0) {
-      throw new \Exception('Expected the command to fail, but it exited with code 0.');
+      throw new AssertionException('Expected the command to fail, but it exited with code 0.');
     }
   }
 
@@ -205,7 +206,7 @@ trait CommandTrait {
     $exit_code = (int) $this->commandExitCode;
 
     if ($exit_code !== $expected) {
-      throw new \Exception(sprintf('Expected the command to exit with code %d, but it exited with code %d.', $expected, $exit_code));
+      throw new AssertionException(sprintf('Expected the command to exit with code %d, but it exited with code %d.', $expected, $exit_code));
     }
   }
 
@@ -224,7 +225,7 @@ trait CommandTrait {
     $this->commandAssertHasRun();
 
     if (!str_contains($this->commandStdout, $text)) {
-      throw new \Exception(sprintf('Expected the command output to contain "%s", but it did not. Actual output: %s.', $text, $this->commandStdout));
+      throw new AssertionException(sprintf('Expected the command output to contain "%s", but it did not. Actual output: %s.', $text, $this->commandStdout));
     }
   }
 
@@ -243,7 +244,7 @@ trait CommandTrait {
     $this->commandAssertHasRun();
 
     if (str_contains($this->commandStdout, $text)) {
-      throw new \Exception(sprintf('Expected the command output to not contain "%s", but it did. Actual output: %s.', $text, $this->commandStdout));
+      throw new AssertionException(sprintf('Expected the command output to not contain "%s", but it did. Actual output: %s.', $text, $this->commandStdout));
     }
   }
 
@@ -264,7 +265,7 @@ trait CommandTrait {
     $this->commandAssertHasRun();
 
     if (trim($this->commandStdout) !== trim($text)) {
-      throw new \Exception(sprintf('Expected the command output to be "%s", but got "%s".', trim($text), trim($this->commandStdout)));
+      throw new AssertionException(sprintf('Expected the command output to be "%s", but got "%s".', trim($text), trim($this->commandStdout)));
     }
   }
 
@@ -283,7 +284,7 @@ trait CommandTrait {
     $this->commandAssertHasRun();
 
     if (!str_contains($this->commandStderr, $text)) {
-      throw new \Exception(sprintf('Expected the command error output to contain "%s", but it did not. Actual error output: %s.', $text, $this->commandStderr));
+      throw new AssertionException(sprintf('Expected the command error output to contain "%s", but it did not. Actual error output: %s.', $text, $this->commandStderr));
     }
   }
 
@@ -302,7 +303,7 @@ trait CommandTrait {
     $limit = $this->commandAssertNumeric($seconds, 'expected duration');
 
     if ($this->commandDuration >= $limit) {
-      throw new \Exception(sprintf('Expected the command to complete in less than %s seconds, but it took %.3f seconds.', $seconds, $this->commandDuration));
+      throw new AssertionException(sprintf('Expected the command to complete in less than %s seconds, but it took %.3f seconds.', $seconds, $this->commandDuration));
     }
   }
 
@@ -321,7 +322,7 @@ trait CommandTrait {
     $limit = $this->commandAssertNumeric($seconds, 'expected duration');
 
     if ($this->commandDuration <= $limit) {
-      throw new \Exception(sprintf('Expected the command to complete in more than %s seconds, but it took %.3f seconds.', $seconds, $this->commandDuration));
+      throw new AssertionException(sprintf('Expected the command to complete in more than %s seconds, but it took %.3f seconds.', $seconds, $this->commandDuration));
     }
   }
 

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -112,7 +112,7 @@ trait BlockTrait {
           }
           // @codeCoverageIgnoreStart
           else {
-            throw new \InvalidArgumentException('Expected region as string.');
+            throw new \RuntimeException('Expected region as string.');
           }
           // @codeCoverageIgnoreEnd
           break;

--- a/src/Drupal/BlockTrait.php
+++ b/src/Drupal/BlockTrait.php
@@ -247,7 +247,7 @@ trait BlockTrait {
    *   Then the block "My block" should exist
    * @endcode
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ExpectationException
    *   When no block with the specified label is found.
    */
   #[Then('the block :label should exist')]
@@ -269,7 +269,7 @@ trait BlockTrait {
    *   Then the block "My block" should not exist
    * @endcode
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ExpectationException
    *   When block with the specified label is found.
    */
   #[Then('the block :label should not exist')]
@@ -293,7 +293,7 @@ trait BlockTrait {
    *   Then the block "My block" should exist in the "content" region
    * @endcode
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ExpectationException
    *   When no block with the specified label is found in the given region.
    */
   #[Then('the block :label should exist in the :region region')]
@@ -320,7 +320,7 @@ trait BlockTrait {
    *   Then the block "My block" should not exist in the "content" region
    * @endcode
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ExpectationException
    *   When block with the specified label is found in the given region.
    */
   #[Then('the block :label should not exist in the :region region')]

--- a/src/Drupal/CacheTrait.php
+++ b/src/Drupal/CacheTrait.php
@@ -30,11 +30,11 @@ trait CacheTrait {
   #[Given('the page cache for the path :path is empty')]
   public function cacheClearPagePath(string $path): void {
     if ($path === '') {
-      throw new \InvalidArgumentException('The path must not be empty.');
+      throw new \RuntimeException('The path must not be empty.');
     }
 
     if (!str_starts_with($path, '/')) {
-      throw new \InvalidArgumentException(sprintf('The path "%s" must start with a leading slash.', $path));
+      throw new \RuntimeException(sprintf('The path "%s" must start with a leading slash.', $path));
     }
 
     Cache::invalidateTags(['http_response', 'url:' . $path]);
@@ -53,11 +53,11 @@ trait CacheTrait {
   #[Given('the page cache for the paths matching :path_pattern is empty')]
   public function cacheClearPagePathWildcard(string $path_pattern): void {
     if ($path_pattern === '') {
-      throw new \InvalidArgumentException('The path pattern must not be empty.');
+      throw new \RuntimeException('The path pattern must not be empty.');
     }
 
     if (!str_starts_with($path_pattern, '/')) {
-      throw new \InvalidArgumentException(sprintf('The path pattern "%s" must start with a leading slash.', $path_pattern));
+      throw new \RuntimeException(sprintf('The path pattern "%s" must start with a leading slash.', $path_pattern));
     }
 
     $bin = $this->cacheGetPageCacheBin();

--- a/src/Drupal/ConfigTrait.php
+++ b/src/Drupal/ConfigTrait.php
@@ -11,6 +11,7 @@ use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use DrevOps\BehatSteps\Exception\AssertionException;
 
 /**
  * Assert and set stored Drupal configuration values with automatic revert.
@@ -307,18 +308,18 @@ trait ConfigTrait {
 
     if ($should_match) {
       if (!$is_set) {
-        throw new \Exception(sprintf('The config "%s" key "%s" is not set, but it should have the %s "%s".', $name, $key, $descriptor, $expected));
+        throw new AssertionException(sprintf('The config "%s" key "%s" is not set, but it should have the %s "%s".', $name, $key, $descriptor, $expected));
       }
 
       if (!$matches) {
-        throw new \Exception(sprintf('The config "%s" key "%s" has the %s "%s", but it should have the %s "%s".', $name, $key, $descriptor, $actual_string, $descriptor, $expected));
+        throw new AssertionException(sprintf('The config "%s" key "%s" has the %s "%s", but it should have the %s "%s".', $name, $key, $descriptor, $actual_string, $descriptor, $expected));
       }
 
       return;
     }
 
     if ($matches) {
-      throw new \Exception(sprintf('The config "%s" key "%s" has the %s "%s", but it should not have the %s "%s".', $name, $key, $descriptor, $actual_string, $descriptor, $expected));
+      throw new AssertionException(sprintf('The config "%s" key "%s" has the %s "%s", but it should not have the %s "%s".', $name, $key, $descriptor, $actual_string, $descriptor, $expected));
     }
   }
 
@@ -346,18 +347,18 @@ trait ConfigTrait {
 
     if ($should_contain) {
       if (!$is_set) {
-        throw new \Exception(sprintf('The config "%s" key "%s" is not set, but its %s should contain "%s".', $name, $key, $descriptor, $expected));
+        throw new AssertionException(sprintf('The config "%s" key "%s" is not set, but its %s should contain "%s".', $name, $key, $descriptor, $expected));
       }
 
       if (!$contains) {
-        throw new \Exception(sprintf('The config "%s" key "%s" has the %s "%s", which does not contain "%s".', $name, $key, $descriptor, $actual_string, $expected));
+        throw new AssertionException(sprintf('The config "%s" key "%s" has the %s "%s", which does not contain "%s".', $name, $key, $descriptor, $actual_string, $expected));
       }
 
       return;
     }
 
     if ($contains) {
-      throw new \Exception(sprintf('The config "%s" key "%s" has the %s "%s", which contains "%s" but should not.', $name, $key, $descriptor, $actual_string, $expected));
+      throw new AssertionException(sprintf('The config "%s" key "%s" has the %s "%s", which contains "%s" but should not.', $name, $key, $descriptor, $actual_string, $expected));
     }
   }
 

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -332,7 +332,7 @@ trait FileTrait {
     $file_content = @file_get_contents($uri);
     // @codeCoverageIgnoreStart
     if ($file_content === FALSE) {
-      throw new \Exception(sprintf('Unable to read file "%s".', $uri));
+      throw new \RuntimeException(sprintf('Unable to read file "%s".', $uri));
     }
     // @codeCoverageIgnoreEnd
     if (!str_contains($file_content, $content)) {
@@ -354,7 +354,7 @@ trait FileTrait {
     $file_content = @file_get_contents($uri);
     // @codeCoverageIgnoreStart
     if ($file_content === FALSE) {
-      throw new \Exception(sprintf('Unable to read file "%s".', $uri));
+      throw new \RuntimeException(sprintf('Unable to read file "%s".', $uri));
     }
     // @codeCoverageIgnoreEnd
     if (str_contains($file_content, $content)) {

--- a/src/Drupal/MediaTrait.php
+++ b/src/Drupal/MediaTrait.php
@@ -285,12 +285,12 @@ trait MediaTrait {
 
     // @codeCoverageIgnoreStart
     if (empty($bundle)) {
-      throw new \Exception('Cannot create media because it is missing the required bundle.');
+      throw new \RuntimeException('Cannot create media because it is missing the required bundle.');
     }
 
     $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo('media');
     if (!in_array($bundle, array_keys($bundles))) {
-      throw new \Exception(sprintf("Cannot create media because provided bundle '%s' does not exist.", $bundle));
+      throw new \RuntimeException(sprintf("Cannot create media because provided bundle '%s' does not exist.", $bundle));
     }
     // @codeCoverageIgnoreEnd
     $this->mediaExpandEntityFieldsFixtures($stub);

--- a/src/Drupal/ModuleTrait.php
+++ b/src/Drupal/ModuleTrait.php
@@ -11,6 +11,7 @@ use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use DrevOps\BehatSteps\Exception\AssertionException;
 
 /**
  * Enable and disable Drupal modules with automatic state restoration.
@@ -165,7 +166,7 @@ trait ModuleTrait {
   #[Then('the :module module should be enabled')]
   public function moduleAssertEnabled(string $module): void {
     if (!$this->moduleIsEnabled($module)) {
-      throw new \Exception(sprintf('The module "%s" is not enabled, but it should be.', $module));
+      throw new AssertionException(sprintf('The module "%s" is not enabled, but it should be.', $module));
     }
   }
 
@@ -179,7 +180,7 @@ trait ModuleTrait {
   #[Then('the :module module should be disabled')]
   public function moduleAssertDisabled(string $module): void {
     if ($this->moduleIsEnabled($module)) {
-      throw new \Exception(sprintf('The module "%s" is enabled, but it should not be.', $module));
+      throw new AssertionException(sprintf('The module "%s" is enabled, but it should not be.', $module));
     }
   }
 
@@ -196,7 +197,7 @@ trait ModuleTrait {
   public function moduleAssertEnabledMultiple(TableNode $modules_table): void {
     foreach ($modules_table->getColumn(0) as $module) {
       if (!$this->moduleIsEnabled($module)) {
-        throw new \Exception(sprintf('The module "%s" is not enabled, but it should be.', $module));
+        throw new AssertionException(sprintf('The module "%s" is not enabled, but it should be.', $module));
       }
     }
   }
@@ -214,7 +215,7 @@ trait ModuleTrait {
   public function moduleAssertDisabledMultiple(TableNode $modules_table): void {
     foreach ($modules_table->getColumn(0) as $module) {
       if ($this->moduleIsEnabled($module)) {
-        throw new \Exception(sprintf('The module "%s" is enabled, but it should not be.', $module));
+        throw new AssertionException(sprintf('The module "%s" is enabled, but it should not be.', $module));
       }
     }
   }

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -7,6 +7,7 @@ namespace DrevOps\BehatSteps\Drupal;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use DrevOps\BehatSteps\Exception\AssertionException;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\redirect\Entity\Redirect;
 
@@ -181,7 +182,7 @@ trait RedirectTrait {
     }
 
     if ($missing !== []) {
-      throw new \Exception(sprintf('The following redirects should exist but were not found: %s.', implode(', ', $missing)));
+      throw new AssertionException(sprintf('The following redirects should exist but were not found: %s.', implode(', ', $missing)));
     }
   }
 
@@ -217,7 +218,7 @@ trait RedirectTrait {
     }
 
     if ($present !== []) {
-      throw new \Exception(sprintf('The following redirects should not exist but were found: %s.', implode(', ', $present)));
+      throw new AssertionException(sprintf('The following redirects should not exist but were found: %s.', implode(', ', $present)));
     }
   }
 

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -11,6 +11,7 @@ use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use DrevOps\BehatSteps\Exception\AssertionException;
 
 /**
  * Manage and assert Drupal State API values with automatic revert.
@@ -130,14 +131,14 @@ trait StateTrait {
   public function stateAssertHasValue(string $name, string $value): void {
     $state_value = $this->stateReadValue($name);
     if (!$state_value['exists']) {
-      throw new \Exception(sprintf('The state "%s" does not exist, but it should have the value "%s".', $name, $value));
+      throw new AssertionException(sprintf('The state "%s" does not exist, but it should have the value "%s".', $name, $value));
     }
 
     $expected = $this->stateNormaliseValue($value);
     $actual_stringified = $this->stateStringifyValue($state_value['value']);
     $expected_stringified = $this->stateStringifyValue($expected);
     if ($actual_stringified !== $expected_stringified) {
-      throw new \Exception(sprintf('The state "%s" has the value "%s", but it should have the value "%s".', $name, $actual_stringified, $expected_stringified));
+      throw new AssertionException(sprintf('The state "%s" has the value "%s", but it should have the value "%s".', $name, $actual_stringified, $expected_stringified));
     }
   }
 
@@ -152,7 +153,7 @@ trait StateTrait {
   public function stateAssertNotExists(string $name): void {
     $state_value = $this->stateReadValue($name);
     if ($state_value['exists']) {
-      throw new \Exception(sprintf('The state "%s" exists with the value "%s", but it should not exist.', $name, $this->stateStringifyValue($state_value['value'])));
+      throw new AssertionException(sprintf('The state "%s" exists with the value "%s", but it should not exist.', $name, $this->stateStringifyValue($state_value['value'])));
     }
   }
 

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -1275,7 +1275,7 @@ JS;
   protected function elementExecuteJs(string $selector, string $script) {
     // @codeCoverageIgnoreStart
     if (!str_contains($script, '{{ELEMENT}}')) {
-      throw new \InvalidArgumentException('The script must contain the {{ELEMENT}} token to reference the element.');
+      throw new \RuntimeException('The script must contain the {{ELEMENT}} token to reference the element.');
     }
     // @codeCoverageIgnoreEnd
     $selector_js = json_encode($selector, JSON_UNESCAPED_SLASHES);

--- a/src/Exception/AssertionException.php
+++ b/src/Exception/AssertionException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Exception;
+
+/**
+ * Thrown when a step assertion fails and no Mink session is available.
+ *
+ * \Behat\Mink\Exception\ExpectationException requires a Mink driver, so a
+ * trait that never touches the browser cannot construct it. This carries the
+ * same meaning - an expectation about the system under test was not met -
+ * without that dependency.
+ *
+ * A failure that is not an assertion, such as an invalid step argument, an
+ * unmet prerequisite or an infrastructure error, is a \RuntimeException.
+ */
+class AssertionException extends \Exception {
+
+}

--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -440,6 +440,16 @@ trait FieldTrait {
   }
 
   /**
+   * The path of the current page, as used in failure messages.
+   *
+   * @return string
+   *   The path component of the current URL.
+   */
+  protected function fieldCurrentPath(): string {
+    return (string) parse_url((string) $this->getSession()->getCurrentUrl(), PHP_URL_PATH);
+  }
+
+  /**
    * Wrap a string in an XPath-safe literal.
    *
    * Handles strings containing single quotes, double quotes, or both.
@@ -579,13 +589,15 @@ JS;
   #[Then('the option :option should exist within the select element :selector')]
   public function fieldAssertSelectOptionExists(string $selector, string $option): void {
     $select_element = $this->getSession()->getPage()->findField($selector);
+
     if ($select_element === NULL) {
-      throw new \InvalidArgumentException(sprintf('Element "%s" is not found.', $selector));
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
     }
 
     $option_element = $select_element->find('named', ['option', $option]);
+
     if ($option_element === NULL) {
-      throw new \InvalidArgumentException(sprintf('Option "%s" is not found in select "%s".', $option, $selector));
+      throw new ExpectationException(sprintf('The option "%s" was not found in the select "%s" on the page %s.', $option, $selector, $this->fieldCurrentPath()), $this->getSession()->getDriver());
     }
   }
 
@@ -599,13 +611,15 @@ JS;
   #[Then('the option :option should not exist within the select element :selector')]
   public function fieldAssertSelectOptionNotExists(string $selector, string $option): void {
     $select_element = $this->getSession()->getPage()->findField($selector);
+
     if ($select_element === NULL) {
-      throw new \InvalidArgumentException(sprintf('Element "%s" is not found.', $selector));
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
     }
 
     $option_element = $select_element->find('named', ['option', $option]);
+
     if ($option_element !== NULL) {
-      throw new \InvalidArgumentException(sprintf('Option "%s" is found in select "%s", but should not.', $option, $selector));
+      throw new ExpectationException(sprintf('The option "%s" was found in the select "%s" on the page %s, but should not exist.', $option, $selector, $this->fieldCurrentPath()), $this->getSession()->getDriver());
     }
   }
 
@@ -619,8 +633,7 @@ JS;
   #[Then('the option :option should be selected within the select element :selector')]
   public function fieldAssertSelectOptionSelected(string $option, string $selector): void {
     $select_field = $this->getSession()->getPage()->findField($selector);
-    $current_url = $this->getSession()->getCurrentUrl();
-    $path = parse_url((string) $current_url, PHP_URL_PATH);
+    $path = $this->fieldCurrentPath();
 
     if (!$select_field) {
       throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);
@@ -650,8 +663,7 @@ JS;
   #[Then('the option :option should not be selected within the select element :selector')]
   public function fieldAssertSelectOptionNotSelected(string $option, string $selector): void {
     $select_field = $this->getSession()->getPage()->findField($selector);
-    $current_url = $this->getSession()->getCurrentUrl();
-    $path = parse_url((string) $current_url, PHP_URL_PATH);
+    $path = $this->fieldCurrentPath();
 
     if (!$select_field) {
       throw new ElementNotFoundException($this->getSession()->getDriver(), 'select', 'id|name|label', $selector);

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -104,7 +104,7 @@ trait JavascriptTrait {
    * reported here instead. The scenario has already failed by then, so the
    * assertion cannot mask a passing scenario from the rerun cache.
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ExpectationException
    *   If JavaScript errors were detected.
    */
   #[AfterScenario('@javascript')]
@@ -172,7 +172,7 @@ trait JavascriptTrait {
    * on the last step rather than on every step lets the registry accumulate
    * errors from every page the scenario visited.
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ExpectationException
    *   If JavaScript errors were detected.
    */
   #[AfterStep]
@@ -320,7 +320,7 @@ JS;
   /**
    * Assert that no JavaScript errors were collected.
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ExpectationException
    *   If JavaScript errors were detected.
    */
   protected function javascriptAssertNoErrors(): void {

--- a/src/KeyboardTrait.php
+++ b/src/KeyboardTrait.php
@@ -126,7 +126,7 @@ trait KeyboardTrait {
     ];
 
     if (strlen($char) < 1) {
-      throw new \InvalidArgumentException('The keyboard key must not be empty.');
+      throw new \RuntimeException('The keyboard key must not be empty.');
     }
 
     if (strlen($char) > 1) {

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -6,6 +6,7 @@ namespace DrevOps\BehatSteps;
 
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Selector\Xpath\Escaper;
 use Behat\Step\Then;
 
@@ -59,7 +60,7 @@ trait MetatagTrait {
     }
 
     if (!$found) {
-      throw new \Exception(sprintf('Meta tag with specified attributes was not found: %s.', json_encode($attributes)));
+      throw new ExpectationException(sprintf('Meta tag with specified attributes was not found: %s.', json_encode($attributes)), $this->getSession()->getDriver());
     }
   }
 
@@ -91,7 +92,7 @@ trait MetatagTrait {
       }
 
       if ($all_attributes_matched) {
-        throw new \Exception(sprintf('Meta tag with specified attributes should not exist: %s.', json_encode($attributes)));
+        throw new ExpectationException(sprintf('Meta tag with specified attributes should not exist: %s.', json_encode($attributes)), $this->getSession()->getDriver());
       }
     }
   }
@@ -112,13 +113,13 @@ trait MetatagTrait {
     $meta_tag = $this->metatagFindMeta($meta_name);
 
     if ($meta_tag === NULL) {
-      throw new \Exception(sprintf('Meta tag with name or property "%s" not found.', $meta_name));
+      throw new ExpectationException(sprintf('Meta tag with name or property "%s" not found.', $meta_name), $this->getSession()->getDriver());
     }
 
     $content = (string) $meta_tag->getAttribute('content');
 
     if ($content !== strip_tags($content)) {
-      throw new \Exception(sprintf('The "%s" meta tag contains HTML tags: %s.', $meta_name, $content));
+      throw new ExpectationException(sprintf('The "%s" meta tag contains HTML tags: %s.', $meta_name, $content), $this->getSession()->getDriver());
     }
   }
 
@@ -139,11 +140,11 @@ trait MetatagTrait {
     $href = $this->metatagGetCanonicalHref();
 
     if ($href === NULL || $href === '') {
-      throw new \Exception('The canonical URL is not set.');
+      throw new ExpectationException('The canonical URL is not set.', $this->getSession()->getDriver());
     }
 
     if ($this->metatagResolveUrl($href) !== $this->metatagResolveUrl($url)) {
-      throw new \Exception(sprintf('The canonical URL is "%s", but expected "%s".', $href, $url));
+      throw new ExpectationException(sprintf('The canonical URL is "%s", but expected "%s".', $href, $url), $this->getSession()->getDriver());
     }
   }
 
@@ -159,7 +160,7 @@ trait MetatagTrait {
     $href = $this->metatagGetCanonicalHref();
 
     if ($href === NULL || $href === '') {
-      throw new \Exception('The canonical URL is not set.');
+      throw new ExpectationException('The canonical URL is not set.', $this->getSession()->getDriver());
     }
   }
 
@@ -175,7 +176,7 @@ trait MetatagTrait {
     $href = $this->metatagGetCanonicalHref();
 
     if ($href !== NULL && $href !== '') {
-      throw new \Exception(sprintf('The canonical URL should not be set, but found "%s".', $href));
+      throw new ExpectationException(sprintf('The canonical URL should not be set, but found "%s".', $href), $this->getSession()->getDriver());
     }
   }
 
@@ -192,7 +193,7 @@ trait MetatagTrait {
   #[Then('the page should be indexable')]
   public function metatagAssertIndexable(): void {
     if (!$this->metatagIsIndexable()) {
-      throw new \Exception('The page is not indexable: a "noindex" directive is present in the robots meta tag or the "X-Robots-Tag" header.');
+      throw new ExpectationException('The page is not indexable: a "noindex" directive is present in the robots meta tag or the "X-Robots-Tag" header.', $this->getSession()->getDriver());
     }
   }
 
@@ -206,7 +207,7 @@ trait MetatagTrait {
   #[Then('the page should not be indexable')]
   public function metatagAssertNotIndexable(): void {
     if ($this->metatagIsIndexable()) {
-      throw new \Exception('The page is indexable, but it should not be: no "noindex" directive found in the robots meta tag or the "X-Robots-Tag" header.');
+      throw new ExpectationException('The page is indexable, but it should not be: no "noindex" directive found in the robots meta tag or the "X-Robots-Tag" header.', $this->getSession()->getDriver());
     }
   }
 
@@ -226,7 +227,7 @@ trait MetatagTrait {
     $directives = $this->metatagGetRobotsDirectives();
 
     if (!in_array(strtolower(trim($directive)), $directives, TRUE)) {
-      throw new \Exception(sprintf('The robots meta tag does not include the "%s" directive. Found: %s.', $directive, $directives === [] ? '(none)' : implode(', ', $directives)));
+      throw new ExpectationException(sprintf('The robots meta tag does not include the "%s" directive. Found: %s.', $directive, $directives === [] ? '(none)' : implode(', ', $directives)), $this->getSession()->getDriver());
     }
   }
 
@@ -243,7 +244,7 @@ trait MetatagTrait {
     $directives = $this->metatagGetRobotsDirectives();
 
     if (in_array(strtolower(trim($directive)), $directives, TRUE)) {
-      throw new \Exception(sprintf('The robots meta tag includes the "%s" directive, but it should not.', $directive));
+      throw new ExpectationException(sprintf('The robots meta tag includes the "%s" directive, but it should not.', $directive), $this->getSession()->getDriver());
     }
   }
 
@@ -264,16 +265,16 @@ trait MetatagTrait {
     $alternates = $this->metatagGetHreflangAlternates();
 
     if ($alternates === []) {
-      throw new \Exception('No hreflang alternate links were found on the page.');
+      throw new ExpectationException('No hreflang alternate links were found on the page.', $this->getSession()->getDriver());
     }
 
     foreach ($alternates as $alternate) {
       if ($alternate['href'] === '') {
-        throw new \Exception(sprintf('The hreflang alternate for "%s" has an empty href.', $alternate['hreflang']));
+        throw new ExpectationException(sprintf('The hreflang alternate for "%s" has an empty href.', $alternate['hreflang']), $this->getSession()->getDriver());
       }
 
       if (!$this->metatagIsValidHreflang($alternate['hreflang'])) {
-        throw new \Exception(sprintf('The hreflang value "%s" is not a valid language code.', $alternate['hreflang']));
+        throw new ExpectationException(sprintf('The hreflang value "%s" is not a valid language code.', $alternate['hreflang']), $this->getSession()->getDriver());
       }
     }
 
@@ -285,7 +286,7 @@ trait MetatagTrait {
       }
     }
 
-    throw new \Exception(sprintf('No self-referencing hreflang alternate was found for the current URL "%s".', $current));
+    throw new ExpectationException(sprintf('No self-referencing hreflang alternate was found for the current URL "%s".', $current), $this->getSession()->getDriver());
   }
 
   /**
@@ -314,7 +315,7 @@ trait MetatagTrait {
       }
 
       if (!$this->metatagHtmlLinksBackTo($this->metatagFetchUrl($target), $current, $target)) {
-        throw new \Exception(sprintf('The hreflang alternate "%s" (%s) does not link back to the current URL "%s".', $alternate['hreflang'], $target, $current));
+        throw new ExpectationException(sprintf('The hreflang alternate "%s" (%s) does not link back to the current URL "%s".', $alternate['hreflang'], $target, $current), $this->getSession()->getDriver());
       }
     }
   }
@@ -531,7 +532,7 @@ trait MetatagTrait {
 
     if ($handle === FALSE) {
       // @codeCoverageIgnoreStart
-      throw new \Exception(sprintf('Failed to initialise a request for "%s".', $url));
+      throw new \RuntimeException(sprintf('Failed to initialise a request for "%s".', $url));
       // @codeCoverageIgnoreEnd
     }
 
@@ -544,12 +545,12 @@ trait MetatagTrait {
 
     if (!is_string($body)) {
       // @codeCoverageIgnoreStart
-      throw new \Exception(sprintf('Failed to fetch the hreflang alternate page "%s".', $url));
+      throw new \RuntimeException(sprintf('Failed to fetch the hreflang alternate page "%s".', $url));
       // @codeCoverageIgnoreEnd
     }
 
     if ($status >= 400) {
-      throw new \Exception(sprintf('The hreflang alternate page "%s" returned HTTP status %d.', $url, $status));
+      throw new ExpectationException(sprintf('The hreflang alternate page "%s" returned HTTP status %d.', $url, $status), $this->getSession()->getDriver());
     }
 
     return $body;
@@ -649,7 +650,7 @@ trait MetatagTrait {
     }
 
     if ($missing !== []) {
-      throw new \Exception(sprintf('The following required %s meta tags are missing or empty: %s.', $label, implode(', ', $missing)));
+      throw new ExpectationException(sprintf('The following required %s meta tags are missing or empty: %s.', $label, implode(', ', $missing)), $this->getSession()->getDriver());
     }
   }
 

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -117,7 +117,11 @@ trait XmlTrait {
    */
   #[Then('the response should be in XML format')]
   public function xmlAssertResponseIsXml(): void {
-    $this->xmlEnsureDocument();
+    $error = $this->xmlContentError($this->xmlResolveContent());
+
+    if ($error !== NULL) {
+      throw new ExpectationException(sprintf('The response is not valid XML: %s.', $error), $this->getSession()->getDriver());
+    }
   }
 
   /**
@@ -133,16 +137,7 @@ trait XmlTrait {
    */
   #[Then('the response should not be in XML format')]
   public function xmlAssertResponseIsNotXml(): void {
-    // Resolve content the same way as xmlEnsureDocument().
-    $content = $this->xmlTestContent ?? $this->getSession()->getPage()->getContent();
-
-    $document = new \DOMDocument();
-    libxml_clear_errors();
-    $loaded = @$document->loadXML($content);
-    $errors = libxml_get_errors();
-    libxml_clear_errors();
-
-    if ($loaded && empty($errors)) {
+    if ($this->xmlContentError($this->xmlResolveContent()) === NULL) {
       throw new ExpectationException('The response is valid XML, but it should not be.', $this->getSession()->getDriver());
     }
   }
@@ -678,6 +673,40 @@ trait XmlTrait {
     }
 
     print $output;
+  }
+
+  /**
+   * Resolve the response content to assert against.
+   *
+   * @return string
+   *   The content set by a fixture step, or the live page content.
+   */
+  protected function xmlResolveContent(): string {
+    return $this->xmlTestContent ?? (string) $this->getSession()->getPage()->getContent();
+  }
+
+  /**
+   * Parse XML content and report why it is not well-formed.
+   *
+   * @param string $content
+   *   The XML content to parse.
+   *
+   * @return string|null
+   *   The formatted parse errors, or NULL when the content is well-formed.
+   */
+  protected function xmlContentError(string $content): ?string {
+    $document = new \DOMDocument();
+
+    libxml_clear_errors();
+    $loaded = @$document->loadXML($content);
+    $errors = libxml_get_errors();
+    libxml_clear_errors();
+
+    if ($loaded && $errors === []) {
+      return NULL;
+    }
+
+    return $this->xmlFormatErrors($errors);
   }
 
   /**

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -117,10 +117,10 @@ trait XmlTrait {
    */
   #[Then('the response should be in XML format')]
   public function xmlAssertResponseIsXml(): void {
-    $error = $this->xmlContentError($this->xmlResolveContent());
+    $parsed = $this->xmlParse($this->xmlResolveContent());
 
-    if ($error !== NULL) {
-      throw new ExpectationException(sprintf('The response is not valid XML: %s.', $error), $this->getSession()->getDriver());
+    if (!$parsed['loaded']) {
+      throw new ExpectationException(sprintf('The response is not valid XML: %s.', $this->xmlFormatErrors($parsed['errors'])), $this->getSession()->getDriver());
     }
   }
 
@@ -137,7 +137,9 @@ trait XmlTrait {
    */
   #[Then('the response should not be in XML format')]
   public function xmlAssertResponseIsNotXml(): void {
-    if ($this->xmlContentError($this->xmlResolveContent()) === NULL) {
+    $parsed = $this->xmlParse($this->xmlResolveContent());
+
+    if ($parsed['loaded'] && $parsed['errors'] === []) {
       throw new ExpectationException('The response is valid XML, but it should not be.', $this->getSession()->getDriver());
     }
   }
@@ -686,27 +688,24 @@ trait XmlTrait {
   }
 
   /**
-   * Parse XML content and report why it is not well-formed.
+   * Parse XML content without disturbing the cached document.
    *
    * @param string $content
    *   The XML content to parse.
    *
-   * @return string|null
-   *   The formatted parse errors, or NULL when the content is well-formed.
+   * @return array{loaded: bool, errors: array<int, \LibXMLError>}
+   *   Whether the content parsed into a document, and the errors libxml raised
+   *   while parsing it. A document can parse and still raise errors.
    */
-  protected function xmlContentError(string $content): ?string {
+  protected function xmlParse(string $content): array {
     $document = new \DOMDocument();
 
     libxml_clear_errors();
-    $loaded = @$document->loadXML($content);
+    $loaded = (bool) @$document->loadXML($content);
     $errors = libxml_get_errors();
     libxml_clear_errors();
 
-    if ($loaded && $errors === []) {
-      return NULL;
-    }
-
-    return $this->xmlFormatErrors($errors);
+    return ['loaded' => $loaded, 'errors' => $errors];
   }
 
   /**

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -360,12 +360,14 @@ EOL;
   #[Then('it should fail with an error:')]
   public function behatCliAssertFailWithError(PyStringNode $message): void {
     $this->itShouldPassOrFailWith('fail', $message);
-    // Enforce assertion exceptions (ExpectationException, ElementNotFoundException, or generic Exception).
-    // Non-assertion exceptions should be thrown as \RuntimeException.
+    // Enforce assertion exceptions: ExpectationException and its
+    // ElementNotFoundException subclass where a Mink session is available,
+    // AssertionException where it is not. Non-assertion failures should be
+    // thrown as \RuntimeException.
     $output = $this->getOutput();
-    $has_valid_exception = str_contains((string) $output, ' (Exception)')
-      || str_contains((string) $output, ' (Behat\Mink\Exception\ExpectationException)')
-      || str_contains((string) $output, ' (Behat\Mink\Exception\ElementNotFoundException)');
+    $has_valid_exception = str_contains((string) $output, ' (Behat\Mink\Exception\ExpectationException)')
+      || str_contains((string) $output, ' (Behat\Mink\Exception\ElementNotFoundException)')
+      || str_contains((string) $output, ' (DrevOps\BehatSteps\Exception\AssertionException)');
     if (!$has_valid_exception) {
       throw new \RuntimeException('The output does not contain an assertion exception string as expected.');
     }
@@ -377,8 +379,8 @@ EOL;
   #[Then('it should fail with an exception:')]
   public function behatCliAssertFailWithException(PyStringNode $message): void {
     $this->itShouldPassOrFailWith('fail', $message);
-    // Enforce \RuntimeException for all non-assertion exceptions. Assertion
-    // exceptions should be thrown as \Exception.
+    // Enforce \RuntimeException for all non-assertion failures. Assertion
+    // failures should be thrown as an assertion exception.
     if (!str_contains($this->getOutput(), ' (RuntimeException)')) {
       throw new \RuntimeException('The output does not contain an "(RuntimeException)" string as expected.');
     }
@@ -390,8 +392,6 @@ EOL;
   #[Then('it should fail with a :exception exception:')]
   public function behatCliAssertFailWithCustomException(string $exception, PyStringNode $message): void {
     $this->itShouldPassOrFailWith('fail', $message);
-    // Enforce \RuntimeException for all non-assertion exceptions. Assertion
-    // exceptions should be thrown as \Exception.
     if (!str_contains($this->getOutput(), ' (' . $exception . ')')) {
       throw new \RuntimeException(sprintf('The output does not contain an "(%s)" string as expected.', $exception));
     }

--- a/tests/behat/features/drupal_cache.feature
+++ b/tests/behat/features/drupal_cache.feature
@@ -33,7 +33,7 @@ Feature: Check that CacheTrait works
       And the page cache for the path "" is empty
       """
     When I run "behat --no-colors"
-    Then it should fail with a "InvalidArgumentException" exception:
+    Then it should fail with an exception:
       """
       The path must not be empty.
       """
@@ -47,7 +47,7 @@ Feature: Check that CacheTrait works
       And the page cache for the path "about" is empty
       """
     When I run "behat --no-colors"
-    Then it should fail with a "InvalidArgumentException" exception:
+    Then it should fail with an exception:
       """
       The path "about" must start with a leading slash.
       """
@@ -61,7 +61,7 @@ Feature: Check that CacheTrait works
       And the page cache for the paths matching "" is empty
       """
     When I run "behat --no-colors"
-    Then it should fail with a "InvalidArgumentException" exception:
+    Then it should fail with an exception:
       """
       The path pattern must not be empty.
       """
@@ -75,7 +75,7 @@ Feature: Check that CacheTrait works
       And the page cache for the paths matching "news/*" is empty
       """
     When I run "behat --no-colors"
-    Then it should fail with a "InvalidArgumentException" exception:
+    Then it should fail with an exception:
       """
       The path pattern "news/*" must start with a leading slash.
       """

--- a/tests/behat/features/field.feature
+++ b/tests/behat/features/field.feature
@@ -300,9 +300,9 @@ Feature: Check that FieldTrait works
       Then the option "UTC" should exist within the select element "non_existent_select"
       """
     When I run "behat --no-colors"
-    Then it should fail with a "InvalidArgumentException" exception:
+    Then it should fail with a "Behat\Mink\Exception\ElementNotFoundException" exception:
       """
-      Element "non_existent_select" is not found.
+      Select with id|name|label "non_existent_select" not found.
       """
 
   @api @trait:FieldTrait
@@ -315,9 +315,9 @@ Feature: Check that FieldTrait works
       Then the option "INVALID_OPTION" should exist within the select element "date_default_timezone"
       """
     When I run "behat --no-colors"
-    Then it should fail with a "InvalidArgumentException" exception:
+    Then it should fail with a "Behat\Mink\Exception\ExpectationException" exception:
       """
-      Option "INVALID_OPTION" is not found in select "date_default_timezone".
+      The option "INVALID_OPTION" was not found in the select "date_default_timezone" on the page /admin/config/regional/settings.
       """
 
   @api @trait:FieldTrait
@@ -330,9 +330,9 @@ Feature: Check that FieldTrait works
       Then the option "UTC" should not exist within the select element "date_default_timezone"
       """
     When I run "behat --no-colors"
-    Then it should fail with a "InvalidArgumentException" exception:
+    Then it should fail with a "Behat\Mink\Exception\ExpectationException" exception:
       """
-      Option "UTC" is found in select "date_default_timezone", but should not.
+      The option "UTC" was found in the select "date_default_timezone" on the page /admin/config/regional/settings, but should not exist.
       """
 
   @api @trait:FieldTrait
@@ -390,9 +390,9 @@ Feature: Check that FieldTrait works
       Then the option "UTC" should not exist within the select element "non_existent_select"
       """
     When I run "behat --no-colors"
-    Then it should fail with a "InvalidArgumentException" exception:
+    Then it should fail with a "Behat\Mink\Exception\ElementNotFoundException" exception:
       """
-      Element "non_existent_select" is not found.
+      Select with id|name|label "non_existent_select" not found.
       """
 
   @api @trait:FieldTrait

--- a/tests/behat/features/keyboard.feature
+++ b/tests/behat/features/keyboard.feature
@@ -76,7 +76,7 @@ Feature: Check that KeyboardTrait works
       When I press the key "" on the element "#input1"
       """
     When I run "behat --no-colors"
-    Then it should fail with a "InvalidArgumentException" exception:
+    Then it should fail with an exception:
       """
       The keyboard key must not be empty.
       """

--- a/tests/behat/features/xml.feature
+++ b/tests/behat/features/xml.feature
@@ -32,7 +32,7 @@ Feature: Check that XmlTrait works
     Then the response should be in XML format
 
   @trait:XmlTrait
-  Scenario: Assert that negative assertion for "Then the response should be in XML format" fails with an exception
+  Scenario: Assert that negative assertion for "Then the response should be in XML format" fails with an error
     Given some behat configuration
     And scenario steps tagged with "@phpserver":
       """
@@ -40,9 +40,9 @@ Feature: Check that XmlTrait works
       Then the response should be in XML format
       """
     When I run "behat --no-colors"
-    Then it should fail with an exception:
+    Then it should fail with an error:
       """
-      Failed to load XML
+      The response is not valid XML
       """
 
   @phpserver

--- a/tests/phpunit/src/CommandTraitTest.php
+++ b/tests/phpunit/src/CommandTraitTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps\Tests;
 
 use DrevOps\BehatSteps\CommandTrait;
+use DrevOps\BehatSteps\Exception\AssertionException;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -123,15 +124,15 @@ class CommandTraitTest extends UnitTestCase {
 
   public static function dataProviderAssertionFailures(): array {
     return [
-      'succeed on a failed command' => ['exit 1', 'commandAssertSuccess', [], \Exception::class, 'Expected the command to succeed, but it exited with code 1.'],
-      'fail on a successful command' => ['echo hello', 'commandAssertFailure', [], \Exception::class, 'Expected the command to fail, but it exited with code 0.'],
-      'exit code mismatch' => ['echo hello', 'commandAssertExitCode', ['3'], \Exception::class, 'Expected the command to exit with code 3, but it exited with code 0.'],
-      'output does not contain' => ['echo hello', 'commandAssertOutputContains', ['goodbye'], \Exception::class, 'Expected the command output to contain "goodbye"'],
-      'output unexpectedly contains' => ['echo hello', 'commandAssertOutputNotContains', ['hello'], \Exception::class, 'Expected the command output to not contain "hello"'],
-      'output does not equal' => ['echo hello', 'commandAssertOutputEquals', ['goodbye'], \Exception::class, 'Expected the command output to be "goodbye", but got "hello".'],
-      'error output does not contain' => ['echo hello', 'commandAssertErrorOutputContains', ['missing'], \Exception::class, 'Expected the command error output to contain "missing"'],
-      'duration exceeds the limit' => ['sleep 1', 'commandAssertDurationLessThan', ['0.5'], \Exception::class, 'Expected the command to complete in less than 0.5 seconds'],
-      'duration below the floor' => ['echo fast', 'commandAssertDurationMoreThan', ['5'], \Exception::class, 'Expected the command to complete in more than 5 seconds'],
+      'succeed on a failed command' => ['exit 1', 'commandAssertSuccess', [], AssertionException::class, 'Expected the command to succeed, but it exited with code 1.'],
+      'fail on a successful command' => ['echo hello', 'commandAssertFailure', [], AssertionException::class, 'Expected the command to fail, but it exited with code 0.'],
+      'exit code mismatch' => ['echo hello', 'commandAssertExitCode', ['3'], AssertionException::class, 'Expected the command to exit with code 3, but it exited with code 0.'],
+      'output does not contain' => ['echo hello', 'commandAssertOutputContains', ['goodbye'], AssertionException::class, 'Expected the command output to contain "goodbye"'],
+      'output unexpectedly contains' => ['echo hello', 'commandAssertOutputNotContains', ['hello'], AssertionException::class, 'Expected the command output to not contain "hello"'],
+      'output does not equal' => ['echo hello', 'commandAssertOutputEquals', ['goodbye'], AssertionException::class, 'Expected the command output to be "goodbye", but got "hello".'],
+      'error output does not contain' => ['echo hello', 'commandAssertErrorOutputContains', ['missing'], AssertionException::class, 'Expected the command error output to contain "missing"'],
+      'duration exceeds the limit' => ['sleep 1', 'commandAssertDurationLessThan', ['0.5'], AssertionException::class, 'Expected the command to complete in less than 0.5 seconds'],
+      'duration below the floor' => ['echo fast', 'commandAssertDurationMoreThan', ['5'], AssertionException::class, 'Expected the command to complete in more than 5 seconds'],
       'assertion before any command' => [NULL, 'commandAssertSuccess', [], \RuntimeException::class, 'No command has been run.'],
       'non-integer exit code word' => ['echo hello', 'commandAssertExitCode', ['three'], \RuntimeException::class, 'The expected exit code must be an integer, but got "three".'],
       'non-integer exit code float' => ['echo hello', 'commandAssertExitCode', ['3.5'], \RuntimeException::class, 'The expected exit code must be an integer, but got "3.5".'],


### PR DESCRIPTION
Closes #716

## Summary

`CommandTrait`, `Drupal\ConfigTrait`, `Drupal\ModuleTrait`, `Drupal\StateTrait` and `Drupal\RedirectTrait` now throw the new `DrevOps\BehatSteps\Exception\AssertionException` from their assertion steps instead of plain `\Exception`, since none of the five ever call `$this->getSession()` and so cannot construct `ExpectationException`, which requires a Mink driver as its second constructor argument.
Before this branch the same class of failure surfaced as five different exception types depending on the trait - plain `\Exception` in those five traits and in `MetatagTrait`, `\RuntimeException` from `XmlTrait::xmlAssertResponseIsXml()` while its JSON twin `jsonAssertResponseIsJson()` threw `ExpectationException` for the same kind of failure, and `\InvalidArgumentException` from `FieldTrait::fieldAssertSelectOptionExists()` and `fieldAssertSelectOptionNotExists()` where their four immediate siblings already threw `ElementNotFoundException` or `ExpectationException`.
After this merge every assertion step in `src/` throws `ExpectationException` (or its `ElementNotFoundException` subclass) when a Mink session exists and `AssertionException` when it does not, every non-assertion failure throws `\RuntimeException`, and `tests/behat/bootstrap/BehatCliTrait.php`'s `it should fail with an error:` step enforces this by rejecting a plain `(Exception)` in the output; this branch does not touch `elementFindNthOrFail()` or its 2-argument `ElementNotFoundException` call.

## Before / After

```
┌────────────────────────────────────────────────────────────────────────┐
│ Assertion, no Mink session (5 traits)                                  │
│   BEFORE  \Exception                                                   │
│   AFTER   AssertionException                                           │
├────────────────────────────────────────────────────────────────────────┤
│ Assertion, Mink session present (MetatagTrait, XmlTrait)               │
│   BEFORE  \Exception / \RuntimeException                               │
│   AFTER   ExpectationException                                         │
├────────────────────────────────────────────────────────────────────────┤
│ Missing select or option (FieldTrait)                                  │
│   BEFORE  \InvalidArgumentException                                    │
│   AFTER   ElementNotFoundException / ExpectationException              │
├────────────────────────────────────────────────────────────────────────┤
│ Not an assertion (Cache, Block, Element, Keyboard, File, Media traits) │
│   BEFORE  \InvalidArgumentException / \Exception                       │
│   AFTER   \RuntimeException                                            │
└────────────────────────────────────────────────────────────────────────┘
```

## Changes

- Added `src/Exception/AssertionException.php`, extending `\Exception`, for assertion failures in traits with no Mink session.
- Converted `CommandTrait`, `Drupal\ConfigTrait`, `Drupal\ModuleTrait`, `Drupal\StateTrait` and `Drupal\RedirectTrait` from `\Exception` to `AssertionException` across all of their `Then` steps.
- Converted `MetatagTrait`'s 18 assertion throws from `\Exception` to `ExpectationException`; its 2 curl-infrastructure failures in `metatagFetchUrl()` became `\RuntimeException`, while the HTTP >= 400 branch of that same method became `ExpectationException`, since a bad status there is the defect `metatagAssertHreflangReciprocal()` exists to catch.
- `XmlTrait::xmlAssertResponseIsXml()` now throws `ExpectationException` with the message `The response is not valid XML: ...` instead of leaking a `\RuntimeException` out of `xmlEnsureDocument()`. Added `xmlParse()` and `xmlResolveContent()` helpers and used them from `xmlAssertResponseIsNotXml()`, removing its inline content-resolution and `DOMDocument` duplication; each step still applies its own well-formedness predicate (`xmlAssertResponseIsXml()` checks only that the document loaded, `xmlAssertResponseIsNotXml()` also checks that libxml raised no errors).
- `FieldTrait::fieldAssertSelectOptionExists()` and `fieldAssertSelectOptionNotExists()` now throw `ElementNotFoundException` for a missing select and `ExpectationException` (naming the current page) for a missing option, matching their four sibling select-option steps instead of `\InvalidArgumentException`. Added a `fieldCurrentPath()` helper, used by all four select-option assertions, replacing the 2-line `parse_url()` lookup duplicated between `fieldAssertSelectOptionSelected()` and `fieldAssertSelectOptionNotSelected()`.
- `fieldAssertSelectOptionExists()` and `fieldAssertSelectOptionNotExists()` declare `(string $selector, string $option)`, the reverse order of their siblings' `(string $option, string $selector)`. Behat binds turnip placeholders by name rather than position, so both orders work and the feature tests pass either way; left as-is here and out of scope for a separate signature-alignment change.
- Converted the remaining 7 `\InvalidArgumentException` sites (`Drupal\CacheTrait`'s 4 path-validation checks, `Drupal\BlockTrait`, `ElementTrait::elementExecuteJs()`, `KeyboardTrait::keyboardPressKeyOnElementSingle()`) and 4 non-assertion `\Exception` sites (`Drupal\FileTrait`'s 2 file-read checks, `Drupal\MediaTrait`'s 2 bundle checks) to `\RuntimeException`. `keyboardPressKeyOnElementSingle()` previously threw `\InvalidArgumentException` for an empty key and `\RuntimeException` 5 lines below for an unsupported key, two names for the same category of failure.
- Not changed: `elementFindNthOrFail()` keeps its 2-argument `ElementNotFoundException($driver, $subject)` call. The issue lists this as an inconsistency with the 4-argument calls elsewhere, but its 3 callers each pass a phrase that already carries its own locator (for example `link "Read more"`), and that same phrase is reused verbatim in the "only N found" message; splitting it into type/selector/locator would churn 3 call sites and 3 test messages to produce worse text (`Link with text "Read more" not found.` instead of `Link "Read more" not found.`).
- Updated 7 stale `@throws \Exception` docblocks (4 in `Drupal\BlockTrait`, 3 in `JavascriptTrait`) to name the `ExpectationException` the code actually throws.
- `tests/behat/bootstrap/BehatCliTrait.php`'s `it should fail with an error:` step now accepts `AssertionException` in the output and no longer accepts a plain `(Exception)` string, so a regression back to `\Exception` fails CI.
- `docs.php` now collects trait files via a new `file_declares_trait()` check instead of assuming every file under `src/` declares a trait, so it no longer stumbles on `src/Exception/AssertionException.php`.
- Documented the contract in `README.md` (exception table plus the `AssertionException` / `ElementNotFoundException` relationship), added an "Exception Types" section to `CLAUDE.md` for contributors, and added a 4.0 breaking-change section to `MIGRATION.md` with before/after tables per trait.
- 3 failure messages changed along with their type: `the response should be in XML format` (`Failed to load XML. Errors: ...` -> `The response is not valid XML: ...`), and the two select-option steps' messages, which now name the select and the current page path.
