### PR TITLE
[#714] Settled the negation shape, 'Normalize' spelling and getter naming across 44 trait methods.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,13 +45,41 @@ of tests. Follow these guidelines:
 We have some automated check for the steps format.
 Run `ahoy lint-docs` to validate the format of the steps.
 
-## Assertion Method Naming Conventions
+## Method naming conventions
 
-- **Existence assertions**:
-  - Singular subjects → `Exists` or `NotExists` (e.g., `fieldAssertExists()`, `vocabularyAssertNotExists()`)
-  - Plural subjects → `Exist` or `NotExist` (e.g., `termsAssertExist()`)
-- **Contains assertions**: Always use `Contains` or `NotContains` (e.g., `xmlAssertElementContains()`, `headerAssertNotContains()`)
-- Never use "DoesNot" or "DoNot" patterns - use "Not" prefix directly
+Every method a trait contributes begins with the trait's own name, so that traits mixed into one context cannot collide. `tests/phpunit/src/TraitMethodNamingTest.php` enforces this and the three conventions below.
+
+### Assertions
+
+An assertion method reads `<trait>Assert<Subject><Predicate>`.
+
+- **Existence**:
+  - Singular subjects → `Exists` or `NotExists` (e.g., `fieldAssertExists()`, `taxonomyAssertVocabularyNotExists()`)
+  - Plural subjects → `Exist` or `NotExist` (e.g., `redirectAssertExist()`)
+- **Containment**: always `Contains` or `NotContains` (e.g., `xmlAssertElementContains()`, `responseAssertHeaderNotContains()`)
+- **Subject first**: the thing being asserted about precedes what is asserted of it, as in `responseAssertHeaderExists()` rather than `responseAssertContainsHeader()`.
+- **No copula**: `Assert` already states that the subject is something, so `Is` is dropped - `elementAssertVisible()`, not `elementAssertIsVisible()`.
+
+### Negation
+
+`Not` is the only negation particle, and it sits immediately after `Assert<Subject>`, directly before the predicate it negates. A negative name is its positive counterpart with `Not` inserted and nothing else changed.
+
+| Instead of | Write |
+| --- | --- |
+| `userAssertHasNoRoles()` | `userAssertNotHasRoles()` |
+| `emailAssertNoMessagesSent()` | `emailAssertMessagesNotSent()` |
+| `userAssertIsNotBlocked()` | `userAssertNotBlocked()` |
+| `elementAssertIsVisuallyHidden()` | `elementAssertNotVisuallyVisible()` |
+
+The determiner `No`, the copula `Is`, an antonym standing in for a negation, and `DoesNot` or `DoNot` are all out.
+
+### Consumer override points
+
+A documented override point that supplies a value is `<trait>Get<Noun>()`, booleans included - `modalGetWaitTimeout()`, `commandGetTimeout()`, `accessibilityGetFailOnIncomplete()`, `diagnosticsGetShowUrl()`. A method that computes rather than supplies keeps a verb describing what it does, as in `accessibilityResolveTags()` or `contentResolveNidByTitle()`.
+
+### Spelling
+
+`Normalize`, not `Normalise`, in method names and in prose.
 
 ## Unsettled style questions
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -233,7 +233,7 @@ Placeholders name the value's role rather than its type, so `:number` became `:o
 | `Then the element :selector should be displayed within a viewport with a top offset of :number pixels` | `Then the element :selector should be displayed within a viewport with a top offset of :offset pixels` |
 | `Then the element :selector should not be displayed within a viewport with a top offset of :number pixels` | `Then the element :selector should not be displayed within a viewport with a top offset of :offset pixels` |
 
-This also renames the `$number` argument of `ElementTrait::elementAssertIsVisuallyVisibleWithOffset()` and `ElementTrait::elementAssertIsNotVisuallyVisibleWithOffset()` to `$offset`, which matters only if you call either method with named arguments.
+This also renames the `$number` argument of `ElementTrait::elementAssertVisuallyVisibleWithOffset()` and `ElementTrait::elementAssertNotVisuallyVisibleWithOffset()` to `$offset`, which matters only if you call either method with named arguments.
 
 ## Optional dependencies moved to `require-dev` and `suggest`
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -433,3 +433,88 @@ Hook methods used to come in 3 shapes: taking and using the scope, taking and ig
 | `Drupal\WatchdogTrait::$watchdogMessageTypes` | `array` |
 | `Drupal\WatchdogTrait::$watchdogScenarioStartTime` | `?int` |
 | `FileDownloadTrait::$fileDownloadDownloadedFileInfo` | `array` |
+
+## One shape per naming idea
+
+Method names carried six shapes for "assert the negative", two spellings of "normalize", and two shapes for a consumer override point. They are trait members a consumer calls or overrides, so each is renamed rather than aliased. Gherkin step text, step parameter names and method bodies are unchanged, so no `.feature` file needs an edit.
+
+`CONTRIBUTING.md` states the settled conventions and `tests/phpunit/src/TraitMethodNamingTest.php` enforces them.
+
+### Negation is spelled `Not`, in one slot
+
+`Not` sits immediately after `Assert<Subject>`, directly before the predicate it negates, so a negative name is its positive counterpart with `Not` inserted and nothing else changed. The determiner `No`, the copula `Is`, and antonyms standing in for a negation are gone.
+
+| Trait | Old | New |
+| --- | --- | --- |
+| `Drupal\EmailTrait` | `emailAssertNoMessagesSent()` | `emailAssertMessagesNotSent()` |
+| `Drupal\EmailTrait` | `emailAssertNoMessagesSentToAddress()` | `emailAssertMessagesNotSentToAddress()` |
+| `Drupal\FileTrait` | `fileAssertUnmanagedHasNoContent()` | `fileAssertUnmanagedNotHasContent()` |
+| `Drupal\UserTrait` | `userAssertHasNoRoles()` | `userAssertNotHasRoles()` |
+| `Drupal\UserTrait` | `userAssertIsBlocked()` | `userAssertBlocked()` |
+| `Drupal\UserTrait` | `userAssertIsNotBlocked()` | `userAssertNotBlocked()` |
+| `Drupal\WatchdogTrait` | `watchdogAssertNoErrors()` | `watchdogAssertNotHasErrors()` |
+| `ElementTrait` | `elementAssertIsNotPinnedToTop()` | `elementAssertNotPinnedToTop()` |
+| `ElementTrait` | `elementAssertIsNotVisible()` | `elementAssertNotVisible()` |
+| `ElementTrait` | `elementAssertIsNotVisuallyVisibleWithOffset()` | `elementAssertNotVisuallyVisibleWithOffset()` |
+| `ElementTrait` | `elementAssertIsPinnedToTop()` | `elementAssertPinnedToTop()` |
+| `ElementTrait` | `elementAssertIsPinnedToTopWithTolerance()` | `elementAssertPinnedToTopWithTolerance()` |
+| `ElementTrait` | `elementAssertIsVisible()` | `elementAssertVisible()` |
+| `ElementTrait` | `elementAssertIsVisuallyHidden()` | `elementAssertNotVisuallyVisible()` |
+| `ElementTrait` | `elementAssertIsVisuallyVisible()` | `elementAssertVisuallyVisible()` |
+| `ElementTrait` | `elementAssertIsVisuallyVisibleWithOffset()` | `elementAssertVisuallyVisibleWithOffset()` |
+| `ElementTrait` | `elementAssertPinnedToTop()` (protected helper) | `elementAssertPinnedToTopWithin()` |
+| `FileDownloadTrait` | `fileDownloadAssertNoZipContainsPartial()` | `fileDownloadAssertZipNotContainsPartial()` |
+| `JavascriptTrait` | `javascriptAssertNoErrors()` | `javascriptAssertNotHasErrors()` |
+| `JsonTrait` | `jsonAssertResponseIsJson()` | `jsonAssertResponseJson()` |
+| `JsonTrait` | `jsonAssertResponseIsNotJson()` | `jsonAssertResponseNotJson()` |
+| `LinkTrait` | `linkAssertLinkIsAbsolute()` | `linkAssertAbsolute()` |
+| `LinkTrait` | `linkAssertLinkIsNotAbsolute()` | `linkAssertNotAbsolute()` |
+| `MetatagTrait` | `metatagAssertNoHtml()` | `metatagAssertNotContainsHtml()` |
+| `PathTrait` | `pathAssertUrlHasNoParameter()` | `pathAssertUrlNotHasParameter()` |
+| `PathTrait` | `pathAssertUrlHasNoParameterWithValue()` | `pathAssertUrlNotHasParameterWithValue()` |
+| `XmlTrait` | `xmlAssertResponseIsXml()` | `xmlAssertResponseXml()` |
+| `XmlTrait` | `xmlAssertResponseIsNotXml()` | `xmlAssertResponseNotXml()` |
+
+`ElementTrait::elementAssertPinnedToTop()` appears on both sides of that table. The public step took the name once its copula was dropped, and the protected helper that backs all three pinned-to-top steps moved to `elementAssertPinnedToTopWithin()`, after the tolerance it takes.
+
+Three `Drupal\EmailTrait` methods asserted an exact match under names that gave no way to derive one from the other. They now carry the `Equals` predicate the rest of the library uses.
+
+| Old | New |
+| --- | --- |
+| `emailAssertMessageField()` | `emailAssertMessageFieldEquals()` |
+| `emailAssertMessageFieldNotExact()` | `emailAssertMessageFieldNotEquals()` |
+| `emailAssertMessageHeader()` | `emailAssertMessageHeaderEquals()` |
+
+### `ResponseTrait` header assertions read subject first
+
+Two of the four header assertions were verb-first and two subject-first. The existence pair joins the value pair, so `Header` opens the predicate in all four.
+
+| Old | New |
+| --- | --- |
+| `responseAssertContainsHeader()` | `responseAssertHeaderExists()` |
+| `responseAssertNotContainsHeader()` | `responseAssertHeaderNotExists()` |
+
+`responseAssertHeaderContains()` and `responseAssertHeaderNotContains()` are unchanged.
+
+### `Normalize`, not `Normalise`
+
+| Trait | Old | New |
+| --- | --- | --- |
+| `Drupal\StateTrait` | `stateNormaliseValue()` | `stateNormalizeValue()` |
+| `ElementTrait` | `elementNormaliseCssProperty()` | `elementNormalizeCssProperty()` |
+
+### Consumer override points are `Get`-prefixed
+
+A documented override point that supplies a value now reads `<trait>Get<Noun>()`, booleans included. The 30 that already did are unchanged.
+
+| Trait | Old | New |
+| --- | --- | --- |
+| `CommandTrait` | `commandTimeout()` | `commandGetTimeout()` |
+| `DiagnosticsTrait` | `diagnosticsHeader()` | `diagnosticsGetHeader()` |
+| `DiagnosticsTrait` | `diagnosticsRerunBinary()` | `diagnosticsGetRerunBinary()` |
+| `DiagnosticsTrait` | `diagnosticsShowDriver()` | `diagnosticsGetShowDriver()` |
+| `DiagnosticsTrait` | `diagnosticsShowJsErrors()` | `diagnosticsGetShowJsErrors()` |
+| `DiagnosticsTrait` | `diagnosticsShowRerun()` | `diagnosticsGetShowRerun()` |
+| `DiagnosticsTrait` | `diagnosticsShowStatusCode()` | `diagnosticsGetShowStatusCode()` |
+| `DiagnosticsTrait` | `diagnosticsShowUrl()` | `diagnosticsGetShowUrl()` |
+| `ElementTrait` | `elementScrollIntoViewCenter()` | `elementGetScrollIntoViewCenter()` |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -505,7 +505,7 @@ Two of the four header assertions were verb-first and two subject-first. The exi
 
 ### Consumer override points are `Get`-prefixed
 
-A documented override point that supplies a value now reads `<trait>Get<Noun>()`, booleans included. The 30 that already did are unchanged.
+A documented override point that supplies a value now reads `<trait>Get<Noun>()`, booleans included. The ones that already did are unchanged.
 
 | Trait | Old | New |
 | --- | --- | --- |

--- a/STEPS.md
+++ b/STEPS.md
@@ -513,9 +513,9 @@ Then a cookie with a name containing "user" and a value containing "guest" shoul
 >  
 >  The trait is opt-in: `use` it in the context and it is active with no further
 >  configuration. Every field is individually toggleable by overriding its
->  `diagnosticsShow*()` method to return FALSE, and each value source degrades
->  gracefully to nothing when the driver cannot provide it - a failed step is
->  never turned into a different failure by this trait.
+>  `diagnosticsGetShow*()` method to return FALSE, and each value source
+>  degrades gracefully to nothing when the driver cannot provide it - a failed
+>  step is never turned into a different failure by this trait.
 >  <br/><br/>
 >  Skip processing with tags: `@behat-steps-skip:DiagnosticsTrait`.
 >  <br/><br/>

--- a/src/CommandTrait.php
+++ b/src/CommandTrait.php
@@ -102,7 +102,7 @@ trait CommandTrait {
 
     $stdout = '';
     $stderr = '';
-    $timeout = $this->commandTimeout();
+    $timeout = $this->commandGetTimeout();
 
     while (!feof($pipes[1]) || !feof($pipes[2])) {
       if (microtime(TRUE) - $started > $timeout) {
@@ -381,7 +381,7 @@ trait CommandTrait {
   /**
    * The maximum time, in seconds, a command may run before it is terminated.
    */
-  protected function commandTimeout(): int {
+  protected function commandGetTimeout(): int {
     return 300;
   }
 

--- a/src/DiagnosticsTrait.php
+++ b/src/DiagnosticsTrait.php
@@ -27,9 +27,9 @@ use Behat\Testwork\Tester\Result\ExceptionResult;
  *
  * The trait is opt-in: `use` it in the context and it is active with no further
  * configuration. Every field is individually toggleable by overriding its
- * `diagnosticsShow*()` method to return FALSE, and each value source degrades
- * gracefully to nothing when the driver cannot provide it - a failed step is
- * never turned into a different failure by this trait.
+ * `diagnosticsGetShow*()` method to return FALSE, and each value source
+ * degrades gracefully to nothing when the driver cannot provide it - a failed
+ * step is never turned into a different failure by this trait.
  *
  * Skip processing with tags: `@behat-steps-skip:DiagnosticsTrait`.
  *
@@ -126,35 +126,35 @@ trait DiagnosticsTrait {
   protected function diagnosticsBuildBlock(): string {
     $lines = [];
 
-    if ($this->diagnosticsShowUrl()) {
+    if ($this->diagnosticsGetShowUrl()) {
       $url = $this->diagnosticsGetUrl();
       if ($url !== NULL) {
         $lines[] = 'URL: ' . $url;
       }
     }
 
-    if ($this->diagnosticsShowStatusCode()) {
+    if ($this->diagnosticsGetShowStatusCode()) {
       $status = $this->diagnosticsGetStatusCode();
       if ($status !== NULL) {
         $lines[] = 'HTTP status: ' . $status;
       }
     }
 
-    if ($this->diagnosticsShowDriver()) {
+    if ($this->diagnosticsGetShowDriver()) {
       $driver = $this->diagnosticsGetDriverName();
       if ($driver !== NULL) {
         $lines[] = 'Mink driver: ' . $driver;
       }
     }
 
-    if ($this->diagnosticsShowJsErrors()) {
+    if ($this->diagnosticsGetShowJsErrors()) {
       $errors = $this->diagnosticsGetJsErrors();
       if ($errors !== []) {
         $lines[] = 'JS console errors: ' . implode('; ', $errors);
       }
     }
 
-    if ($this->diagnosticsShowRerun()) {
+    if ($this->diagnosticsGetShowRerun()) {
       $rerun = $this->diagnosticsGetRerunCommand();
       if ($rerun !== NULL) {
         $lines[] = 'Re-run: ' . $rerun;
@@ -165,7 +165,7 @@ trait DiagnosticsTrait {
       return '';
     }
 
-    return $this->diagnosticsHeader() . PHP_EOL . implode(PHP_EOL, $lines);
+    return $this->diagnosticsGetHeader() . PHP_EOL . implode(PHP_EOL, $lines);
   }
 
   /**
@@ -258,7 +258,7 @@ trait DiagnosticsTrait {
       return NULL;
     }
 
-    return sprintf('%s %s:%d', $this->diagnosticsRerunBinary(), $this->diagnosticsRelativePath($this->diagnosticsFeatureFile), $this->diagnosticsScenarioLine);
+    return sprintf('%s %s:%d', $this->diagnosticsGetRerunBinary(), $this->diagnosticsRelativePath($this->diagnosticsFeatureFile), $this->diagnosticsScenarioLine);
   }
 
   /**
@@ -284,49 +284,49 @@ trait DiagnosticsTrait {
   /**
    * Return the header line that precedes the diagnostics block.
    */
-  protected function diagnosticsHeader(): string {
+  protected function diagnosticsGetHeader(): string {
     return '--- Failure diagnostics ---';
   }
 
   /**
    * Return the binary used in the re-run command. Override to customise.
    */
-  protected function diagnosticsRerunBinary(): string {
+  protected function diagnosticsGetRerunBinary(): string {
     return 'vendor/bin/behat';
   }
 
   /**
    * Return TRUE to include the current URL. Override to suppress.
    */
-  protected function diagnosticsShowUrl(): bool {
+  protected function diagnosticsGetShowUrl(): bool {
     return TRUE;
   }
 
   /**
    * Return TRUE to include the HTTP status code. Override to suppress.
    */
-  protected function diagnosticsShowStatusCode(): bool {
+  protected function diagnosticsGetShowStatusCode(): bool {
     return TRUE;
   }
 
   /**
    * Return TRUE to include the Mink driver class. Override to suppress.
    */
-  protected function diagnosticsShowDriver(): bool {
+  protected function diagnosticsGetShowDriver(): bool {
     return TRUE;
   }
 
   /**
    * Return TRUE to include JavaScript console errors. Override to suppress.
    */
-  protected function diagnosticsShowJsErrors(): bool {
+  protected function diagnosticsGetShowJsErrors(): bool {
     return TRUE;
   }
 
   /**
    * Return TRUE to include the re-run command. Override to suppress.
    */
-  protected function diagnosticsShowRerun(): bool {
+  protected function diagnosticsGetShowRerun(): bool {
     return TRUE;
   }
 

--- a/src/Drupal/EmailTrait.php
+++ b/src/Drupal/EmailTrait.php
@@ -141,7 +141,7 @@ trait EmailTrait {
    * @endcode
    */
   #[Then('no emails should have been sent')]
-  public function emailAssertNoMessagesSent(): void {
+  public function emailAssertMessagesNotSent(): void {
     $messages = $this->emailGetCollectedMessages();
     if (count($messages) > 0) {
       throw new ExpectationException('No emails should have been sent, but some were found: ' . PHP_EOL . print_r($messages, TRUE), $this->getSession()->getDriver());
@@ -156,7 +156,7 @@ trait EmailTrait {
    * @endcode
    */
   #[Then('no emails should have been sent to the address :address')]
-  public function emailAssertNoMessagesSentToAddress(string $address): void {
+  public function emailAssertMessagesNotSentToAddress(string $address): void {
     foreach ($this->emailGetCollectedMessages() as $message) {
       $to = $this->helperSplitCommaSeparated((string) $message['to']);
       if (in_array($address, $to, TRUE)) {
@@ -217,7 +217,7 @@ trait EmailTrait {
    * @endcode
    */
   #[Then('the email header :header should exactly be:')]
-  public function emailAssertMessageHeader(string $header, PyStringNode $string): void {
+  public function emailAssertMessageHeaderEquals(string $header, PyStringNode $string): void {
     $this->emailAssertMessageHeaderContains($header, $string, TRUE);
   }
 
@@ -235,7 +235,7 @@ trait EmailTrait {
   #[Then('an email should be sent to the address :address with the content:')]
   public function emailAssertMessageSentToAddressWithContent(string $address, PyStringNode $string): void {
     $this->emailAssertMessageSentTo($address);
-    $this->emailAssertMessageField('body', $string);
+    $this->emailAssertMessageFieldEquals('body', $string);
   }
 
   /**
@@ -282,8 +282,8 @@ trait EmailTrait {
    */
   #[Then('an email should not be sent to the address :address with the content:')]
   public function emailAssertMessageNotSentToAddressWithContent(string $address, PyStringNode $string): void {
-    $this->emailAssertNoMessagesSentToAddress($address);
-    $this->emailAssertMessageFieldNotExact('body', $string);
+    $this->emailAssertMessagesNotSentToAddress($address);
+    $this->emailAssertMessageFieldNotEquals('body', $string);
   }
 
   /**
@@ -298,7 +298,7 @@ trait EmailTrait {
    */
   #[Then('an email should not be sent to the address :address with the content containing:')]
   public function emailAssertMessageNotSentToAddressWithContentContaining(string $address, PyStringNode $string): void {
-    $this->emailAssertNoMessagesSentToAddress($address);
+    $this->emailAssertMessagesNotSentToAddress($address);
     $this->emailAssertMessageFieldNotContains('body', $string);
   }
 
@@ -332,7 +332,7 @@ trait EmailTrait {
    * @endcode
    */
   #[Then('the email field :field should be:')]
-  public function emailAssertMessageField(string $field, PyStringNode $string): void {
+  public function emailAssertMessageFieldEquals(string $field, PyStringNode $string): void {
     $this->emailAssertMessageFieldContains($field, $string, TRUE);
   }
 
@@ -375,7 +375,7 @@ trait EmailTrait {
    * @endcode
    */
   #[Then('the email field :field should not be:')]
-  public function emailAssertMessageFieldNotExact(string $field, PyStringNode $string): void {
+  public function emailAssertMessageFieldNotEquals(string $field, PyStringNode $string): void {
     $this->emailAssertMessageFieldNotContains($field, $string, TRUE);
   }
 

--- a/src/Drupal/FileTrait.php
+++ b/src/Drupal/FileTrait.php
@@ -348,7 +348,7 @@ trait FileTrait {
    * @endcode
    */
   #[Then('an unmanaged file at the URI :uri should not contain :content')]
-  public function fileAssertUnmanagedHasNoContent(string $uri, string $content): void {
+  public function fileAssertUnmanagedNotHasContent(string $uri, string $content): void {
     $this->fileAssertUnmanagedExists($uri);
 
     $file_content = @file_get_contents($uri);

--- a/src/Drupal/RedirectTrait.php
+++ b/src/Drupal/RedirectTrait.php
@@ -133,7 +133,7 @@ trait RedirectTrait {
    *
    * The `from` column is required. The `to` and `status_code` columns are
    * optional: when blank or omitted, only the source path is matched. When
-   * `to` is provided, internal paths (`/about`) are normalised to
+   * `to` is provided, internal paths (`/about`) are normalized to
    * `internal:/about` to match the storage format. When `status_code` is
    * provided, it is validated against the allowed set (301, 302, 303, 307,
    * 308).
@@ -223,7 +223,7 @@ trait RedirectTrait {
   }
 
   /**
-   * Normalise the status code value from a table cell.
+   * Normalize the status code value from a table cell.
    *
    * @param string|null $value
    *   The raw value from the table cell, or NULL when the column is missing.
@@ -252,14 +252,14 @@ trait RedirectTrait {
   }
 
   /**
-   * Normalise a source path the same way the `redirect` module stores it.
+   * Normalize a source path the same way the `redirect` module stores it.
    */
   protected function redirectNormalizeSource(string $path): string {
     return ltrim(trim($path), '/');
   }
 
   /**
-   * Normalise a destination URI the same way `Redirect::setRedirect()` does.
+   * Normalize a destination URI the same way `Redirect::setRedirect()` does.
    *
    * Internal paths gain an `internal:/` prefix; external `http(s)://` URLs
    * pass through unchanged. Values that already begin with `internal:` are

--- a/src/Drupal/StateTrait.php
+++ b/src/Drupal/StateTrait.php
@@ -81,7 +81,7 @@ trait StateTrait {
   #[Given('the state :name has the value :value')]
   public function stateSet(string $name, string $value): void {
     $this->stateStoreOriginalValue($name);
-    \Drupal::state()->set($name, $this->stateNormaliseValue($value));
+    \Drupal::state()->set($name, $this->stateNormalizeValue($value));
   }
 
   /**
@@ -116,7 +116,7 @@ trait StateTrait {
       }
       $name = $row['name'];
       $this->stateStoreOriginalValue($name);
-      $state->set($name, $this->stateNormaliseValue($row['value']));
+      $state->set($name, $this->stateNormalizeValue($row['value']));
     }
   }
 
@@ -134,7 +134,7 @@ trait StateTrait {
       throw new AssertionException(sprintf('The state "%s" does not exist, but it should have the value "%s".', $name, $value));
     }
 
-    $expected = $this->stateNormaliseValue($value);
+    $expected = $this->stateNormalizeValue($value);
     $actual_stringified = $this->stateStringifyValue($state_value['value']);
     $expected_stringified = $this->stateStringifyValue($expected);
     if ($actual_stringified !== $expected_stringified) {
@@ -196,17 +196,17 @@ trait StateTrait {
   }
 
   /**
-   * Normalise a string value from a step into the shape actually stored.
+   * Normalize a string value from a step into the shape actually stored.
    *
    * @param string $value
    *   The raw value captured from the step or table cell.
    *
    * @return mixed
-   *   The normalised value: decoded JSON for array/object input, integer or
+   *   The normalized value: decoded JSON for array/object input, integer or
    *   float for numeric input, boolean for "true"/"false", NULL for "null",
    *   or the original string otherwise.
    */
-  protected function stateNormaliseValue(string $value): mixed {
+  protected function stateNormalizeValue(string $value): mixed {
     $trimmed = trim($value);
 
     if ($trimmed === '') {

--- a/src/Drupal/UserTrait.php
+++ b/src/Drupal/UserTrait.php
@@ -312,7 +312,7 @@ trait UserTrait {
    * @endcode
    */
   #[Then('the user :name should not have the role(s) :roles assigned')]
-  public function userAssertHasNoRoles(string $name, string $roles): void {
+  public function userAssertNotHasRoles(string $name, string $roles): void {
     $user = $this->userLoadByName($name);
 
     $roles = $this->helperSplitCommaSeparated($roles);
@@ -385,7 +385,7 @@ trait UserTrait {
    * @endcode
    */
   #[Then('the user :name should be blocked')]
-  public function userAssertIsBlocked(string $name): void {
+  public function userAssertBlocked(string $name): void {
     $user = $this->userLoadByName($name);
 
     if ($user->isActive()) {
@@ -401,7 +401,7 @@ trait UserTrait {
    * @endcode
    */
   #[Then('the user :name should not be blocked')]
-  public function userAssertIsNotBlocked(string $name): void {
+  public function userAssertNotBlocked(string $name): void {
     $user = $this->userLoadByName($name);
 
     if (!$user->isActive()) {

--- a/src/Drupal/WatchdogTrait.php
+++ b/src/Drupal/WatchdogTrait.php
@@ -131,7 +131,7 @@ trait WatchdogTrait {
       throw new \RuntimeException('Watchdog table does not exist. Ensure the dblog module is enabled.');
     }
 
-    $this->watchdogAssertNoErrors(sprintf('during scenario "%s" (line %s)', $this->watchdogScenarioTitle, $this->watchdogScenarioLine));
+    $this->watchdogAssertNotHasErrors(sprintf('during scenario "%s" (line %s)', $this->watchdogScenarioTitle, $this->watchdogScenarioLine));
   }
 
   /**
@@ -163,7 +163,7 @@ trait WatchdogTrait {
       $context = sprintf('during the teardown of scenario "%s" (line %s), which "behat --rerun" cannot record', $this->watchdogScenarioTitle, $this->watchdogScenarioLine);
     }
 
-    $this->watchdogAssertNoErrors($context);
+    $this->watchdogAssertNotHasErrors($context);
   }
 
   /**
@@ -177,7 +177,7 @@ trait WatchdogTrait {
    * @throws \Behat\Mink\Exception\ExpectationException
    *   If errors at or above the severity threshold were logged.
    */
-  protected function watchdogAssertNoErrors(string $context): void {
+  protected function watchdogAssertNotHasErrors(string $context): void {
     $database = Database::getConnection();
 
     // Select entries for every tracked message type that appeared from the

--- a/src/ElementTrait.php
+++ b/src/ElementTrait.php
@@ -35,13 +35,13 @@ trait ElementTrait {
    * @code
    * class FeatureContext extends DrupalContext {
    *   use ElementTrait;
-   *   protected function elementScrollIntoViewCenter(): bool {
+   *   protected function elementGetScrollIntoViewCenter(): bool {
    *     return FALSE;
    *   }
    * }
    * @endcode
    */
-  protected function elementScrollIntoViewCenter(): bool {
+  protected function elementGetScrollIntoViewCenter(): bool {
     return TRUE;
   }
 
@@ -319,7 +319,7 @@ trait ElementTrait {
       throw new ElementNotFoundException($this->getSession()->getDriver(), 'element', 'css', $selector);
     }
 
-    $property_js = json_encode($this->elementNormaliseCssProperty($property), JSON_UNESCAPED_SLASHES);
+    $property_js = json_encode($this->elementNormalizeCssProperty($property), JSON_UNESCAPED_SLASHES);
     $script = sprintf('return window.getComputedStyle({{ELEMENT}}).getPropertyValue(%s).trim();', $property_js);
     $actual = (string) $this->elementExecuteJs($selector, $script);
 
@@ -354,7 +354,7 @@ trait ElementTrait {
    *   The property name in kebab-case. Custom properties are returned as-is,
    *   because they are case-sensitive.
    */
-  protected function elementNormaliseCssProperty(string $property): string {
+  protected function elementNormalizeCssProperty(string $property): string {
     if (str_starts_with($property, '--')) {
       return $property;
     }
@@ -631,8 +631,8 @@ JS;
    * @javascript
    */
   #[Then('the element :selector should be pinned to the top of the viewport')]
-  public function elementAssertIsPinnedToTop(string $selector): void {
-    $this->elementAssertPinnedToTop($selector, 2, FALSE);
+  public function elementAssertPinnedToTop(string $selector): void {
+    $this->elementAssertPinnedToTopWithin($selector, 2, FALSE);
   }
 
   /**
@@ -645,8 +645,8 @@ JS;
    * @javascript
    */
   #[Then('the element :selector should be pinned to the top of the viewport within :tolerance pixels')]
-  public function elementAssertIsPinnedToTopWithTolerance(string $selector, int $tolerance): void {
-    $this->elementAssertPinnedToTop($selector, $tolerance, FALSE);
+  public function elementAssertPinnedToTopWithTolerance(string $selector, int $tolerance): void {
+    $this->elementAssertPinnedToTopWithin($selector, $tolerance, FALSE);
   }
 
   /**
@@ -660,8 +660,8 @@ JS;
    * @javascript
    */
   #[Then('the element :selector should not be pinned to the top of the viewport')]
-  public function elementAssertIsNotPinnedToTop(string $selector): void {
-    $this->elementAssertPinnedToTop($selector, 2, TRUE);
+  public function elementAssertNotPinnedToTop(string $selector): void {
+    $this->elementAssertPinnedToTopWithin($selector, 2, TRUE);
   }
 
   /**
@@ -678,7 +678,7 @@ JS;
    *
    * @throws \Behat\Mink\Exception\ExpectationException
    */
-  protected function elementAssertPinnedToTop(string $selector, int $tolerance, bool $is_inverted): void {
+  protected function elementAssertPinnedToTopWithin(string $selector, int $tolerance, bool $is_inverted): void {
     if ($tolerance < 0) {
       throw new ExpectationException(sprintf('The tolerance must be 0 or greater, but "%d" was given.', $tolerance), $this->getSession()->getDriver());
     }
@@ -822,8 +822,8 @@ JS;
    * Scroll to an element with ID.
    *
    * By default, scrolls the element to the center of the viewport. Override
-   * the elementScrollIntoViewCenter() method to return FALSE to use the legacy
-   * behavior that aligns the element to the top of the viewport.
+   * the elementGetScrollIntoViewCenter() method to return FALSE to use the
+   * legacy behavior that aligns the element to the top of the viewport.
    *
    * @code
    * When I scroll to the element "#footer"
@@ -831,7 +831,7 @@ JS;
    */
   #[When('I scroll to the element :selector')]
   public function elementScrollTo(string $selector): void {
-    if ($this->elementScrollIntoViewCenter()) {
+    if ($this->elementGetScrollIntoViewCenter()) {
       $this->elementExecuteJs($selector, '{{ELEMENT}}.scrollIntoView({ behavior: "auto", block: "center", inline: "center" });');
     }
     else {
@@ -1039,7 +1039,7 @@ JS;
    * @endcode
    */
   #[Then('the element :selector should be displayed')]
-  public function elementAssertIsVisible(string $selector): void {
+  public function elementAssertVisible(string $selector): void {
     $page = $this->getSession()->getPage();
     $elements = $page->findAll('css', $selector);
 
@@ -1064,7 +1064,7 @@ JS;
    * @endcode
    */
   #[Then('the element :selector should not be displayed')]
-  public function elementAssertIsNotVisible(string $selector): void {
+  public function elementAssertNotVisible(string $selector): void {
     $page = $this->getSession()->getPage();
     $elements = $page->findAll('css', $selector);
 
@@ -1083,8 +1083,8 @@ JS;
    * @endcode
    */
   #[Then('the element :selector should be displayed within a viewport')]
-  public function elementAssertIsVisuallyVisible(string $selector): void {
-    $this->elementAssertIsVisible($selector);
+  public function elementAssertVisuallyVisible(string $selector): void {
+    $this->elementAssertVisible($selector);
 
     if (!$this->elementIsVisuallyVisible($selector, 0)) {
       throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is not displayed within a viewport.', $selector), $this->getSession()->getDriver());
@@ -1099,8 +1099,8 @@ JS;
    * @endcode
    */
   #[Then('the element :selector should be displayed within a viewport with a top offset of :offset pixels')]
-  public function elementAssertIsVisuallyVisibleWithOffset(string $selector, int $offset): void {
-    $this->elementAssertIsVisible($selector);
+  public function elementAssertVisuallyVisibleWithOffset(string $selector, int $offset): void {
+    $this->elementAssertVisible($selector);
     if (!$this->elementIsVisuallyVisible($selector, $offset)) {
       throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is not displayed within a viewport with a top offset of %d pixels.', $selector, $offset), $this->getSession()->getDriver());
     }
@@ -1114,7 +1114,7 @@ JS;
    * @endcode
    */
   #[Then('the element :selector should not be displayed within a viewport with a top offset of :offset pixels')]
-  public function elementAssertIsNotVisuallyVisibleWithOffset(string $selector, int $offset): void {
+  public function elementAssertNotVisuallyVisibleWithOffset(string $selector, int $offset): void {
     if ($this->elementIsVisuallyVisible($selector, $offset)) {
       throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is displayed within a viewport with a top offset of %d pixels, but should not be.', $selector, $offset), $this->getSession()->getDriver());
     }
@@ -1133,7 +1133,7 @@ JS;
    * @endcode
    */
   #[Then('the element :selector should not be displayed within a viewport')]
-  public function elementAssertIsVisuallyHidden(string $selector, int $offset = 0): void {
+  public function elementAssertNotVisuallyVisible(string $selector, int $offset = 0): void {
     if ($this->elementIsVisuallyVisible($selector, $offset)) {
       throw new ExpectationException(sprintf('Element(s) defined by "%s" selector is displayed within a viewport, but should not be.', $selector), $this->getSession()->getDriver());
     }

--- a/src/FileDownloadTrait.php
+++ b/src/FileDownloadTrait.php
@@ -310,7 +310,7 @@ trait FileDownloadTrait {
    * @endcode
    */
   #[Then('the downloaded file should be a zip archive not containing the following files partially named:')]
-  public function fileDownloadAssertNoZipContainsPartial(TableNode $files): void {
+  public function fileDownloadAssertZipNotContainsPartial(TableNode $files): void {
     $zip = $this->fileDownloadOpenZip();
 
     $errors = [];

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -124,7 +124,7 @@ trait JavascriptTrait {
     }
 
     try {
-      $this->javascriptAssertNoErrors();
+      $this->javascriptAssertNotHasErrors();
     }
     finally {
       $this->javascriptClearRegistry();
@@ -215,7 +215,7 @@ trait JavascriptTrait {
     // Asserted outside the collection block above so the blanket catch cannot
     // swallow the failure.
     $this->javascriptAsserted = TRUE;
-    $this->javascriptAssertNoErrors();
+    $this->javascriptAssertNotHasErrors();
   }
 
   /**
@@ -323,7 +323,7 @@ JS;
    * @throws \Behat\Mink\Exception\ExpectationException
    *   If JavaScript errors were detected.
    */
-  protected function javascriptAssertNoErrors(): void {
+  protected function javascriptAssertNotHasErrors(): void {
     if (empty($this->javascriptErrorRegistry)) {
       return;
     }

--- a/src/JsonTrait.php
+++ b/src/JsonTrait.php
@@ -109,7 +109,7 @@ trait JsonTrait {
    * @endcode
    */
   #[Then('the response should be in JSON format')]
-  public function jsonAssertResponseIsJson(): void {
+  public function jsonAssertResponseJson(): void {
     $this->jsonDecodeLoose($this->jsonResolveContent());
   }
 
@@ -121,7 +121,7 @@ trait JsonTrait {
    * @endcode
    */
   #[Then('the response should not be in JSON format')]
-  public function jsonAssertResponseIsNotJson(): void {
+  public function jsonAssertResponseNotJson(): void {
     $content = $this->jsonResolveContent();
 
     json_decode((string) $content);

--- a/src/LinkTrait.php
+++ b/src/LinkTrait.php
@@ -172,7 +172,7 @@ trait LinkTrait {
    * @endcode
    */
   #[Then('the link :link should be an absolute link')]
-  public function linkAssertLinkIsAbsolute(string $link): void {
+  public function linkAssertAbsolute(string $link): void {
     $link_element = $this->getSession()->getPage()->findLink($link);
 
     if (!$link_element) {
@@ -194,7 +194,7 @@ trait LinkTrait {
    * @endcode
    */
   #[Then('the link :link should not be an absolute link')]
-  public function linkAssertLinkIsNotAbsolute(string $link): void {
+  public function linkAssertNotAbsolute(string $link): void {
     $link_element = $this->getSession()->getPage()->findLink($link);
 
     if (!$link_element) {

--- a/src/MetatagTrait.php
+++ b/src/MetatagTrait.php
@@ -109,7 +109,7 @@ trait MetatagTrait {
    * @endcode
    */
   #[Then('the :meta_name meta tag should not contain any HTML tags')]
-  public function metatagAssertNoHtml(string $meta_name): void {
+  public function metatagAssertNotContainsHtml(string $meta_name): void {
     $meta_tag = $this->metatagFindMeta($meta_name);
 
     if ($meta_tag === NULL) {

--- a/src/PathTrait.php
+++ b/src/PathTrait.php
@@ -134,7 +134,7 @@ trait PathTrait {
    * @endcode
    */
   #[Then('the current URL should not have the :param parameter')]
-  public function pathAssertUrlHasNoParameter(string $param): void {
+  public function pathAssertUrlNotHasParameter(string $param): void {
     $query = $this->pathGetCurrentUrlQuery();
 
     if (array_key_exists($param, $query)) {
@@ -152,7 +152,7 @@ trait PathTrait {
    * @endcode
    */
   #[Then('the current URL should not have the :param parameter with the value :value')]
-  public function pathAssertUrlHasNoParameterWithValue(string $param, string $value): void {
+  public function pathAssertUrlNotHasParameterWithValue(string $param, string $value): void {
     $query = $this->pathGetCurrentUrlQuery();
 
     if (!array_key_exists($param, $query)) {

--- a/src/ResponseTrait.php
+++ b/src/ResponseTrait.php
@@ -22,7 +22,7 @@ trait ResponseTrait {
    * @endcode
    */
   #[Then('the response should contain the header :name')]
-  public function responseAssertContainsHeader(string $name): void {
+  public function responseAssertHeaderExists(string $name): void {
     $header = $this->getSession()->getResponseHeader($name);
 
     if (!$header) {
@@ -38,7 +38,7 @@ trait ResponseTrait {
    * @endcode
    */
   #[Then('the response should not contain the header :name')]
-  public function responseAssertNotContainsHeader(string $name): void {
+  public function responseAssertHeaderNotExists(string $name): void {
     $header = $this->getSession()->getResponseHeader($name);
 
     if ($header) {

--- a/src/XmlTrait.php
+++ b/src/XmlTrait.php
@@ -118,7 +118,7 @@ trait XmlTrait {
    * @endcode
    */
   #[Then('the response should be in XML format')]
-  public function xmlAssertResponseIsXml(): void {
+  public function xmlAssertResponseXml(): void {
     $parsed = $this->xmlParse($this->xmlResolveContent());
 
     if (!$parsed['loaded']) {
@@ -138,7 +138,7 @@ trait XmlTrait {
    * @endcode
    */
   #[Then('the response should not be in XML format')]
-  public function xmlAssertResponseIsNotXml(): void {
+  public function xmlAssertResponseNotXml(): void {
     $parsed = $this->xmlParse($this->xmlResolveContent());
 
     if ($parsed['loaded'] && $parsed['errors'] === []) {

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -132,12 +132,12 @@ class FeatureContext extends DrupalContext {
   }
 
   /**
-   * Override elementScrollIntoViewCenter() to allow runtime toggling.
+   * Override elementGetScrollIntoViewCenter() to allow runtime toggling.
    *
    * This cannot be moved to FeatureContextTrait because traits cannot override
    * methods from other traits.
    */
-  protected function elementScrollIntoViewCenter(): bool {
+  protected function elementGetScrollIntoViewCenter(): bool {
     return $this->testElementScrollCenter;
   }
 

--- a/tests/phpunit/src/CommandTraitTest.php
+++ b/tests/phpunit/src/CommandTraitTest.php
@@ -158,7 +158,7 @@ class CommandTraitTestImplementation {
   /**
    * {@inheritdoc}
    */
-  protected function commandTimeout(): int {
+  protected function commandGetTimeout(): int {
     return $this->timeoutOverride;
   }
 

--- a/tests/phpunit/src/DiagnosticsTraitTest.php
+++ b/tests/phpunit/src/DiagnosticsTraitTest.php
@@ -230,7 +230,7 @@ class DiagnosticsTraitTestImplementation {
   public bool $sessionAvailable = TRUE;
 
   /**
-   * Per-field toggle state, keyed to match the diagnosticsShow*() overrides.
+   * Per-field toggle state, keyed to match the diagnosticsGetShow*() overrides.
    *
    * @var array<string, bool>
    */
@@ -293,23 +293,23 @@ class DiagnosticsTraitTestImplementation {
     return $this->diagnosticsGetRerunCommand();
   }
 
-  protected function diagnosticsShowUrl(): bool {
+  protected function diagnosticsGetShowUrl(): bool {
     return $this->show['url'];
   }
 
-  protected function diagnosticsShowStatusCode(): bool {
+  protected function diagnosticsGetShowStatusCode(): bool {
     return $this->show['status'];
   }
 
-  protected function diagnosticsShowDriver(): bool {
+  protected function diagnosticsGetShowDriver(): bool {
     return $this->show['driver'];
   }
 
-  protected function diagnosticsShowJsErrors(): bool {
+  protected function diagnosticsGetShowJsErrors(): bool {
     return $this->show['js'];
   }
 
-  protected function diagnosticsShowRerun(): bool {
+  protected function diagnosticsGetShowRerun(): bool {
     return $this->show['rerun'];
   }
 

--- a/tests/phpunit/src/TraitMethodNamingTest.php
+++ b/tests/phpunit/src/TraitMethodNamingTest.php
@@ -10,10 +10,14 @@ use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * Asserts that every trait method is prefixed with its trait's name.
+ * Asserts that trait method names follow the library's naming conventions.
  *
  * Traits are mixed into a single consumer context, so an unprefixed method
  * name can collide with a method of the same name from another trait.
+ *
+ * The remaining conventions keep one shape per idea across 690 methods, so
+ * that a consumer can derive a name rather than look it up. They are stated
+ * in CONTRIBUTING.md.
  */
 #[CoversNothing]
 class TraitMethodNamingTest extends UnitTestCase {
@@ -38,24 +42,14 @@ class TraitMethodNamingTest extends UnitTestCase {
    * @param string $file
    *   The absolute path to the file declaring the trait.
    */
-  #[DataProvider('dataProviderMethodsArePrefixed')]
+  #[DataProvider('dataProviderTraitFiles')]
   public function testMethodsArePrefixed(string $trait, string $file): void {
     $reflection = new \ReflectionClass($trait);
     $prefix = self::traitPrefix($reflection->getShortName());
     $allowed = self::PARENT_OVERRIDES[$trait] ?? [];
 
-    $methods = $reflection->getMethods();
-
     $violations = [];
-    foreach ($methods as $method) {
-      // A trait that composes another trait reports the composed methods
-      // too; the file each method is declared in tells them apart.
-      if (realpath((string) $method->getFileName()) !== $file) {
-        continue;
-      }
-
-      $name = $method->getName();
-
+    foreach (self::traitOwnMethodNames($trait, $file) as $name) {
       if (in_array($name, $allowed, TRUE) || self::hasPrefix($name, $prefix)) {
         continue;
       }
@@ -66,7 +60,7 @@ class TraitMethodNamingTest extends UnitTestCase {
     $this->assertSame([], $violations, sprintf('Methods in %s must be prefixed with "%s".', $reflection->getShortName(), $prefix));
   }
 
-  public static function dataProviderMethodsArePrefixed(): array {
+  public static function dataProviderTraitFiles(): array {
     $root = realpath(__DIR__ . '/../../../src');
     $files = [];
 
@@ -89,6 +83,58 @@ class TraitMethodNamingTest extends UnitTestCase {
   }
 
   /**
+   * Assert that a negative name reads `Assert<Subject>Not<Predicate>`.
+   *
+   * `Not` is the only negation particle, so the determiner `No` never opens a
+   * negated noun. A negative name is then its positive counterpart with `Not`
+   * inserted and nothing else changed.
+   *
+   * @param class-string $trait
+   *   The trait to check.
+   * @param string $file
+   *   The absolute path to the file declaring the trait.
+   */
+  #[DataProvider('dataProviderTraitFiles')]
+  public function testNegationSpelledNot(string $trait, string $file): void {
+    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => preg_match('/No[A-Z]/', $name) === 1));
+
+    $this->assertSame([], $violations, 'Negate with "Not" placed before the predicate, not with "No" before a noun: "userAssertNotHasRoles", not "userAssertHasNoRoles".');
+  }
+
+  /**
+   * Assert that an assertion name carries no copula.
+   *
+   * `Assert` already states that the subject is something, so a further `Is`
+   * only moves the negation particle out of its one slot.
+   *
+   * @param class-string $trait
+   *   The trait to check.
+   * @param string $file
+   *   The absolute path to the file declaring the trait.
+   */
+  #[DataProvider('dataProviderTraitFiles')]
+  public function testAssertionsCarryNoCopula(string $trait, string $file): void {
+    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => preg_match('/Assert[A-Za-z0-9]*Is[A-Z]/', $name) === 1));
+
+    $this->assertSame([], $violations, 'Drop the "Is" copula from assertion names: "elementAssertVisible" and "elementAssertNotVisible", not "elementAssertIsVisible" and "elementAssertIsNotVisible".');
+  }
+
+  /**
+   * Assert that names spell normalisation the American way.
+   *
+   * @param class-string $trait
+   *   The trait to check.
+   * @param string $file
+   *   The absolute path to the file declaring the trait.
+   */
+  #[DataProvider('dataProviderTraitFiles')]
+  public function testSpellingIsAmerican(string $trait, string $file): void {
+    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => stripos($name, 'normalise') !== FALSE));
+
+    $this->assertSame([], $violations, 'Spell it "Normalize", not "Normalise".');
+  }
+
+  /**
    * The allowlist is not a place to retire a method that no longer exists.
    */
   public function testParentOverrideAllowlistIsCurrent(): void {
@@ -100,6 +146,34 @@ class TraitMethodNamingTest extends UnitTestCase {
         $this->assertFalse(self::hasPrefix($method, self::traitPrefix($reflection->getShortName())), sprintf('%s::%s() is allowlisted but already conforms; remove the entry.', $reflection->getShortName(), $method));
       }
     }
+  }
+
+  /**
+   * Collect the names of the methods a trait declares in its own file.
+   *
+   * @param class-string $trait
+   *   The trait to read.
+   * @param string $file
+   *   The absolute path to the file declaring the trait.
+   *
+   * @return array<int, string>
+   *   The method names.
+   */
+  protected static function traitOwnMethodNames(string $trait, string $file): array {
+    $methods = (new \ReflectionClass($trait))->getMethods();
+
+    $names = [];
+    foreach ($methods as $method) {
+      // A trait that composes another trait reports the composed methods
+      // too; the file each method is declared in tells them apart.
+      if (realpath((string) $method->getFileName()) !== $file) {
+        continue;
+      }
+
+      $names[] = $method->getName();
+    }
+
+    return $names;
   }
 
   /**

--- a/tests/phpunit/src/TraitMethodNamingTest.php
+++ b/tests/phpunit/src/TraitMethodNamingTest.php
@@ -66,9 +66,10 @@ class TraitMethodNamingTest extends UnitTestCase {
   /**
    * Assert that a negative name reads `Assert<Subject>Not<Predicate>`.
    *
-   * `Not` is the only negation particle, so the determiner `No` never opens a
-   * negated noun. A negative name is then its positive counterpart with `Not`
-   * inserted and nothing else changed.
+   * `Not` is the only negation particle, so neither the determiner `No` nor a
+   * `DoesNot` or `DoNot` auxiliary opens a negated word. A negative name is
+   * then its positive counterpart with `Not` inserted and nothing else
+   * changed.
    *
    * @param class-string $trait
    *   The trait to check.
@@ -77,9 +78,9 @@ class TraitMethodNamingTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderNegationSpelledNot')]
   public function testNegationSpelledNot(string $trait, string $file): void {
-    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => preg_match('/No[A-Z]/', $name) === 1));
+    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => preg_match('/(?:No|DoesNot|DoNot)[A-Z]/', $name) === 1));
 
-    $this->assertSame([], $violations, 'Negate with "Not" placed before the predicate, not with "No" before a noun: "userAssertNotHasRoles", not "userAssertHasNoRoles".');
+    $this->assertSame([], $violations, 'Negate with a bare "Not" placed before the predicate: "userAssertNotHasRoles", not "userAssertHasNoRoles" or "userAssertDoesNotHaveRoles".');
   }
 
   public static function dataProviderNegationSpelledNot(): array {

--- a/tests/phpunit/src/TraitMethodNamingTest.php
+++ b/tests/phpunit/src/TraitMethodNamingTest.php
@@ -42,7 +42,7 @@ class TraitMethodNamingTest extends UnitTestCase {
    * @param string $file
    *   The absolute path to the file declaring the trait.
    */
-  #[DataProvider('dataProviderTraitFiles')]
+  #[DataProvider('dataProviderMethodsArePrefixed')]
   public function testMethodsArePrefixed(string $trait, string $file): void {
     $reflection = new \ReflectionClass($trait);
     $prefix = self::traitPrefix($reflection->getShortName());
@@ -60,7 +60,95 @@ class TraitMethodNamingTest extends UnitTestCase {
     $this->assertSame([], $violations, sprintf('Methods in %s must be prefixed with "%s".', $reflection->getShortName(), $prefix));
   }
 
-  public static function dataProviderTraitFiles(): array {
+  public static function dataProviderMethodsArePrefixed(): array {
+    return static::discoverTraitFiles();
+  }
+
+  /**
+   * Assert that a negative name reads `Assert<Subject>Not<Predicate>`.
+   *
+   * `Not` is the only negation particle, so the determiner `No` never opens a
+   * negated noun. A negative name is then its positive counterpart with `Not`
+   * inserted and nothing else changed.
+   *
+   * @param class-string $trait
+   *   The trait to check.
+   * @param string $file
+   *   The absolute path to the file declaring the trait.
+   */
+  #[DataProvider('dataProviderNegationSpelledNot')]
+  public function testNegationSpelledNot(string $trait, string $file): void {
+    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => preg_match('/No[A-Z]/', $name) === 1));
+
+    $this->assertSame([], $violations, 'Negate with "Not" placed before the predicate, not with "No" before a noun: "userAssertNotHasRoles", not "userAssertHasNoRoles".');
+  }
+
+  public static function dataProviderNegationSpelledNot(): array {
+    return static::discoverTraitFiles();
+  }
+
+  /**
+   * Assert that an assertion name carries no copula.
+   *
+   * `Assert` already states that the subject is something, so a further `Is`
+   * only moves the negation particle out of its one slot.
+   *
+   * @param class-string $trait
+   *   The trait to check.
+   * @param string $file
+   *   The absolute path to the file declaring the trait.
+   */
+  #[DataProvider('dataProviderAssertionsCarryNoCopula')]
+  public function testAssertionsCarryNoCopula(string $trait, string $file): void {
+    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => preg_match('/Assert[A-Za-z0-9]*Is[A-Z]/', $name) === 1));
+
+    $this->assertSame([], $violations, 'Drop the "Is" copula from assertion names: "elementAssertVisible" and "elementAssertNotVisible", not "elementAssertIsVisible" and "elementAssertIsNotVisible".');
+  }
+
+  public static function dataProviderAssertionsCarryNoCopula(): array {
+    return static::discoverTraitFiles();
+  }
+
+  /**
+   * Assert that names spell normalisation the American way.
+   *
+   * @param class-string $trait
+   *   The trait to check.
+   * @param string $file
+   *   The absolute path to the file declaring the trait.
+   */
+  #[DataProvider('dataProviderSpellingIsAmerican')]
+  public function testSpellingIsAmerican(string $trait, string $file): void {
+    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => stripos($name, 'normalise') !== FALSE));
+
+    $this->assertSame([], $violations, 'Spell it "Normalize", not "Normalise".');
+  }
+
+  public static function dataProviderSpellingIsAmerican(): array {
+    return static::discoverTraitFiles();
+  }
+
+  /**
+   * The allowlist is not a place to retire a method that no longer exists.
+   */
+  public function testParentOverrideAllowlistIsCurrent(): void {
+    foreach (self::PARENT_OVERRIDES as $trait => $methods) {
+      $reflection = new \ReflectionClass($trait);
+
+      foreach ($methods as $method) {
+        $this->assertTrue($reflection->hasMethod($method), sprintf('%s::%s() is allowlisted but does not exist.', $reflection->getShortName(), $method));
+        $this->assertFalse(self::hasPrefix($method, self::traitPrefix($reflection->getShortName())), sprintf('%s::%s() is allowlisted but already conforms; remove the entry.', $reflection->getShortName(), $method));
+      }
+    }
+  }
+
+  /**
+   * Pair every trait under `src/` with the file that declares it.
+   *
+   * @return array<string, array{string, string}>
+   *   Trait name and absolute file path, keyed by the path relative to `src/`.
+   */
+  protected static function discoverTraitFiles(): array {
     $root = realpath(__DIR__ . '/../../../src');
     $files = [];
 
@@ -80,72 +168,6 @@ class TraitMethodNamingTest extends UnitTestCase {
     ksort($files);
 
     return $files;
-  }
-
-  /**
-   * Assert that a negative name reads `Assert<Subject>Not<Predicate>`.
-   *
-   * `Not` is the only negation particle, so the determiner `No` never opens a
-   * negated noun. A negative name is then its positive counterpart with `Not`
-   * inserted and nothing else changed.
-   *
-   * @param class-string $trait
-   *   The trait to check.
-   * @param string $file
-   *   The absolute path to the file declaring the trait.
-   */
-  #[DataProvider('dataProviderTraitFiles')]
-  public function testNegationSpelledNot(string $trait, string $file): void {
-    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => preg_match('/No[A-Z]/', $name) === 1));
-
-    $this->assertSame([], $violations, 'Negate with "Not" placed before the predicate, not with "No" before a noun: "userAssertNotHasRoles", not "userAssertHasNoRoles".');
-  }
-
-  /**
-   * Assert that an assertion name carries no copula.
-   *
-   * `Assert` already states that the subject is something, so a further `Is`
-   * only moves the negation particle out of its one slot.
-   *
-   * @param class-string $trait
-   *   The trait to check.
-   * @param string $file
-   *   The absolute path to the file declaring the trait.
-   */
-  #[DataProvider('dataProviderTraitFiles')]
-  public function testAssertionsCarryNoCopula(string $trait, string $file): void {
-    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => preg_match('/Assert[A-Za-z0-9]*Is[A-Z]/', $name) === 1));
-
-    $this->assertSame([], $violations, 'Drop the "Is" copula from assertion names: "elementAssertVisible" and "elementAssertNotVisible", not "elementAssertIsVisible" and "elementAssertIsNotVisible".');
-  }
-
-  /**
-   * Assert that names spell normalisation the American way.
-   *
-   * @param class-string $trait
-   *   The trait to check.
-   * @param string $file
-   *   The absolute path to the file declaring the trait.
-   */
-  #[DataProvider('dataProviderTraitFiles')]
-  public function testSpellingIsAmerican(string $trait, string $file): void {
-    $violations = array_values(array_filter(self::traitOwnMethodNames($trait, $file), fn(string $name): bool => stripos($name, 'normalise') !== FALSE));
-
-    $this->assertSame([], $violations, 'Spell it "Normalize", not "Normalise".');
-  }
-
-  /**
-   * The allowlist is not a place to retire a method that no longer exists.
-   */
-  public function testParentOverrideAllowlistIsCurrent(): void {
-    foreach (self::PARENT_OVERRIDES as $trait => $methods) {
-      $reflection = new \ReflectionClass($trait);
-
-      foreach ($methods as $method) {
-        $this->assertTrue($reflection->hasMethod($method), sprintf('%s::%s() is allowlisted but does not exist.', $reflection->getShortName(), $method));
-        $this->assertFalse(self::hasPrefix($method, self::traitPrefix($reflection->getShortName())), sprintf('%s::%s() is allowlisted but already conforms; remove the entry.', $reflection->getShortName(), $method));
-      }
-    }
   }
 
   /**

--- a/tests/phpunit/src/TraitMethodNamingTest.php
+++ b/tests/phpunit/src/TraitMethodNamingTest.php
@@ -15,9 +15,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * Traits are mixed into a single consumer context, so an unprefixed method
  * name can collide with a method of the same name from another trait.
  *
- * The remaining conventions keep one shape per idea across 690 methods, so
- * that a consumer can derive a name rather than look it up. They are stated
- * in CONTRIBUTING.md.
+ * The remaining conventions keep one shape per idea, so that a consumer can
+ * derive a name rather than look it up. CONTRIBUTING.md states them.
  */
 #[CoversNothing]
 class TraitMethodNamingTest extends UnitTestCase {


### PR DESCRIPTION
Closes #714

## Summary

44 trait methods across `src/` were renamed onto one shape each: `ElementTrait::elementAssertVisible()` replaces `elementAssertIsVisible()`, `Drupal\UserTrait::userAssertNotHasRoles()` replaces `userAssertHasNoRoles()`, `Drupal\StateTrait::stateNormalizeValue()` replaces `stateNormaliseValue()`, and `CommandTrait::commandGetTimeout()` replaces `commandTimeout()`, while Gherkin step text, step parameter names and method bodies stay exactly as they were.

The naming surface carried six shapes for a negative assertion (`elementAssertIsNotVisible()`, `userAssertHasNoRoles()`, and the bare antonym `elementAssertIsVisuallyHidden()` among them), two spellings of normalize in method names (`stateNormaliseValue()`, `elementNormaliseCssProperty()`), and two shapes for a documented override point (`diagnosticsShowUrl()` alongside already `Get`-prefixed methods), because `tests/phpunit/src/TraitMethodNamingTest.php` checked only the trait-name prefix added for issue #713 and asserted nothing about which shape a predicate, negation or getter took.

After merge every negation reads `Assert<Subject>Not<Predicate>` with no `Is`, `No` or antonym standing in for it, every value-supplying override point is `Get`-prefixed, and `tests/phpunit/src/TraitMethodNamingTest.php` gained `testNegationSpelledNot()`, `testAssertionsCarryNoCopula()` and `testSpellingIsAmerican()`, each with its own data provider, to hold the three conventions; British spellings elsewhere in `src/` prose (`customise`, `behaviour`, `serialise`) are untouched, and so is `redirectAssertExist()`, which already matched the plural-subject `Exist` rule.

## Before / After

```
BEFORE - six shapes for "assert the negative"
┌──────────────────────────────────────────────────────────────┐
│ userAssertHasNoRoles()              "No" + noun              │
│ elementAssertIsNotVisible()         "Is" + "Not"             │
│ userAssertIsNotBlocked()            "Is" + "Not"             │
│ elementAssertIsVisuallyHidden()     antonym, no "Not" at all │
│ jsonAssertResponseIsNotJson()       "Is" + "Not"             │
│ fileAssertUnmanagedHasNoContent()   "No" + noun              │
└──────────────────────────────────────────────────────────────┘

AFTER - one shape, one slot for "Not"
┌─────────────────────────────────────────────┐
│ <trait>Assert<Subject>Not<Predicate>        │
│                        ^^^                  │
│ the only negation particle, placed directly │
│ before the predicate it negates             │
│                                             │
│ userAssertNotHasRoles()                     │
│ elementAssertNotVisible()                   │
│ userAssertNotBlocked()                      │
│ elementAssertNotVisuallyVisible()           │
│ jsonAssertResponseNotJson()                 │
│ fileAssertUnmanagedNotHasContent()          │
└─────────────────────────────────────────────┘
```

## Changes

- Negation consolidated onto `<trait>Assert<Subject>Not<Predicate>` across `Drupal\EmailTrait`, `Drupal\FileTrait`, `Drupal\UserTrait`, `Drupal\WatchdogTrait`, `ElementTrait`, `FileDownloadTrait`, `JavascriptTrait`, `JsonTrait`, `LinkTrait`, `MetatagTrait`, `PathTrait` and `XmlTrait`.
- `ElementTrait` naming collision resolved: the protected helper `elementAssertPinnedToTop($selector, $tolerance, $is_inverted)` moved to `elementAssertPinnedToTopWithin()`, named after the tolerance it takes, freeing the clean name for the public step, so `elementAssertIsPinnedToTop()` becomes `elementAssertPinnedToTop()`.
- `Drupal\EmailTrait` exact-match methods gained the `Equals` predicate: `emailAssertMessageField()` to `emailAssertMessageFieldEquals()`, `emailAssertMessageFieldNotExact()` to `emailAssertMessageFieldNotEquals()`, `emailAssertMessageHeader()` to `emailAssertMessageHeaderEquals()`.
- `ResponseTrait` header assertions reordered subject-first: `responseAssertContainsHeader()` to `responseAssertHeaderExists()`, `responseAssertNotContainsHeader()` to `responseAssertHeaderNotExists()`; `responseAssertHeaderContains()` and `responseAssertHeaderNotContains()` are unchanged.
- Spelling converged on `Normalize`: `Drupal\StateTrait::stateNormalizeValue()`, `ElementTrait::elementNormalizeCssProperty()`, and the docblock prose in `Drupal\RedirectTrait` that referred to them.
- Override points renamed to `<trait>Get<Noun>()`: `CommandTrait::commandGetTimeout()`, `ElementTrait::elementGetScrollIntoViewCenter()`, and six `DiagnosticsTrait` methods (`diagnosticsGetHeader()`, `diagnosticsGetRerunBinary()`, `diagnosticsGetShowDriver()`, `diagnosticsGetShowJsErrors()`, `diagnosticsGetShowRerun()`, `diagnosticsGetShowStatusCode()`, `diagnosticsGetShowUrl()`).
- `tests/phpunit/src/TraitMethodNamingTest.php` gained `testNegationSpelledNot()`, `testAssertionsCarryNoCopula()` and `testSpellingIsAmerican()`, each fed by its own `dataProvider*()` method, and factored the shared trait-file walk into `discoverTraitFiles()` and `traitOwnMethodNames()`.
- Consumer call sites updated to the new names: `tests/behat/bootstrap/FeatureContext.php`, `tests/phpunit/src/CommandTraitTest.php`, `tests/phpunit/src/DiagnosticsTraitTest.php`.
- `CONTRIBUTING.md` states all four naming conventions, `MIGRATION.md` gained a "One shape per naming idea" section with the full old-to-new tables, and `STEPS.md` was regenerated via `ahoy update-docs`.

Not addressed here: `src/` prose still mixes British and American spelling beyond `Normalize` (`customise`, `behaviour`, `serialise`, `recognise`, `initialise`), a candidate follow-up now that method names are converged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Standardized 44 trait method names with consistent `Not`, `Equals`, `Normalize`, and `Get` forms.
- Updated call sites, tests, documentation, migration mappings, and generated `STEPS.md`.
- Added reflection-based tests for naming conventions.
- Preserved step text, parameter names, and method behavior.

## Breaking changes

- Renamed public assertions and consumer override points.
- Documented old-to-new method mappings and renamed `ElementTrait` offset parameters.

## Step definition review

No Critical step-definition violations were found. The changed step text and parameter names remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->