### PR TITLE
Bounded the accessibility engine fetch with a timeout and retries.

### DIFF
--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -382,20 +382,60 @@ trait AccessibilityTrait {
    *
    * Default: fetched once per process from accessibilityGetCdnUrl(). Override
    * to ship the engine script from a vendored package or asset path.
+   *
+   * A read is bounded by accessibilityGetFetchTimeout() and retried up to
+   * accessibilityGetFetchAttempts() times, so a stalled or throttled source
+   * costs a bounded wait per attempt instead of blocking until PHP's own
+   * default_socket_timeout expires.
    */
   protected function accessibilityGetJs(): string {
     if (self::$accessibilityCachedJs !== NULL) {
       return self::$accessibilityCachedJs;
     }
 
-    $content = @file_get_contents($this->accessibilityGetCdnUrl());
+    $url = $this->accessibilityGetCdnUrl();
+    $timeout = $this->accessibilityGetFetchTimeout();
+    $attempts = max(1, $this->accessibilityGetFetchAttempts());
+    $context = stream_context_create(['http' => ['timeout' => $timeout]]);
+    $content = FALSE;
+
+    for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+      $content = @file_get_contents($url, FALSE, $context);
+
+      if ($content !== FALSE && $content !== '') {
+        break;
+      }
+
+      if ($attempt < $attempts) {
+        usleep($attempt * 500000);
+      }
+    }
+
     if ($content === FALSE || $content === '') {
-      throw new \RuntimeException(sprintf('Failed to fetch accessibility engine from %s.', $this->accessibilityGetCdnUrl()));
+      throw new \RuntimeException(sprintf('Failed to fetch accessibility engine from %s after %d attempt(s) with a %d second timeout.', $url, $attempts, $timeout));
     }
 
     self::$accessibilityCachedJs = $content;
 
     return $content;
+  }
+
+  /**
+   * Return the per-attempt timeout, in seconds, for the engine fetch.
+   *
+   * Default: 10 seconds. Override to suit a slower source.
+   */
+  protected function accessibilityGetFetchTimeout(): int {
+    return 10;
+  }
+
+  /**
+   * Return how many times the engine fetch is attempted before failing.
+   *
+   * Default: 3. Values below 1 are treated as 1.
+   */
+  protected function accessibilityGetFetchAttempts(): int {
+    return 3;
   }
 
   /**

--- a/src/AccessibilityTrait.php
+++ b/src/AccessibilityTrait.php
@@ -396,11 +396,10 @@ trait AccessibilityTrait {
     $url = $this->accessibilityGetCdnUrl();
     $timeout = $this->accessibilityGetFetchTimeout();
     $attempts = max(1, $this->accessibilityGetFetchAttempts());
-    $context = stream_context_create(['http' => ['timeout' => $timeout]]);
     $content = FALSE;
 
     for ($attempt = 1; $attempt <= $attempts; $attempt++) {
-      $content = @file_get_contents($url, FALSE, $context);
+      $content = $this->accessibilityFetchJs($url, $timeout);
 
       if ($content !== FALSE && $content !== '') {
         break;
@@ -418,6 +417,27 @@ trait AccessibilityTrait {
     self::$accessibilityCachedJs = $content;
 
     return $content;
+  }
+
+  /**
+   * Read the engine source once from the given location.
+   *
+   * Default: a single read bounded by the given timeout, returning FALSE
+   * when the read fails. Override to fetch through an HTTP client of your
+   * own; accessibilityGetJs() supplies the retries around it.
+   *
+   * @param string $url
+   *   Location the engine source is read from.
+   * @param int $timeout
+   *   Timeout, in seconds, for this read.
+   *
+   * @return string|false
+   *   The engine source, or FALSE when the read fails.
+   */
+  protected function accessibilityFetchJs(string $url, int $timeout): string|false {
+    $context = stream_context_create(['http' => ['timeout' => $timeout]]);
+
+    return @file_get_contents($url, FALSE, $context);
   }
 
   /**

--- a/tests/phpunit/src/AccessibilityTraitTest.php
+++ b/tests/phpunit/src/AccessibilityTraitTest.php
@@ -28,6 +28,7 @@ class AccessibilityTraitTest extends UnitTestCase {
     $this->testObject = new AccessibilityTraitTestImplementation();
     AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
     AccessibilityTraitTestImplementation::testSetCachedJs(NULL);
+    AccessibilityTraitRetryTestImplementation::testSetCachedJs(NULL);
     AccessibilityTraitTestImplementation::accessibilityAggregateReset();
   }
 
@@ -37,6 +38,7 @@ class AccessibilityTraitTest extends UnitTestCase {
   protected function tearDown(): void {
     AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
     AccessibilityTraitTestImplementation::testSetCachedJs(NULL);
+    AccessibilityTraitRetryTestImplementation::testSetCachedJs(NULL);
     AccessibilityTraitTestImplementation::accessibilityAggregateReset();
 
     parent::tearDown();
@@ -76,6 +78,46 @@ class AccessibilityTraitTest extends UnitTestCase {
     file_put_contents($path, 'CHANGED');
     $this->assertSame('ENGINE', $this->testObject->testGetJs());
     $this->assertSame(1, $this->testObject->engineReads);
+  }
+
+  public function testGetJsRetriesUntilReadSucceeds(): void {
+    $object = new AccessibilityTraitRetryTestImplementation();
+    $object->engineFailures = 2;
+    $object->engineContent = 'ENGINE';
+
+    $this->assertSame('ENGINE', $object->testGetJs());
+    $this->assertSame(3, $object->engineReads);
+  }
+
+  public function testGetJsStopsAfterConfiguredAttempts(): void {
+    $object = new AccessibilityTraitRetryTestImplementation();
+    $object->engineFailures = PHP_INT_MAX;
+    $object->engineAttempts = 2;
+
+    try {
+      $object->testGetJs();
+      $this->fail('Expected a RuntimeException.');
+    }
+    catch (\RuntimeException $runtime_exception) {
+      $this->assertStringContainsString('after 2 attempt(s) with a 1 second timeout', $runtime_exception->getMessage());
+    }
+
+    $this->assertSame(2, $object->engineReads);
+  }
+
+  public function testGetJsReadsOnceWhenRetriesAreDisabled(): void {
+    $object = new AccessibilityTraitRetryTestImplementation();
+    $object->engineFailures = PHP_INT_MAX;
+    $object->engineAttempts = 0;
+
+    $this->expectException(\RuntimeException::class);
+
+    try {
+      $object->testGetJs();
+    }
+    finally {
+      $this->assertSame(1, $object->engineReads);
+    }
   }
 
   public function testGetJsRetriesThenFails(): void {
@@ -776,6 +818,61 @@ class AccessibilityTraitFetchDefaultsTestImplementation {
 
   public function testGetFetchAttempts(): int {
     return $this->accessibilityGetFetchAttempts();
+  }
+
+}
+
+/**
+ * A test implementation that counts reads and controls their outcome.
+ */
+class AccessibilityTraitRetryTestImplementation {
+
+  use AccessibilityTrait;
+
+  /**
+   * Count of reads issued by the retry loop.
+   */
+  public int $engineReads = 0;
+
+  /**
+   * Number of leading reads that fail before one succeeds.
+   */
+  public int $engineFailures = 0;
+
+  /**
+   * Source returned by a read that succeeds.
+   */
+  public string $engineContent = '';
+
+  /**
+   * Number of attempts the retry loop is allowed.
+   */
+  public int $engineAttempts = 3;
+
+  protected function accessibilityGetCdnUrl(): string {
+    return 'https://example.com/engine.js';
+  }
+
+  protected function accessibilityGetFetchAttempts(): int {
+    return $this->engineAttempts;
+  }
+
+  protected function accessibilityGetFetchTimeout(): int {
+    return 1;
+  }
+
+  protected function accessibilityFetchJs(string $url, int $timeout): string|false {
+    $this->engineReads++;
+
+    return $this->engineReads <= $this->engineFailures ? FALSE : $this->engineContent;
+  }
+
+  public function testGetJs(): string {
+    return $this->accessibilityGetJs();
+  }
+
+  public static function testSetCachedJs(?string $js): void {
+    self::$accessibilityCachedJs = $js;
   }
 
 }

