### PR TITLE
[#785] Added the scenario styles documentation page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ from the community.
 
 [//]: # (END)
 
+## 📚 Documentation
+
+- [2 styles, 2 jobs - the vocabulary and the toolbox](docs/2-styles-2-jobs.md) - the imperative and declarative scenario styles, the job each one does, and how to graduate from the shipped steps to your own domain steps built on the same helpers.
+
 ## 📦 Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ from the community.
 
 ## 📚 Documentation
 
-- [2 styles, 2 jobs - the vocabulary and the toolbox](docs/2-styles-2-jobs.md) - the imperative and declarative scenario styles, the job each one does, and how to graduate from the shipped steps to your own domain steps built on the same helpers.
+- [Scenario styles - the vocabulary and the toolbox](docs/scenario-styles.md) - the imperative and declarative scenario styles, the job each one does, and how to graduate from the shipped steps to your own domain steps built on the same helpers.
 
 ## 📦 Installation
 

--- a/docs/2-styles-2-jobs.md
+++ b/docs/2-styles-2-jobs.md
@@ -1,0 +1,66 @@
+# 2 styles, 2 jobs - the vocabulary and the toolbox
+
+Why a generic step library and BDD's own teaching point in different directions, and how this stack serves both.
+
+## The 2 styles
+
+The same behavior can be scripted 2 ways. The first is the imperative style - the style a generic step vocabulary makes possible:
+
+```gherkin
+Scenario: Editor publishes a page
+  Given I am logged in as a user with the "editor" role
+  When I visit "/node/add/page"
+  And I fill in "Title" with "About us"
+  And I select "Published" from "Save as"
+  And I press "Save"
+  Then the path should be "/about-us"
+  And the element ".messages--status" should contain "has been created"
+```
+
+The second is the declarative style - the style Behat's own quick start teaches ("When I add the 'Sith Lord Lightsaber' to the basket"):
+
+```gherkin
+Scenario: Editor publishes a page
+  Given I am an editor
+  When I publish a page titled "About us"
+  Then the page "About us" should be publicly visible at "/about-us"
+```
+
+The declarative version has no shipped step behind it. The project writes each definition itself, as a few lines of PHP over the library's helpers:
+
+```php
+#[When('I publish a page titled :title')]
+public function publishPage(string $title): void {
+  $this->contentCreate('page', ['title' => $title, 'moderation_state' => 'published']);
+}
+```
+
+That is what "domain steps" means: the Gherkin speaks the project's language, and the translation into clicks, fields and API calls happens once, inside a definition, instead of being spelled out in every scenario.
+
+## Why BDD teaches the declarative style
+
+3 arguments, all old and all well-tested. Audience: BDD's founding purpose is scenarios as a conversation artifact with stakeholders - "I fill in Title" is noise to a product owner, "I publish a page" is signal. Resilience: when the form is redesigned, an imperative suite changes in every scenario that touches the form, while a declarative suite changes in exactly 1 definition, because the scenario asserted the behavior, not the widget path. Intent: an imperative scenario can pass while the actual requirement fails, because it verifies mechanics, not meaning.
+
+There is a famous precedent. Cucumber - Behat's Ruby ancestor - used to ship `web_steps.rb`, a generic click/fill/see vocabulary. In 2011 its maintainers deleted it from the project, arguing that generic steps train users into brittle, implementation-coupled suites. MinkContext is PHP's `web_steps.rb` that never got deleted, and this library is a larger, better-engineered descendant of the same pattern. The critique is real and has history behind it.
+
+## Why the imperative style wins in this ecosystem anyway
+
+The critique assumes a context that mostly does not hold for CMS delivery work:
+
+- **The UI is the deliverable.** A Drupal site build is assembled configuration - content types, fields, forms, views, blocks. "The editor can fill this form and the page appears" is not incidental mechanics; it is the requirement. Testing the artifact in the artifact's own terms is legitimate verification.
+- **There is usually no stakeholder audience.** These suites are written and read by developers and QA, so the readability-for-business argument loses most of its force.
+- **Economics at fleet scale.** A domain vocabulary must be written per project, in PHP. A generic vocabulary is 0 PHP and instant coverage - and across dozens of sites, 1 shared vocabulary every developer already knows beats dozens of bespoke mini-DSLs. Cross-project consistency is itself a feature.
+
+## 2 different jobs
+
+These are 2 jobs, not 1 job done well or badly. Specification - BDD proper - uses domain language, faces stakeholders, and keeps its scenarios few and precious. Verification - functional regression - uses infrastructure language, faces developers, and wants its scenarios broad and cheap. Behat the tool supports both; Behat's tutorial teaches only the first; a generic step library equips only the second. Nothing is wrong except not knowing which job a given suite is doing.
+
+## The vocabulary and the toolbox
+
+The library serves both jobs at once through 1 design rule: every step body is a thin wrapper over a named protected helper. That makes the package 2 products in 1 - the vocabulary (the steps: 1 skin over the helpers) and the toolbox (the helpers themselves). A project that outgrows the raw vocabulary does not leave the library; it stops calling the toolbox from Gherkin and starts calling it from PHP.
+
+3 consequences follow:
+
+1. **Helpers are public API** - documented, semver-covered, named as carefully as the steps. The helper surface is half the product. This is also where the trait model earns its keep: the helpers sit on `$this` in the consumer's `FeatureContext`, so a domain step costs 3 lines; under a context model every domain step would start with service lookups.
+2. **Suites split by job**: a spec suite holding the few domain-language scenarios, a regression suite holding the broad generic-vocabulary ones - which is also how Behat's own documentation says suites should be used.
+3. **The docs teach a lifecycle, not a catalogue**: start with the vocabulary for instant coverage, then graduate the flows that matter to domain steps on the toolbox. The quick start shows both scenario styles side by side.

--- a/docs/2-styles-2-jobs.md
+++ b/docs/2-styles-2-jobs.md
@@ -41,7 +41,7 @@ That is what "domain steps" means: the Gherkin speaks the project's language, an
 
 3 arguments, all old and all well-tested. Audience: BDD's founding purpose is scenarios as a conversation artifact with stakeholders - "I fill in Title" is noise to a product owner, "I publish a page" is signal. Resilience: when the form is redesigned, an imperative suite changes in every scenario that touches the form, while a declarative suite changes in exactly 1 definition, because the scenario asserted the behavior, not the widget path. Intent: an imperative scenario can pass while the actual requirement fails, because it verifies mechanics, not meaning.
 
-There is a famous precedent. Cucumber - Behat's Ruby ancestor - used to ship `web_steps.rb`, a generic click/fill/see vocabulary. In 2011 its maintainers deleted it from the project, arguing that generic steps train users into brittle, implementation-coupled suites. MinkContext is PHP's `web_steps.rb` that never got deleted, and this library is a larger, better-engineered descendant of the same pattern. The critique is real and has history behind it.
+There is a famous precedent. `cucumber-rails`, the Rails integration for Cucumber - Behat's Ruby ancestor - used to ship `web_steps.rb`, a generic click/fill/see vocabulary. In 2011 its maintainers deleted it from the project, arguing that generic steps train users into brittle, implementation-coupled suites. MinkContext is PHP's `web_steps.rb` that never got deleted, and this library is a larger, better-engineered descendant of the same pattern. The critique is real and has history behind it.
 
 ## Why the imperative style wins in this ecosystem anyway
 

--- a/docs/scenario-styles.md
+++ b/docs/scenario-styles.md
@@ -1,4 +1,4 @@
-# 2 styles, 2 jobs - the vocabulary and the toolbox
+# Scenario styles - the vocabulary and the toolbox
 
 Why a generic step library and BDD's own teaching point in different directions, and how this stack serves both.
 


### PR DESCRIPTION
Closes #785

## Summary

`README.md` gains a `## 📚 Documentation` section immediately after the `[//]: # (END)` marker on line 109, linking to a new `docs/scenario-styles.md` page, and the repository gains its first `docs/` directory to hold it.

Before this change the repository had no `docs/` directory and no page explaining why the library ships a generic imperative vocabulary (`I fill in`, `I press`) alongside the declarative domain-step style that Behat's own quick start teaches, so that rationale existed only in issue #785 rather than in the shipped documentation.

`docs/scenario-styles.md` reproduces the issue #785 page content with its 5 section headings promoted from `###` to `##`, and corrects the source text's attribution of `web_steps.rb` to Cucumber itself, naming `cucumber-rails` (the Rails integration gem that shipped and removed it in version 1.1.0, October 2011) instead; no PHP files, step definitions, fixtures, or tests are touched.

## Before / After

```
BEFORE - README jumps from the generated steps index straight to Installation, no docs/ directory exists

  behat-steps/ (4.x)
  ├── README.md
  │   ├── ## Available steps        (generated by docs.php)
  │   ├── [//]: # (END)
  │   └── ## 📦 Installation        ◄── next section right after the marker
  ├── STEPS.md
  └── src/


AFTER - a docs/ directory holds the page, README points at it right after the generated region

  behat-steps/ (4.x)
  ├── README.md
  │   ├── ## Available steps        (generated by docs.php)
  │   ├── [//]: # (END)
  │   ├── ## 📚 Documentation       ◄── new section
  │   │       └── links to docs/scenario-styles.md
  │   └── ## 📦 Installation
  ├── STEPS.md
  ├── docs/                         ◄── new directory
  │   └── scenario-styles.md        ◄── new page
  └── src/
```

## Changes

- `docs/scenario-styles.md` (new) - titled `Scenario styles - the vocabulary and the toolbox`, it reproduces the issue #785 page content verbatim aside from 2 mechanical edits: the issue's `Page content:` preamble and `---` fence are dropped, and the 5 section headings are promoted from `###` to `##` so nothing skips a level under the page's own `#` title; the text also carries 1 factual correction, attributing `web_steps.rb` to `cucumber-rails` rather than to Cucumber core, with the year, the argument, and the MinkContext comparison unchanged.
- `README.md` - adds a `## 📚 Documentation` section after the `[//]: # (END)` marker on line 109, linking to `docs/scenario-styles.md`; the section sits outside the region `docs.php` regenerates (`## Available steps` through `[//]: # (END)`), so `ahoy lint-docs` is unaffected.