--- a/tests/phpunit/src/AccessibilityTraitTest.php
+++ b/tests/phpunit/src/AccessibilityTraitTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace DrevOps\BehatSteps\Tests;
 
 use DrevOps\BehatSteps\AccessibilityTrait;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests for AccessibilityTrait.
  */
-#[CoversClass(AccessibilityTrait::class)]
+#[CoversTrait(AccessibilityTrait::class)]
 class AccessibilityTraitTest extends UnitTestCase {
 
   /**
@@ -27,6 +27,7 @@ class AccessibilityTraitTest extends UnitTestCase {
 
     $this->testObject = new AccessibilityTraitTestImplementation();
     AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
+    AccessibilityTraitTestImplementation::testSetCachedJs(NULL);
     AccessibilityTraitTestImplementation::accessibilityAggregateReset();
   }
 
@@ -35,6 +36,7 @@ class AccessibilityTraitTest extends UnitTestCase {
    */
   protected function tearDown(): void {
     AccessibilityTraitTestImplementation::testSetBaseDir(NULL);
+    AccessibilityTraitTestImplementation::testSetCachedJs(NULL);
     AccessibilityTraitTestImplementation::accessibilityAggregateReset();
 
     parent::tearDown();
@@ -60,6 +62,60 @@ class AccessibilityTraitTest extends UnitTestCase {
       'similar prefix not stripped' => ['http://nginx:8080', 'http://nginx:8080extra/foo', 'http://nginx:8080extra/foo'],
       'no base url returns input unchanged' => ['', 'http://nginx:8080/contact', 'http://nginx:8080/contact'],
     ];
+  }
+
+  public function testGetJsReadsSourceOnce(): void {
+    $path = static::locationsTmp() . '/axe-engine.js';
+    file_put_contents($path, 'ENGINE');
+    $this->testObject->engineUrl = $path;
+
+    $this->assertSame('ENGINE', $this->testObject->testGetJs());
+
+    // A second call is served from the process cache, so the source is read
+    // only once even though the getter would return the same path.
+    file_put_contents($path, 'CHANGED');
+    $this->assertSame('ENGINE', $this->testObject->testGetJs());
+    $this->assertSame(1, $this->testObject->engineReads);
+  }
+
+  public function testGetJsRetriesThenFails(): void {
+    $this->testObject->engineUrl = static::locationsTmp() . '/absent-engine.js';
+    $this->testObject->engineAttempts = 2;
+    $this->testObject->engineTimeout = 1;
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('after 2 attempt(s) with a 1 second timeout');
+
+    $this->testObject->testGetJs();
+  }
+
+  public function testGetJsTreatsEmptySourceAsFailure(): void {
+    $path = static::locationsTmp() . '/empty-engine.js';
+    file_put_contents($path, '');
+    $this->testObject->engineUrl = $path;
+    $this->testObject->engineAttempts = 1;
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('after 1 attempt(s)');
+
+    $this->testObject->testGetJs();
+  }
+
+  public function testGetJsClampsAttemptsToOne(): void {
+    $this->testObject->engineUrl = static::locationsTmp() . '/absent-engine.js';
+    $this->testObject->engineAttempts = 0;
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('after 1 attempt(s)');
+
+    $this->testObject->testGetJs();
+  }
+
+  public function testGetJsFetchDefaults(): void {
+    $object = new AccessibilityTraitFetchDefaultsTestImplementation();
+
+    $this->assertSame(10, $object->testGetFetchTimeout());
+    $this->assertSame(3, $object->testGetFetchAttempts());
   }
 
   public function testGetReportDirUsesCapturedBaseDir(): void {
@@ -661,6 +717,65 @@ class AccessibilityTraitTestImplementation {
     $this->accessibilityScenarioThreshold = $threshold;
 
     return $this->accessibilityRenderJunit();
+  }
+
+  /**
+   * Source the engine is read from.
+   */
+  public string $engineUrl = '';
+
+  /**
+   * Number of attempts the engine fetch is allowed.
+   */
+  public int $engineAttempts = 3;
+
+  /**
+   * Per-attempt timeout for the engine fetch.
+   */
+  public int $engineTimeout = 10;
+
+  /**
+   * Count of reads issued against the source.
+   */
+  public int $engineReads = 0;
+
+  protected function accessibilityGetCdnUrl(): string {
+    $this->engineReads++;
+
+    return $this->engineUrl;
+  }
+
+  protected function accessibilityGetFetchAttempts(): int {
+    return $this->engineAttempts;
+  }
+
+  protected function accessibilityGetFetchTimeout(): int {
+    return $this->engineTimeout;
+  }
+
+  public function testGetJs(): string {
+    return $this->accessibilityGetJs();
+  }
+
+  public static function testSetCachedJs(?string $js): void {
+    self::$accessibilityCachedJs = $js;
+  }
+
+}
+
+/**
+ * A test implementation that keeps the trait's own engine fetch defaults.
+ */
+class AccessibilityTraitFetchDefaultsTestImplementation {
+
+  use AccessibilityTrait;
+
+  public function testGetFetchTimeout(): int {
+    return $this->accessibilityGetFetchTimeout();
+  }
+
+  public function testGetFetchAttempts(): int {
+    return $this->accessibilityGetFetchAttempts();
   }
 
 }


### PR DESCRIPTION
## Summary

`AccessibilityTrait::accessibilityGetJs()` now reads the axe-core engine script through `accessibilityFetchJs()`, a single bounded read it retries, so an unreachable source costs a bounded wait and then raises a `RuntimeException` naming the source, the attempt count and the timeout instead of stalling the caller.

The previous implementation called `file_get_contents($this->accessibilityGetCdnUrl())` with no stream context, so a stalled connection to the default source (`https://cdn.jsdelivr.net/npm/axe-core@4.11.4/axe.min.js`) blocked until PHP's `default_socket_timeout` of 60 seconds elapsed. That is exactly the subprocess budget `BehatCliContext` sets at `tests/behat/bootstrap/BehatCliContext.php:343`, so the read consumed the whole budget and killed the `@trait:AccessibilityTrait` scenario at `tests/behat/features/accessibility.feature:143` with "exceeded the timeout of 60 seconds". The script is cached per process in `self::$accessibilityCachedJs` and each such scenario spawns a fresh Behat subprocess, so one job issues roughly 8 reads and the 15-leg matrix issues around 120 per push.

Each attempt is now capped at the `accessibilityGetFetchTimeout()` default of 10 seconds across up to `accessibilityGetFetchAttempts()`'s default of 3 attempts, backing off 0.5s then 1s, for a worst case of about 31 seconds inside the 60 second budget. Consumers can override `accessibilityFetchJs()` to read through their own HTTP client and keep the retries. This does not remove the dependency on the CDN, and it touches neither the axe-core ruleset, the accessibility assertions, nor any other trait.

## Before / After

```
Before: single unbounded read
────────────────────────────────────────────────────────────
accessibilityGetJs()
  └─▶ file_get_contents($url)              [no stream context]
        └─▶ connection stalls
              └─▶ blocks until default_socket_timeout (60s)
                    └─▶ BehatCliContext subprocess budget (60s) exceeded
                          └─▶ scenario killed: "exceeded the timeout of 60 seconds"

After: bounded retries with backoff
────────────────────────────────────────────────────────────
accessibilityGetJs()
  └─▶ attempt 1/3: accessibilityFetchJs($url, 10s)
        ├─▶ success ─────────────────────────▶ cache + return
        └─▶ false/empty
              └─▶ sleep 0.5s
                    └─▶ attempt 2/3: accessibilityFetchJs($url, 10s)
                          ├─▶ success ───────▶ cache + return
                          └─▶ false/empty
                                └─▶ sleep 1s
                                      └─▶ attempt 3/3: accessibilityFetchJs($url, 10s)
                                            ├─▶ success ─▶ cache + return
                                            └─▶ false/empty
                                                  └─▶ throw RuntimeException:
                                                      "...after 3 attempt(s) with a 10 second timeout"
```

## Changes

- `src/AccessibilityTrait.php`: extracts the single read into `accessibilityFetchJs(string $url, int $timeout)`, which applies `stream_context_create(['http' => ['timeout' => ...]])` and returns `FALSE` on failure, and wraps it in a retry loop in `accessibilityGetJs()`. Adds the overridable `accessibilityGetFetchTimeout()` (default `10`) and `accessibilityGetFetchAttempts()` (default `3`, clamped to a minimum of `1`), backs off `0.5s` then `1s` between attempts, and names the source, attempt count and timeout in the exhausted-fetch `RuntimeException`.
- `tests/phpunit/src/AccessibilityTraitTest.php`: replaces `#[CoversClass(AccessibilityTrait::class)]` with `#[CoversTrait(AccessibilityTrait::class)]`, which is the valid attribute for a trait under `requireCoverageMetadata="true"` and is what allows PHPUnit to attribute coverage to the trait at all.
- `tests/phpunit/src/AccessibilityTraitTest.php`: adds `AccessibilityTraitRetryTestImplementation`, which counts reads and chooses each outcome, so `testGetJsRetriesUntilReadSucceeds`, `testGetJsStopsAfterConfiguredAttempts` and `testGetJsReadsOnceWhenRetriesAreDisabled` assert read counts of 3, 2 and 1 rather than trusting the attempt count interpolated into the exception message.
- `tests/phpunit/src/AccessibilityTraitTest.php`: adds `AccessibilityTraitFetchDefaultsTestImplementation` covering the trait's own default timeout and attempt values, plus cases for single-read caching, exhaustion against a real filesystem read, and an empty source treated as a failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a 10-second timeout and bounded retries to `AccessibilityTrait::accessibilityGetJs()`.
- Added configurable timeout and attempt hooks.
- Added retry backoff and detailed failure exceptions.
- Preserved per-process JavaScript caching.
- Expanded PHPUnit coverage for caching, retries, failures, attempt clamping, and default settings.
- Updated coverage metadata to use `CoversTrait`.

## Step-definition compliance

- No step-definition violations identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
