### PR TITLE
[#777] Moved entity-field parsing into the driver's create paths.

### DIFF
--- a/src/Behat/Context/RawContext.php
+++ b/src/Behat/Context/RawContext.php
@@ -34,9 +34,6 @@ use DrevOps\BehatSteps\Driver\Capability\ContentCapabilityInterface;
 use DrevOps\BehatSteps\Driver\Capability\LanguageCapabilityInterface;
 use DrevOps\BehatSteps\Driver\Capability\RoleCapabilityInterface;
 use DrevOps\BehatSteps\Driver\Capability\UserCapabilityInterface;
-use DrevOps\BehatSteps\Driver\Core\Field\FieldClassifierInterface;
-use DrevOps\BehatSteps\Driver\Core\Field\Parser\EntityFieldParser;
-use DrevOps\BehatSteps\Driver\Core\Field\Parser\EntityFieldParserInterface;
 use DrevOps\BehatSteps\Driver\DriverInterface;
 use DrevOps\BehatSteps\Driver\DrupalDriverInterface;
 use DrevOps\BehatSteps\Driver\Entity\EntityStub;
@@ -388,7 +385,7 @@ class RawContext extends RawMinkContext implements DriverAwareInterface {
   public function nodeCreate(EntityStubInterface $stub): EntityStubInterface {
     $this->dispatchHooks(BeforeNodeCreateScope::class, $stub);
     $this->dispatchHooks(BeforeEntityCreateScope::class, $stub);
-    $this->parseCreatedEntityFields($stub, ['author']);
+    $this->parseCreatedEntityFields($stub);
 
     $driver = $this->getContentDriver();
 
@@ -421,7 +418,7 @@ class RawContext extends RawMinkContext implements DriverAwareInterface {
   public function userCreate(EntityStubInterface $stub): EntityStubInterface {
     $this->dispatchHooks(BeforeUserCreateScope::class, $stub);
     $this->dispatchHooks(BeforeEntityCreateScope::class, $stub);
-    $this->parseCreatedEntityFields($stub, ['role']);
+    $this->parseCreatedEntityFields($stub);
 
     $driver = $this->getDriver();
 
@@ -471,7 +468,7 @@ class RawContext extends RawMinkContext implements DriverAwareInterface {
 
     $this->dispatchHooks(BeforeTermCreateScope::class, $stub);
     $this->dispatchHooks(BeforeEntityCreateScope::class, $stub);
-    $this->parseCreatedEntityFields($stub, ['vocabulary_machine_name']);
+    $this->parseCreatedEntityFields($stub);
 
     $driver = $this->getContentDriver();
 
@@ -524,8 +521,10 @@ class RawContext extends RawMinkContext implements DriverAwareInterface {
    * Expands a stub's raw Gherkin values into the storage field shape.
    *
    * Table cells arrive as written - a bare scalar, a comma-separated list, or
-   * a compound 'key:"value"' cell - and the parser resolves each against the
-   * field's own definition before the driver saves the entity.
+   * a compound 'key:"value"' cell - and the driver resolves each against the
+   * field's own definition before the entity is saved. A step that saves an
+   * entity through Drupal's API rather than the driver calls this first, so
+   * both routes see the same values.
    *
    * @param \DrevOps\BehatSteps\Driver\Entity\EntityStubInterface $stub
    *   The stub, mutated in place.
@@ -537,12 +536,7 @@ class RawContext extends RawMinkContext implements DriverAwareInterface {
    *   When the scenario does not run on the in-process Drupal driver.
    */
   public function parseEntityFields(EntityStubInterface $stub, array $ignored_properties = []): void {
-    $classifier = $this->assertDrupal()->getCore()->getFieldClassifier();
-
-    $parser = $this->getFieldParser($stub->getEntityType(), $classifier, $stub->getBundle());
-    $parser->ignoring($ignored_properties);
-
-    $stub->setValues($parser->parse($stub->getValues()));
+    $this->assertDrupal()->getCore()->parseEntityFields($stub, $ignored_properties);
   }
 
   /**
@@ -769,40 +763,23 @@ class RawContext extends RawMinkContext implements DriverAwareInterface {
   }
 
   /**
-   * Expands a stub's values during creation, when the driver can classify them.
+   * Expands a stub's values before the create hooks reach the driver.
    *
-   * Classification reads the site's field definitions, which only the
-   * in-process driver exposes. On the Drush driver the values reach the
-   * command line as the scenario wrote them, so the pipeline leaves them
-   * alone rather than failing a creation the driver can carry out.
+   * The driver parses the values bag itself during creation, so this only
+   * brings that forward to the point where the scalar snapshot is taken. On
+   * the Drush driver the values reach the command line as the scenario wrote
+   * them, so the pipeline leaves them alone rather than failing a creation
+   * the driver can carry out.
    *
    * @param \DrevOps\BehatSteps\Driver\Entity\EntityStubInterface $stub
    *   The stub, mutated in place.
-   * @param array<int, string> $ignored_properties
-   *   Value names to leave untouched.
    */
-  protected function parseCreatedEntityFields(EntityStubInterface $stub, array $ignored_properties = []): void {
+  protected function parseCreatedEntityFields(EntityStubInterface $stub): void {
     if (!$this->getDriver() instanceof DrupalDriverInterface) {
       return;
     }
 
-    $this->parseEntityFields($stub, $ignored_properties);
-  }
-
-  /**
-   * Builds the entity-field parser for one parsing call.
-   *
-   * Override in the consuming context to swap in a custom implementation.
-   *
-   * @param string $entity_type
-   *   The entity type the values belong to.
-   * @param \DrevOps\BehatSteps\Driver\Core\Field\FieldClassifierInterface $classifier
-   *   The classifier resolving each value's field definition.
-   * @param string|null $bundle
-   *   The bundle, or NULL for an entity type without bundles.
-   */
-  protected function getFieldParser(string $entity_type, FieldClassifierInterface $classifier, ?string $bundle = NULL): EntityFieldParserInterface {
-    return new EntityFieldParser($entity_type, $classifier, $bundle);
+    $this->parseEntityFields($stub);
   }
 
   /**

--- a/src/Behat/Context/RawContext.php
+++ b/src/Behat/Context/RawContext.php
@@ -456,7 +456,14 @@ class RawContext extends RawMinkContext implements DriverAwareInterface {
     $vocabulary = $stub->getValue('vocabulary_machine_name');
 
     if (!empty($vocabulary)) {
-      $stub->setValue('vocabulary_machine_name', $this->resolveVocabularyMachineName((string) $vocabulary));
+      $vocabulary = $this->resolveVocabularyMachineName((string) $vocabulary);
+      $stub->setValue('vocabulary_machine_name', $vocabulary);
+
+      // Parsing below resolves the bundle from 'vid', so a stub that names its
+      // vocabulary only through the alias needs it seeded first.
+      if ($stub->getBundle() === NULL && !$stub->hasValue('vid')) {
+        $stub->setValue('vid', $vocabulary);
+      }
     }
 
     // The driver resolves 'parent' as a term name in the same vocabulary, so

--- a/src/Driver/Core/Core.php
+++ b/src/Driver/Core/Core.php
@@ -17,6 +17,8 @@ use DrevOps\BehatSteps\Driver\Core\Field\FieldClassifierInterface;
 use DrevOps\BehatSteps\Driver\Core\Field\FieldHandlerInterface;
 use DrevOps\BehatSteps\Driver\Core\Field\FieldShapeClassifier;
 use DrevOps\BehatSteps\Driver\Core\Field\FieldShapeClassifierInterface;
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\EntityFieldParser;
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\EntityFieldParserInterface;
 use DrevOps\BehatSteps\Driver\Entity\EntityStubInterface;
 use DrevOps\BehatSteps\Driver\Exception\BootstrapException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
@@ -260,6 +262,31 @@ class Core implements CoreInterface, AuthenticationCapabilityInterface, Creation
   /**
    * {@inheritdoc}
    */
+  public function getFieldParser(string $entity_type, ?string $bundle = NULL): EntityFieldParserInterface {
+    return new EntityFieldParser($entity_type, $this->getFieldClassifier(), $bundle);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function parseEntityFields(EntityStubInterface $stub, array $ignored_properties = []): void {
+    if ($stub->isParsed()) {
+      return;
+    }
+
+    $entity_type = $stub->getEntityType();
+    $aliases = array_keys($this->getCreationAliases($entity_type));
+
+    $parser = $this->getFieldParser($entity_type, $this->resolveBundle($stub));
+    $parser->ignoring(array_values(array_unique(array_merge($aliases, $ignored_properties))));
+
+    $stub->setValues($parser->parse($stub->getValues()));
+    $stub->markParsed();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getFieldHandler(EntityStubInterface $stub, string $entity_type, string $field_name): FieldHandlerInterface {
     $bundle = $this->resolveBundle($stub);
     $field_types = $this->getEntityFieldTypes($entity_type, $bundle);
@@ -485,6 +512,7 @@ class Core implements CoreInterface, AuthenticationCapabilityInterface, Creation
       $stub->setValue('type', $type);
     }
 
+    $this->parseEntityFields($stub);
     $this->applyPreCreateAliases($stub, 'node');
 
     $this->expandEntityFields($stub);
@@ -616,6 +644,7 @@ class Core implements CoreInterface, AuthenticationCapabilityInterface, Creation
       $stub->setValue('status', 1);
     }
 
+    $this->parseEntityFields($stub);
     $this->applyPreCreateAliases($stub, 'user');
 
     $this->expandEntityFields($stub);
@@ -871,6 +900,7 @@ class Core implements CoreInterface, AuthenticationCapabilityInterface, Creation
    * {@inheritdoc}
    */
   public function termCreate(EntityStubInterface $stub): EntityStubInterface {
+    $this->parseEntityFields($stub);
     $this->applyPreCreateAliases($stub, 'taxonomy_term');
 
     $vocabulary = $stub->getBundle() ?? $stub->getValue('vid');
@@ -1158,6 +1188,7 @@ class Core implements CoreInterface, AuthenticationCapabilityInterface, Creation
       }
     }
 
+    $this->parseEntityFields($stub);
     $this->expandEntityFields($stub);
     $created_entity = \Drupal::entityTypeManager()->getStorage($entity_type)->create($stub->getValues());
     $created_entity->save();

--- a/src/Driver/Core/Core.php
+++ b/src/Driver/Core/Core.php
@@ -900,7 +900,6 @@ class Core implements CoreInterface, AuthenticationCapabilityInterface, Creation
    * {@inheritdoc}
    */
   public function termCreate(EntityStubInterface $stub): EntityStubInterface {
-    $this->parseEntityFields($stub);
     $this->applyPreCreateAliases($stub, 'taxonomy_term');
 
     $vocabulary = $stub->getBundle() ?? $stub->getValue('vid');
@@ -915,6 +914,9 @@ class Core implements CoreInterface, AuthenticationCapabilityInterface, Creation
 
     $stub->setValue('vid', $vocabulary);
 
+    // Parse once 'vid' carries the vocabulary: the bundle the parser resolves
+    // from it is what makes bundle-scoped fields recognisable.
+    $this->parseEntityFields($stub);
     $this->expandEntityFields($stub);
     $entity = Term::create($stub->getValues());
     $entity->save();

--- a/src/Driver/Core/CoreInterface.php
+++ b/src/Driver/Core/CoreInterface.php
@@ -19,6 +19,7 @@ use DrevOps\BehatSteps\Driver\Capability\WatchdogCapabilityInterface;
 use DrevOps\BehatSteps\Driver\Core\Field\FieldClassifierInterface;
 use DrevOps\BehatSteps\Driver\Core\Field\FieldHandlerInterface;
 use DrevOps\BehatSteps\Driver\Core\Field\FieldShapeClassifierInterface;
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\EntityFieldParserInterface;
 use DrevOps\BehatSteps\Driver\Entity\EntityStubInterface;
 use Drupal\Component\Utility\Random;
 
@@ -161,5 +162,43 @@ interface CoreInterface extends
    *   The field shape classifier instance.
    */
   public function getFieldShapeClassifier(): FieldShapeClassifierInterface;
+
+  /**
+   * Returns a field parser bound to one entity type and bundle.
+   *
+   * Override in a 'Core' subclass to swap in a parser that reads a different
+   * cell grammar.
+   *
+   * @param string $entity_type
+   *   The entity type the values belong to.
+   * @param string|null $bundle
+   *   The bundle, or NULL for an entity type without bundles. Bundle-scoped
+   *   fields are only recognised when it is supplied.
+   *
+   * @return \DrevOps\BehatSteps\Driver\Core\Field\Parser\EntityFieldParserInterface
+   *   A parser instance.
+   */
+  public function getFieldParser(string $entity_type, ?string $bundle = NULL): EntityFieldParserInterface;
+
+  /**
+   * Expands a stub's raw cell values into the storage field shape.
+   *
+   * Values arrive as authored - a bare scalar, a comma-separated list, or a
+   * compound 'key:"value"' cell - and each is resolved against its own field
+   * definition. Creation-alias names are accepted without validation, so an
+   * alias key such as 'author' reaches its alias untouched. The stub is
+   * marked parsed, and a stub that is already marked is left alone.
+   *
+   * @param \DrevOps\BehatSteps\Driver\Entity\EntityStubInterface $stub
+   *   The stub, mutated in place.
+   * @param array<int, string> $ignored_properties
+   *   Further value names to accept without field-type validation.
+   *
+   * @throws \RuntimeException
+   *   When a value names no field on the entity type.
+   * @throws \DrevOps\BehatSteps\Driver\Core\Field\Parser\Exception\ParseException
+   *   When a cell does not match the grammar.
+   */
+  public function parseEntityFields(EntityStubInterface $stub, array $ignored_properties = []): void;
 
 }

--- a/src/Driver/Core/Field/Parser/EntityFieldParser.php
+++ b/src/Driver/Core/Field/Parser/EntityFieldParser.php
@@ -106,6 +106,19 @@ class EntityFieldParser implements EntityFieldParserInterface {
       $field_name = $multicolumn_field !== '' ? $multicolumn_field : $field;
 
       if ($this->fieldClassifier->fieldIsConfigurable($this->entityType, $field_name)) {
+        // Only text carries the cell grammar. A caller that assembled the
+        // records itself hands them to the field handlers as they are.
+        if (!$is_multicolumn && !is_string($field_value)) {
+          if ($field_value === NULL) {
+            unset($parsed[$field_name]);
+          }
+          else {
+            $parsed[$field_name] = $field_value;
+          }
+
+          continue;
+        }
+
         try {
           $records = $this->parseCell((string) $field_value, $is_multicolumn);
         }

--- a/src/Driver/Core/Field/Parser/Exception/MultipleParseException.php
+++ b/src/Driver/Core/Field/Parser/Exception/MultipleParseException.php
@@ -45,7 +45,9 @@ class MultipleParseException extends ParseException {
     $count = count($errors);
 
     if ($count === 1) {
-      return $errors[0]->description;
+      // Read by iteration order for the same reason the constructor does: the
+      // list may arrive with gaps in its keys.
+      return reset($errors)->description;
     }
 
     $codes = array_map(fn(ParseException $error): string => $error->errorCode, $errors);

--- a/src/Driver/Core/Field/README.md
+++ b/src/Driver/Core/Field/README.md
@@ -181,18 +181,25 @@ which likewise allows subclasses to extend registration per version.
 For reference, here is the complete flow when `entityCreate()` is called with
 a stub:
 
-1. `entityCreate($entity_type, $entity)` calls `expandEntityFields($entity_type, $entity)`.
-2. `expandEntityFields()` resolves the bundle from the stub and calls
+1. `entityCreate($stub)` calls `parseEntityFields($stub)`, which reads each
+   authored cell (`'a, b'`, `'uri: "https://example.com", title: "Example"'`)
+   against the field's own definition and replaces it with the records the
+   handlers expect. Creation-alias names are accepted without validation; a
+   value naming no field is rejected here. A value that is not text was
+   assembled by the caller and is left alone, as is a stub already marked
+   parsed.
+2. `entityCreate($stub)` calls `expandEntityFields($stub)`.
+3. `expandEntityFields()` resolves the bundle from the stub and calls
    `getEntityFieldTypes($entity_type, $bundle)`.
-3. `getEntityFieldTypes()` iterates `getFieldStorageDefinitions()`,
+4. `getEntityFieldTypes()` iterates `getFieldStorageDefinitions()`,
    `getBaseFieldDefinitions()`, and per-bundle definitions (when a bundle is
    known). Each field is kept iff `fieldIsBaseStandard()`,
    `fieldIsConfigurable()`, or `fieldIsBundleStorageBacked()` is TRUE.
-4. `expandEntityFields()` iterates the returned map and, for each field whose
+5. `expandEntityFields()` iterates the returned map and, for each field whose
    name is also set as a property on the stub, calls `getFieldHandler()` to
    resolve a typed handler by field-type string (falling back to
    `DefaultHandler`). The handler's `expand()` transforms the stub value
    into Drupal's storage shape.
-5. Fields not in the returned map (F2/F3/F4/F6/F7/F8) keep their original
+6. Fields not in the returned map (F2/F3/F4/F6/F7/F8) keep their original
    stub values. The entity constructor receives the full stub as an array;
    Drupal's field classes and storage layer take over from there.

--- a/src/Driver/Entity/EntityStub.php
+++ b/src/Driver/Entity/EntityStub.php
@@ -26,6 +26,11 @@ final class EntityStub implements EntityStubInterface {
   protected string $bundleKey = self::DEFAULT_BUNDLE_KEY;
 
   /**
+   * Whether the values bag has been through the field parser.
+   */
+  protected bool $parsed = FALSE;
+
+  /**
    * Set up the stub.
    *
    * @param string $entityType
@@ -116,6 +121,22 @@ final class EntityStub implements EntityStubInterface {
    */
   public function setValues(array $values): self {
     $this->values = $values;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isParsed(): bool {
+    return $this->parsed;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function markParsed(): self {
+    $this->parsed = TRUE;
 
     return $this;
   }

--- a/src/Driver/Entity/EntityStubInterface.php
+++ b/src/Driver/Entity/EntityStubInterface.php
@@ -97,6 +97,21 @@ interface EntityStubInterface {
   public function setValues(array $values): self;
 
   /**
+   * Returns TRUE once 'markParsed()' has been called.
+   */
+  public function isParsed(): bool;
+
+  /**
+   * Records that the values bag has been through the field parser.
+   *
+   * Parsing is not idempotent - a parsed cell is a structured value the
+   * grammar cannot read a second time - so a caller that parses ahead of
+   * the driver marks the stub and the driver's create path skips its own
+   * parse.
+   */
+  public function markParsed(): self;
+
+  /**
    * Returns TRUE once the driver has called 'markSaved()'.
    */
   public function isSaved(): bool;

--- a/src/Steps/Drupal/HelperTrait.php
+++ b/src/Steps/Drupal/HelperTrait.php
@@ -85,7 +85,7 @@ trait HelperTrait {
         continue;
       }
 
-      // Parsed shapes produced by 'EntityFieldParser' or the legacy parser:
+      // Parsed shapes produced by 'EntityFieldParser':
       // - scalar: 'foo.jpg' (treated as single-value)
       // - scalar list: ['foo.jpg', 'bar.jpg'] (multi-value)
       // - keyed record: ['target_id' => 'foo.jpg', 'alt' => 'A'] (single compound)

--- a/tests/phpunit/src/Kernel/Behat/Context/RawContextVocabularyKernelTest.php
+++ b/tests/phpunit/src/Kernel/Behat/Context/RawContextVocabularyKernelTest.php
@@ -74,6 +74,52 @@ class RawContextVocabularyKernelTest extends KernelTestBase {
   }
 
   /**
+   * Tests that a bundle-less term stub carries the vocabulary on 'vid'.
+   */
+  public function testTermCreationSeedsTheVocabularyForFieldParsing(): void {
+    $stub = new EntityStub('taxonomy_term', NULL, ['name' => 'A term', 'vocabulary_machine_name' => 'Tags']);
+
+    $driver = $this->createMockForIntersectionOfInterfaces([DriverInterface::class, ContentCapabilityInterface::class]);
+    $driver->method('termCreate')->willReturn($stub);
+
+    $environment = $this->createMock(Environment::class);
+
+    $driver_manager = $this->createMock(DriverManagerInterface::class);
+    $driver_manager->method('getDriver')->willReturn($driver);
+    $driver_manager->method('getEnvironment')->willReturn($environment);
+
+    $this->context->setDriverManager($driver_manager);
+    $this->context->setDispatcher(new HookDispatcher(new HookRepository(new EnvironmentManager()), new CallCenter()));
+
+    $this->context->termCreate($stub);
+
+    $this->assertSame('tags', $stub->getValue('vid'));
+  }
+
+  /**
+   * Tests that a stub carrying its own 'vid' keeps it.
+   */
+  public function testTermCreationKeepsAnExplicitVocabulary(): void {
+    $stub = new EntityStub('taxonomy_term', NULL, ['name' => 'A term', 'vid' => 'tags', 'vocabulary_machine_name' => 'Tags']);
+
+    $driver = $this->createMockForIntersectionOfInterfaces([DriverInterface::class, ContentCapabilityInterface::class]);
+    $driver->method('termCreate')->willReturn($stub);
+
+    $environment = $this->createMock(Environment::class);
+
+    $driver_manager = $this->createMock(DriverManagerInterface::class);
+    $driver_manager->method('getDriver')->willReturn($driver);
+    $driver_manager->method('getEnvironment')->willReturn($environment);
+
+    $this->context->setDriverManager($driver_manager);
+    $this->context->setDispatcher(new HookDispatcher(new HookRepository(new EnvironmentManager()), new CallCenter()));
+
+    $this->context->termCreate($stub);
+
+    $this->assertSame('tags', $stub->getValue('vid'));
+  }
+
+  /**
    * Tests that term creation resolves the label before calling the driver.
    */
   public function testTermCreationResolvesTheVocabularyLabel(): void {

--- a/tests/phpunit/src/Kernel/Driver/Core/CoreEntityParseKernelTest.php
+++ b/tests/phpunit/src/Kernel/Driver/Core/CoreEntityParseKernelTest.php
@@ -194,6 +194,33 @@ class CoreEntityParseKernelTest extends KernelTestBase {
   }
 
   /**
+   * Tests that a term's vocabulary is resolved before its fields are parsed.
+   */
+  public function testTermVocabularyIsResolvedBeforeParsing(): void {
+    $this->enableModules(['taxonomy']);
+    $this->installEntitySchema('taxonomy_term');
+
+    \Drupal::entityTypeManager()->getStorage('taxonomy_vocabulary')->create(['vid' => 'tags', 'name' => 'Tags'])->save();
+
+    FieldStorageConfig::create(['field_name' => 'field_note', 'entity_type' => 'taxonomy_term', 'type' => 'string', 'cardinality' => 2])->save();
+    FieldConfig::create(['field_name' => 'field_note', 'entity_type' => 'taxonomy_term', 'bundle' => 'tags'])->save();
+
+    // The vocabulary reaches the driver only through the creation alias, so
+    // the bundle is unknown until the alias has run.
+    $stub = new EntityStub('taxonomy_term', NULL, [
+      'name' => 'A term',
+      'vocabulary_machine_name' => 'tags',
+      'field_note' => 'alpha, beta',
+    ]);
+
+    $this->core->termCreate($stub);
+
+    $term = Term::load($stub->getValue('tid'));
+    $this->assertInstanceOf(Term::class, $term);
+    $this->assertSame([['value' => 'alpha'], ['value' => 'beta']], $term->get('field_note')->getValue());
+  }
+
+  /**
    * Tests that a user stub is parsed on its own create path.
    */
   public function testUserStubIsParsedByTheDriver(): void {

--- a/tests/phpunit/src/Kernel/Driver/Core/CoreEntityParseKernelTest.php
+++ b/tests/phpunit/src/Kernel/Driver/Core/CoreEntityParseKernelTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests\Kernel\Driver\Core;
+
+use DrevOps\BehatSteps\Driver\Core\Core;
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\EntityFieldParserInterface;
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\Exception\ParseException;
+use DrevOps\BehatSteps\Driver\Entity\EntityStub;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Kernel test for cell parsing inside the driver's create paths.
+ *
+ * Drives Core directly, with no Behat context in play, so a cell written in
+ * the compound grammar has to reach storage through the driver alone.
+ *
+ * @group core
+ * @group fields
+ */
+#[CoversClass(Core::class)]
+#[Group('core')]
+#[Group('fields')]
+class CoreEntityParseKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * @var array<string>
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'field',
+    'text',
+    'filter',
+  ];
+
+  /**
+   * The Core driver under test.
+   */
+  protected Core $core;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['system', 'user', 'node', 'filter', 'field']);
+
+    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+
+    $this->attachField('field_body', 'text_long', 1);
+    $this->attachField('field_keyword', 'string', 3);
+
+    $this->core = new Core($this->root);
+  }
+
+  /**
+   * Tests that a compound cell reaches storage through the driver alone.
+   */
+  public function testCompoundCellIsParsedByTheDriver(): void {
+    $stub = new EntityStub('node', 'article', [
+      'title' => 'A node',
+      'field_body' => 'value: "Body text", format: "plain_text"',
+    ]);
+
+    $this->core->nodeCreate($stub);
+
+    $node = Node::load($stub->getValue('nid'));
+    $this->assertInstanceOf(Node::class, $node);
+    $this->assertSame([['value' => 'Body text', 'format' => 'plain_text']], $node->get('field_body')->getValue());
+  }
+
+  /**
+   * Tests that a comma-separated cell becomes one delta per item.
+   */
+  public function testCommaSeparatedCellBecomesSeveralDeltas(): void {
+    $stub = new EntityStub('node', 'article', [
+      'title' => 'A node',
+      'field_keyword' => 'alpha, "beta, gamma"',
+    ]);
+
+    $this->core->nodeCreate($stub);
+
+    $node = Node::load($stub->getValue('nid'));
+    $this->assertInstanceOf(Node::class, $node);
+    $this->assertSame([['value' => 'alpha'], ['value' => 'beta, gamma']], $node->get('field_keyword')->getValue());
+  }
+
+  /**
+   * Tests that a creation-alias key is accepted without field validation.
+   */
+  public function testCreationAliasKeyIsNotValidatedAsField(): void {
+    User::create(['name' => 'author_of_record', 'status' => 1])->save();
+
+    $stub = new EntityStub('node', 'article', ['title' => 'A node', 'author' => 'author_of_record']);
+
+    $this->core->nodeCreate($stub);
+
+    $node = Node::load($stub->getValue('nid'));
+    $this->assertInstanceOf(Node::class, $node);
+    $this->assertSame('author_of_record', $node->getOwner()->getAccountName());
+  }
+
+  /**
+   * Tests that a value naming no field is rejected during creation.
+   */
+  public function testAnUnknownFieldIsRejectedDuringCreation(): void {
+    $stub = new EntityStub('node', 'article', ['title' => 'A node', 'field_absent' => 'a']);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Field "field_absent" does not exist on entity type "node".');
+
+    $this->core->nodeCreate($stub);
+  }
+
+  /**
+   * Tests that a malformed cell is rejected during creation.
+   */
+  public function testMalformedCellIsRejectedDuringCreation(): void {
+    $stub = new EntityStub('node', 'article', ['title' => 'A node', 'field_body' => 'value: "Body text", format: bare']);
+
+    $this->expectException(ParseException::class);
+
+    $this->core->nodeCreate($stub);
+  }
+
+  /**
+   * Tests that parsing runs once, however many times it is asked for.
+   */
+  public function testParsedStubIsLeftAlone(): void {
+    $stub = new EntityStub('node', 'article', [
+      'title' => 'A node',
+      'field_keyword' => 'alpha, beta',
+    ]);
+
+    $this->core->parseEntityFields($stub);
+    $this->assertTrue($stub->isParsed());
+    $this->assertSame(['alpha', 'beta'], $stub->getValue('field_keyword'));
+
+    $this->core->parseEntityFields($stub);
+    $this->assertSame(['alpha', 'beta'], $stub->getValue('field_keyword'));
+
+    $this->core->nodeCreate($stub);
+
+    $node = Node::load($stub->getValue('nid'));
+    $this->assertInstanceOf(Node::class, $node);
+    $this->assertSame([['value' => 'alpha'], ['value' => 'beta']], $node->get('field_keyword')->getValue());
+  }
+
+  /**
+   * Tests that the caller can widen the accepted property names.
+   */
+  public function testCallerSuppliedPropertiesAreAccepted(): void {
+    $stub = new EntityStub('node', 'article', ['title' => 'A node', 'custom_hint' => 'a']);
+
+    $this->core->parseEntityFields($stub, ['custom_hint']);
+
+    $this->assertSame('a', $stub->getValue('custom_hint'));
+  }
+
+  /**
+   * Tests that a term stub is parsed on its own create path.
+   */
+  public function testTermCellIsParsedByTheDriver(): void {
+    $this->enableModules(['taxonomy']);
+    $this->installEntitySchema('taxonomy_term');
+
+    $stub = new EntityStub('taxonomy_term', 'tags', ['name' => 'A term', 'vocabulary_machine_name' => 'tags']);
+
+    \Drupal::entityTypeManager()->getStorage('taxonomy_vocabulary')->create(['vid' => 'tags', 'name' => 'Tags'])->save();
+
+    $this->core->termCreate($stub);
+
+    $term = Term::load($stub->getValue('tid'));
+    $this->assertInstanceOf(Term::class, $term);
+    $this->assertTrue($stub->isParsed());
+    $this->assertSame('A term', $term->label());
+  }
+
+  /**
+   * Tests that a user stub is parsed on its own create path.
+   */
+  public function testUserStubIsParsedByTheDriver(): void {
+    $stub = new EntityStub('user', NULL, ['name' => 'a_user', 'mail' => 'a@example.com']);
+
+    $this->core->userCreate($stub);
+
+    $user = User::load($stub->getValue('uid'));
+    $this->assertInstanceOf(User::class, $user);
+    $this->assertTrue($stub->isParsed());
+    $this->assertSame('a_user', $user->getAccountName());
+  }
+
+  /**
+   * Tests that the parser factory binds the entity type it is handed.
+   */
+  public function testTheParserFactoryBindsTheEntityType(): void {
+    $parser = $this->core->getFieldParser('node', 'article');
+
+    $this->assertInstanceOf(EntityFieldParserInterface::class, $parser);
+    $this->assertSame(['field_keyword' => ['alpha']], $parser->parse(['field_keyword' => 'alpha']));
+  }
+
+  /**
+   * Attaches a field to the article bundle.
+   */
+  protected function attachField(string $field_name, string $type, int $cardinality): void {
+    FieldStorageConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => 'node',
+      'type' => $type,
+      'cardinality' => $cardinality,
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => 'node',
+      'bundle' => 'article',
+    ])->save();
+  }
+
+}

--- a/tests/phpunit/src/Unit/Behat/Context/RawContextTest.php
+++ b/tests/phpunit/src/Unit/Behat/Context/RawContextTest.php
@@ -26,6 +26,7 @@ use DrevOps\BehatSteps\Driver\Capability\ContentCapabilityInterface;
 use DrevOps\BehatSteps\Driver\Capability\LanguageCapabilityInterface;
 use DrevOps\BehatSteps\Driver\Capability\RoleCapabilityInterface;
 use DrevOps\BehatSteps\Driver\Capability\UserCapabilityInterface;
+use DrevOps\BehatSteps\Driver\Core\CoreInterface;
 use DrevOps\BehatSteps\Driver\DriverInterface;
 use DrevOps\BehatSteps\Driver\DrupalDriver;
 use DrevOps\BehatSteps\Driver\DrupalDriverInterface;
@@ -628,6 +629,27 @@ class RawContextTest extends UnitTestCase {
     $driver->method('isBootstrapped')->willReturn(TRUE);
 
     $this->assertSame($driver, $this->createContext($driver)->assertDrupal());
+  }
+
+  public function testFieldParsingIsHandedToTheDriver(): void {
+    $stub = new EntityStub('node', 'page', ['title' => 'A title']);
+
+    $core = $this->createMock(CoreInterface::class);
+    $core->expects($this->once())->method('parseEntityFields')->with($stub, ['author']);
+
+    $driver = $this->createMock(DrupalDriverInterface::class);
+    $driver->method('isBootstrapped')->willReturn(TRUE);
+    $driver->method('getCore')->willReturn($core);
+
+    $this->createContext($driver)->parseEntityFields($stub, ['author']);
+  }
+
+  public function testFieldParsingIsSkippedOnDriverThatCannotClassify(): void {
+    $stub = new EntityStub('node', 'page', ['field_a' => 'a, b']);
+
+    $this->createContext($this->createContentDriver())->nodeCreate($stub);
+
+    $this->assertSame('a, b', $stub->getValue('field_a'));
   }
 
   public function testStringTimestampIsConvertedForInProcessDriver(): void {

--- a/tests/phpunit/src/Unit/Driver/Core/Field/Parser/EntityFieldParserTest.php
+++ b/tests/phpunit/src/Unit/Driver/Core/Field/Parser/EntityFieldParserTest.php
@@ -1,0 +1,489 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests\Unit\Driver\Core\Field\Parser;
+
+use DrevOps\BehatSteps\Driver\Core\Field\FieldClassifierInterface;
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\EntityFieldParser;
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\Exception\MultipleParseException;
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\Exception\ParseException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the entity-field cell grammar.
+ *
+ * @group core
+ * @group fields
+ */
+#[CoversClass(EntityFieldParser::class)]
+#[Group('core')]
+#[Group('fields')]
+class EntityFieldParserTest extends TestCase {
+
+  /**
+   * The classifier predicates that admit a field without configurable storage.
+   *
+   * @var array<int, string>
+   */
+  protected const BASE_PREDICATES = [
+    'fieldIsBaseStandard',
+    'fieldIsBaseComputedReadOnly',
+    'fieldIsBaseComputedWritable',
+    'fieldIsBaseCustomStorage',
+  ];
+
+  /**
+   * The classifier predicates that need a bundle to answer.
+   *
+   * @var array<int, string>
+   */
+  protected const BUNDLE_PREDICATES = [
+    'fieldIsBundleComputedReadOnly',
+    'fieldIsBundleComputedWritable',
+    'fieldIsBundleCustomStorage',
+    'fieldIsBundleStorageBacked',
+  ];
+
+  /**
+   * Tests scalar cells: bare values, lists, quoting and escapes.
+   *
+   * @param string $cell
+   *   The cell as authored.
+   * @param array<int, string> $expected
+   *   The items the cell resolves to.
+   */
+  #[DataProvider('dataProviderScalarCell')]
+  public function testScalarCell(string $cell, array $expected): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    $this->assertSame(['field_a' => $expected], $parser->parse(['field_a' => $cell]));
+  }
+
+  /**
+   * Data provider for scalar cells.
+   *
+   * @return array<string, array{string, array<int, string>}>
+   *   Cell text and the expected items.
+   */
+  public static function dataProviderScalarCell(): array {
+    return [
+      'bare value' => ['Hello', ['Hello']],
+      'surrounding whitespace' => ['  Hello  ', ['Hello']],
+      'comma list' => ['a, b, c', ['a', 'b', 'c']],
+      'comma list without spaces' => ['a,b', ['a', 'b']],
+      'trailing comma yields an empty item' => ['a,', ['a', '']],
+      'quoted item keeps its comma' => ['"a, b", c', ['a, b', 'c']],
+      'quoted item keeps its semicolon' => ['"a; b"', ['a; b']],
+      'quoted item keeps its whitespace' => ['"  padded  "', ['  padded  ']],
+      'escaped quote' => ['"say \\"hi\\""', ['say "hi"']],
+      'escaped backslash' => ['"a\\\\b"', ['a\\b']],
+      'escaped newline, tab and return' => ['"a\\nb\\tc\\rd"', ["a\nb\tc\rd"]],
+      'quote inside an unquoted item is literal' => ['<a href="x">y</a>', ['<a href="x">y</a>']],
+      'whitespace-only cell' => ['   ', ['']],
+      'bracketed token stays verbatim' => ['[node:1]', ['[node:1]']],
+      'quoted compound-looking text stays scalar' => ['"uri:\\"https://example.com\\""', ['uri:"https://example.com"']],
+    ];
+  }
+
+  /**
+   * Tests compound cells: records, columns, tokens and whitespace.
+   *
+   * @param string $cell
+   *   The cell as authored.
+   * @param array<int, array<string, string>> $expected
+   *   The records the cell resolves to.
+   */
+  #[DataProvider('dataProviderCompoundCell')]
+  public function testCompoundCell(string $cell, array $expected): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    $this->assertSame(['field_a' => $expected], $parser->parse(['field_a' => $cell]));
+  }
+
+  /**
+   * Data provider for compound cells.
+   *
+   * @return array<string, array{string, array<int, array<string, string>>}>
+   *   Cell text and the expected records.
+   */
+  public static function dataProviderCompoundCell(): array {
+    return [
+      'single column' => ['uri: "https://example.com"', [['uri' => 'https://example.com']]],
+      'two columns' => ['uri: "https://example.com", title: "Example"', [['uri' => 'https://example.com', 'title' => 'Example']]],
+      'no whitespace' => ['uri:"a",title:"b"', [['uri' => 'a', 'title' => 'b']]],
+      'generous whitespace' => ["uri \t: \t\"a\" ,  title : \"b\"", [['uri' => 'a', 'title' => 'b']]],
+      'two records' => ['uri: "a"; uri: "b"', [['uri' => 'a'], ['uri' => 'b']]],
+      'token value' => ['target_id: [node:1]', [['target_id' => '[node:1]']]],
+      'token and string columns' => ['target_id: [node:1], alt: "A"', [['target_id' => '[node:1]', 'alt' => 'A']]],
+      'separators inside a quoted value' => ['title: "a, b; c"', [['title' => 'a, b; c']]],
+      'separators inside a token' => ['target_id: [node:a,b]', [['target_id' => '[node:a,b]']]],
+      'escapes inside a column value' => ['title: "a\\nb"', [['title' => "a\nb"]]],
+      'underscored column names' => ['end_value: "2020-01-01"', [['end_value' => '2020-01-01']]],
+      'repeated column keeps the last' => ['uri: "a", uri: "b"', [['uri' => 'b']]],
+    ];
+  }
+
+  /**
+   * Tests that a malformed cell reports its error code and offset.
+   */
+  #[DataProvider('dataProviderCellError')]
+  public function testCellError(string $cell, string $expected_code, int $expected_offset): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    try {
+      $parser->parse(['field_a' => $cell]);
+      $this->fail('Expected a ParseException.');
+    }
+    catch (ParseException $e) {
+      $this->assertSame($expected_code, $e->errorCode);
+      $this->assertSame($expected_offset, $e->offset);
+      $this->assertSame($cell, $e->cell);
+    }
+  }
+
+  /**
+   * Data provider for malformed cells.
+   *
+   * @return array<string, array{string, string, int}>
+   *   Cell text, the expected error code and the expected offset.
+   */
+  public static function dataProviderCellError(): array {
+    return [
+      'semicolon in an unquoted item' => ['a; b', 'unquoted_semicolon', 1],
+      'unterminated quote' => ['"abc', 'unclosed_quote', 0],
+      'dangling backslash' => ['"abc\\', 'unclosed_quote', 0],
+      'unknown escape' => ['"a\\q"', 'unknown_escape', 2],
+      'character after a closing quote' => ['"a"b', 'unexpected_character', 3],
+      'bare compound value' => ['uri: "a", title: bare', 'unquoted_compound_value', 17],
+      'compound column without a value' => ['uri: "a", title:', 'unquoted_compound_value', 16],
+      'compound column that is not a pair' => ['uri: "a", title', 'invalid_column', 10],
+      'empty compound record' => ['uri: "a";; uri: "b"', 'empty_record', 9],
+      'empty compound column' => ['uri: "a",, title: "b"', 'empty_column', 9],
+      'characters after a column quote' => ['uri: "a"x, title: "b"', 'trailing_characters', 8],
+      'characters after a column token' => ['uri: [node:1]x, title: "b"', 'trailing_characters', 13],
+      'unclosed token in a column' => ['uri: [node:1, title: "b"', 'unclosed_token', 5],
+      'unclosed quote in a column' => ['uri: "a, title: b', 'unclosed_quote', 5],
+      'column quote that closes early' => ['uri: "a, title: "b"', 'trailing_characters', 17],
+    ];
+  }
+
+  /**
+   * Tests that every error in one cell is reported together.
+   */
+  public function testAllErrorsInOneCellAreReportedTogether(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    try {
+      $parser->parse(['field_a' => 'alt: "a", uri: bare, title: also_bare']);
+      $this->fail('Expected a MultipleParseException.');
+    }
+    catch (MultipleParseException $e) {
+      $this->assertCount(2, $e->errors);
+      $this->assertStringContainsString('2 parse errors', $e->getMessage());
+    }
+  }
+
+  /**
+   * Tests that every failing record in one cell is reported together.
+   */
+  public function testAllFailingRecordsAreReportedTogether(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    try {
+      $parser->parse(['field_a' => 'uri: "a"; uri: bare; uri: also_bare']);
+      $this->fail('Expected a MultipleParseException.');
+    }
+    catch (MultipleParseException $e) {
+      $this->assertCount(2, $e->errors);
+    }
+  }
+
+  /**
+   * Tests that errors from different cells are reported together.
+   */
+  public function testErrorsFromSeveralCellsAreReportedTogether(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a', 'field_b']));
+
+    try {
+      $parser->parse(['field_a' => '"unclosed', 'field_b' => 'a; b']);
+      $this->fail('Expected a MultipleParseException.');
+    }
+    catch (MultipleParseException $e) {
+      $this->assertCount(2, $e->errors);
+      $this->assertSame('unclosed_quote', $e->errors[0]->errorCode);
+      $this->assertSame('unquoted_semicolon', $e->errors[1]->errorCode);
+      $this->assertSame('"unclosed', $e->cell);
+    }
+  }
+
+  /**
+   * Tests that a lone failing cell throws its own exception unwrapped.
+   */
+  public function testSingleFailingCellThrowsItsOwnException(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a', 'field_b']));
+
+    try {
+      $parser->parse(['field_a' => 'fine', 'field_b' => '"unclosed']);
+      $this->fail('Expected a ParseException.');
+    }
+    catch (ParseException $e) {
+      $this->assertNotInstanceOf(MultipleParseException::class, $e);
+      $this->assertSame('unclosed_quote', $e->errorCode);
+    }
+  }
+
+  /**
+   * Tests that an empty configurable cell leaves the field unset.
+   */
+  #[DataProvider('dataProviderAnEmptyConfigurableValueIsDropped')]
+  public function testAnEmptyConfigurableValueIsDropped(mixed $value): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    $this->assertSame([], $parser->parse(['field_a' => $value]));
+  }
+
+  /**
+   * Data provider for empty configurable values.
+   *
+   * @return array<string, array{mixed}>
+   *   The value written into the cell.
+   */
+  public static function dataProviderAnEmptyConfigurableValueIsDropped(): array {
+    return [
+      'empty string' => [''],
+      'null' => [NULL],
+    ];
+  }
+
+  /**
+   * Tests that a value carrying no cell grammar is handed on untouched.
+   */
+  #[DataProvider('dataProviderAnAssembledValueIsNotParsed')]
+  public function testAnAssembledValueIsNotParsed(mixed $value): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    $this->assertSame(['field_a' => $value], $parser->parse(['field_a' => $value]));
+  }
+
+  /**
+   * Data provider for values a caller assembled itself.
+   *
+   * @return array<string, array{mixed}>
+   *   The value written into the cell.
+   */
+  public static function dataProviderAnAssembledValueIsNotParsed(): array {
+    return [
+      'list of scalars' => [['alpha', 'beta']],
+      'single record' => [['uri' => 'https://example.com', 'title' => 'Example']],
+      'list of records' => [[['uri' => 'https://example.com']]],
+      'integer' => [7],
+      'boolean' => [TRUE],
+    ];
+  }
+
+  /**
+   * Tests that a base field's value reaches the entity untouched.
+   */
+  #[DataProvider('dataProviderBaseFieldValueIsNotParsed')]
+  public function testBaseFieldValueIsNotParsed(string $predicate): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier([], $predicate));
+
+    $this->assertSame(['title' => 'a, b'], $parser->parse(['title' => 'a, b']));
+  }
+
+  /**
+   * Data provider for the base-field predicates.
+   *
+   * @return array<string, array{string}>
+   *   The predicate that answers TRUE for the field.
+   */
+  public static function dataProviderBaseFieldValueIsNotParsed(): array {
+    return [
+      'standard' => ['fieldIsBaseStandard'],
+      'computed read-only' => ['fieldIsBaseComputedReadOnly'],
+      'computed writable' => ['fieldIsBaseComputedWritable'],
+      'custom storage' => ['fieldIsBaseCustomStorage'],
+    ];
+  }
+
+  /**
+   * Tests that a bundle-scoped field is known once the bundle is supplied.
+   */
+  #[DataProvider('dataProviderBundleFieldIsKnownWhenTheBundleIsSupplied')]
+  public function testBundleFieldIsKnownWhenTheBundleIsSupplied(string $predicate): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier([], $predicate), 'article');
+
+    $this->assertSame(['field_a' => 'a, b'], $parser->parse(['field_a' => 'a, b']));
+  }
+
+  /**
+   * Data provider for the bundle-scoped predicates.
+   *
+   * @return array<string, array{string}>
+   *   The predicate that answers TRUE for the field.
+   */
+  public static function dataProviderBundleFieldIsKnownWhenTheBundleIsSupplied(): array {
+    return [
+      'computed read-only' => ['fieldIsBundleComputedReadOnly'],
+      'computed writable' => ['fieldIsBundleComputedWritable'],
+      'custom storage' => ['fieldIsBundleCustomStorage'],
+      'storage backed' => ['fieldIsBundleStorageBacked'],
+    ];
+  }
+
+  /**
+   * Tests that a bundle-scoped field is unknown without a bundle.
+   */
+  #[DataProvider('dataProviderBundleFieldIsUnknownWithoutBundle')]
+  public function testBundleFieldIsUnknownWithoutBundle(string $predicate): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier([], $predicate));
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Field "field_a" does not exist on entity type "node".');
+
+    $parser->parse(['field_a' => 'a']);
+  }
+
+  /**
+   * Data provider for the bundle-scoped predicates.
+   *
+   * @return array<string, array{string}>
+   *   The predicate that answers TRUE for the field.
+   */
+  public static function dataProviderBundleFieldIsUnknownWithoutBundle(): array {
+    return self::dataProviderBundleFieldIsKnownWhenTheBundleIsSupplied();
+  }
+
+  /**
+   * Tests that a field belonging to no classification is rejected.
+   */
+  public function testAnUnknownFieldIsRejected(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier());
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Field "field_a" does not exist on entity type "node".');
+
+    $parser->parse(['field_a' => 'a']);
+  }
+
+  /**
+   * Tests that an ignored property is accepted without classification.
+   */
+  public function testAnIgnoredPropertyIsAccepted(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier());
+
+    $this->assertSame(['author' => 'alice'], $parser->ignoring(['author'])->parse(['author' => 'alice']));
+  }
+
+  /**
+   * Tests that the ignore list is fluent.
+   */
+  public function testIgnoringReturnsTheParser(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier());
+
+    $this->assertSame($parser, $parser->ignoring(['author']));
+  }
+
+  /**
+   * Tests that a 'field:column' header merges into one compound field.
+   */
+  public function testMulticolumnHeaderBuildsOneRecord(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    $parsed = $parser->parse(['field_a:value' => 'Body text', ':format' => 'full_html']);
+
+    $this->assertSame(['field_a' => [['value' => 'Body text', 'format' => 'full_html']]], $parsed);
+  }
+
+  /**
+   * Tests that a multicolumn header pairs its columns delta by delta.
+   */
+  public function testMulticolumnHeaderPairsColumnsByDelta(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    $parsed = $parser->parse(['field_a:value' => 'one, two', ':format' => 'plain, full_html']);
+
+    $this->assertSame(['field_a' => [['value' => 'one', 'format' => 'plain'], ['value' => 'two', 'format' => 'full_html']]], $parsed);
+  }
+
+  /**
+   * Tests that a second 'field:column' header opens a new field.
+   */
+  public function testSecondMulticolumnHeaderOpensNewField(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a', 'field_b']));
+
+    $parsed = $parser->parse(['field_a:value' => 'a', 'field_b:value' => 'b']);
+
+    $this->assertSame(['field_a' => [['value' => 'a']], 'field_b' => [['value' => 'b']]], $parsed);
+  }
+
+  /**
+   * Tests that a plain header closes the preceding multicolumn field.
+   */
+  public function testPlainHeaderClosesTheMulticolumnField(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a', 'field_b']));
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Field name missing for :format');
+
+    $parser->parse(['field_a:value' => 'a', 'field_b' => 'b', ':format' => 'plain']);
+  }
+
+  /**
+   * Tests that a column continuation without a preceding field is rejected.
+   */
+  public function testAnOrphanColumnContinuationIsRejected(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['field_a']));
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Field name missing for :format');
+
+    $parser->parse([':format' => 'full_html']);
+  }
+
+  /**
+   * Tests that a multicolumn header on a base field is left as authored.
+   */
+  public function testMulticolumnHeaderOnBaseFieldIsNotParsed(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier([], 'fieldIsBaseStandard'));
+
+    $this->assertSame(['title:value' => 'a, b'], $parser->parse(['title:value' => 'a, b']));
+  }
+
+  /**
+   * Tests that a numeric header is read as a field name.
+   */
+  public function testNumericHeaderIsReadAsFieldName(): void {
+    $parser = new EntityFieldParser('node', $this->createClassifier(['0']));
+
+    $this->assertSame(['0' => ['a']], $parser->parse(['a']));
+  }
+
+  /**
+   * Builds a classifier that admits the named fields and predicate.
+   *
+   * @param array<int, string> $configurable
+   *   Field names 'fieldIsConfigurable()' answers TRUE for.
+   * @param string $true_predicate
+   *   The single other predicate that answers TRUE for every field name.
+   *   Empty for a classifier that recognises nothing else.
+   */
+  protected function createClassifier(array $configurable = [], string $true_predicate = ''): FieldClassifierInterface {
+    $classifier = $this->createMock(FieldClassifierInterface::class);
+
+    $classifier->method('fieldIsConfigurable')->willReturnCallback(
+      static fn(string $entity_type, string $field_name): bool => in_array($field_name, $configurable, TRUE)
+    );
+
+    foreach (array_merge(self::BASE_PREDICATES, self::BUNDLE_PREDICATES) as $predicate) {
+      $classifier->method($predicate)->willReturn($predicate === $true_predicate);
+    }
+
+    return $classifier;
+  }
+
+}

--- a/tests/phpunit/src/Unit/Driver/Core/Field/Parser/Exception/MultipleParseExceptionTest.php
+++ b/tests/phpunit/src/Unit/Driver/Core/Field/Parser/Exception/MultipleParseExceptionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests\Unit\Driver\Core\Field\Parser\Exception;
+
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\Exception\MultipleParseException;
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\Exception\ParseException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the aggregate parse error.
+ *
+ * @group core
+ * @group fields
+ */
+#[CoversClass(MultipleParseException::class)]
+#[Group('core')]
+#[Group('fields')]
+class MultipleParseExceptionTest extends TestCase {
+
+  /**
+   * Tests that several errors are summarised by their codes.
+   */
+  public function testSeveralErrorsAreSummarisedByCode(): void {
+    $errors = [
+      new ParseException('unclosed_quote', 0, 'a', 'First problem.'),
+      new ParseException('unknown_escape', 4, 'a', 'Second problem.'),
+    ];
+
+    $exception = new MultipleParseException($errors, 'the cell');
+
+    $this->assertSame('2 parse errors: unclosed_quote, unknown_escape', $exception->description);
+    $this->assertSame($errors, $exception->errors);
+  }
+
+  /**
+   * Tests that the first error supplies the code and offset.
+   */
+  public function testTheFirstErrorSuppliesTheCodeAndOffset(): void {
+    $exception = new MultipleParseException([
+      new ParseException('unclosed_quote', 7, 'a', 'First problem.'),
+      new ParseException('unknown_escape', 4, 'a', 'Second problem.'),
+    ], 'the cell');
+
+    $this->assertSame('unclosed_quote', $exception->errorCode);
+    $this->assertSame(7, $exception->offset);
+    $this->assertSame('the cell', $exception->cell);
+  }
+
+  /**
+   * Tests that a lone error contributes its own description.
+   */
+  public function testLoneErrorKeepsItsDescription(): void {
+    $exception = new MultipleParseException([new ParseException('unclosed_quote', 0, 'a', 'Only problem.')], 'the cell');
+
+    $this->assertSame('Only problem.', $exception->description);
+  }
+
+  /**
+   * Tests that a filtered list with gaps in its keys is read in order.
+   */
+  public function testGapKeyedListIsReadInOrder(): void {
+    $exception = new MultipleParseException([3 => new ParseException('unclosed_quote', 9, 'a', 'Only problem.')], 'the cell');
+
+    $this->assertSame('unclosed_quote', $exception->errorCode);
+    $this->assertSame(9, $exception->offset);
+    $this->assertSame('Only problem.', $exception->description);
+  }
+
+  /**
+   * Tests that an empty list is refused.
+   */
+  public function testAnEmptyListIsRefused(): void {
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('MultipleParseException requires at least one error.');
+
+    new MultipleParseException([], 'the cell');
+  }
+
+  /**
+   * Tests that a previous throwable is chained.
+   */
+  public function testThePreviousThrowableIsChained(): void {
+    $previous = new \RuntimeException('cause');
+    $exception = new MultipleParseException([new ParseException('unclosed_quote', 0, 'a', 'Only problem.')], 'the cell', $previous);
+
+    $this->assertSame($previous, $exception->getPrevious());
+  }
+
+}

--- a/tests/phpunit/src/Unit/Driver/Core/Field/Parser/Exception/ParseExceptionTest.php
+++ b/tests/phpunit/src/Unit/Driver/Core/Field/Parser/Exception/ParseExceptionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatSteps\Tests\Unit\Driver\Core\Field\Parser\Exception;
+
+use DrevOps\BehatSteps\Driver\Core\Field\Parser\Exception\ParseException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the position-aware parse error message.
+ *
+ * @group core
+ * @group fields
+ */
+#[CoversClass(ParseException::class)]
+#[Group('core')]
+#[Group('fields')]
+class ParseExceptionTest extends TestCase {
+
+  /**
+   * Tests that the message carries the cell, a caret and the description.
+   */
+  public function testTheMessagePointsAtTheOffendingCharacter(): void {
+    $exception = new ParseException('unquoted_semicolon', 3, 'abc; d', 'Semicolons are not allowed.');
+
+    $this->assertSame("abc; d\n   ^\nunquoted_semicolon at offset 3: Semicolons are not allowed.", $exception->getMessage());
+  }
+
+  /**
+   * Tests that a hint is appended as its own line.
+   */
+  public function testHintIsAppended(): void {
+    $exception = new ParseException('unclosed_quote', 0, '"abc', 'Missing a closing quote.', 'Add a closing double quote.');
+
+    $this->assertStringEndsWith("\nHint: Add a closing double quote.", $exception->getMessage());
+  }
+
+  /**
+   * Tests that an empty hint adds no line.
+   */
+  public function testAnEmptyHintIsOmitted(): void {
+    $exception = new ParseException('unclosed_quote', 0, '"abc', 'Missing a closing quote.', '');
+
+    $this->assertStringNotContainsString('Hint:', $exception->getMessage());
+  }
+
+  /**
+   * Tests that a negative offset still renders a caret.
+   */
+  public function testNegativeOffsetRendersTheCaretFirst(): void {
+    $exception = new ParseException('unknown', -5, 'abc', 'Something went wrong.');
+
+    $this->assertStringContainsString("abc\n^\n", $exception->getMessage());
+  }
+
+  /**
+   * Tests that the reported details stay readable on the exception.
+   */
+  public function testTheDetailsAreExposed(): void {
+    $previous = new \RuntimeException('cause');
+    $exception = new ParseException('unknown_escape', 2, 'a\\qb', 'Unknown escape.', 'Use a known escape.', $previous);
+
+    $this->assertSame('unknown_escape', $exception->errorCode);
+    $this->assertSame(2, $exception->offset);
+    $this->assertSame('a\\qb', $exception->cell);
+    $this->assertSame('Unknown escape.', $exception->description);
+    $this->assertSame('Use a known escape.', $exception->hint);
+    $this->assertSame($previous, $exception->getPrevious());
+  }
+
+}

--- a/tests/phpunit/src/Unit/Driver/Entity/EntityStubTest.php
+++ b/tests/phpunit/src/Unit/Driver/Entity/EntityStubTest.php
@@ -114,6 +114,19 @@ class EntityStubTest extends TestCase {
   }
 
   /**
+   * Tests that 'isParsed()' flips after 'markParsed()'.
+   */
+  public function testIsParsedFlipsAfterMarkParsed(): void {
+    $stub = new EntityStub('node', 'article');
+
+    $this->assertFalse($stub->isParsed());
+
+    $this->assertSame($stub, $stub->markParsed());
+
+    $this->assertTrue($stub->isParsed());
+  }
+
+  /**
    * Tests that 'isSaved()' flips after 'markSaved()'.
    */
   public function testIsSavedFlipsAfterMarkSaved(): void {


### PR DESCRIPTION
Closes #777

## Summary

`Core::nodeCreate()`, `userCreate()`, `termCreate()` and the generic `entityCreate()` now call the new `CoreInterface::parseEntityFields()` before `expandEntityFields()`, so `EntityFieldParser` reads a stub's compound cell grammar on every creation path the driver exposes, not only when `RawContext` calls it first.

`EntityFieldParser` and its exceptions already lived under `src/Driver/Core/Field/Parser/`, but a stub built and saved through `Core` without going through `RawContext::parseCreatedEntityFields()` reached `expandEntityFields()` with cells such as `uri: "https://example.com", title: "Example"` still as raw text, because the parser call and its hardcoded ignored-property lists (`['author']`, `['role']`, `['vocabulary_machine_name']`) lived only in the Behat context layer.

`Core::parseEntityFields()` now derives ignored properties from `getCreationAliases()` and marks each stub with `EntityStubInterface::markParsed()` so a stub `RawContext` already parsed is not parsed twice; `RawContext::getFieldParser()` is removed and `Core::getFieldParser()` is the sole override point, while the field-handler pipeline that runs after parsing (`expandEntityFields()` and the `FieldHandlerInterface` implementations) is untouched.

## Before / After

```
┌─ BEFORE ────────────────────────────────────────────────────────────────┐
│                                                                          │
│  RawContext::nodeCreate() / userCreate() / termCreate()                 │
│        │                                                                │
│        ├──> parseCreatedEntityFields($stub, ['author'|'role'|...])      │
│        │        └──> RawContext::parseEntityFields()                   │
│        │                 └──> EntityFieldParser (reads the cell grammar)│
│        │                                                                │
│        └──> Core::nodeCreate() / userCreate() / termCreate()           │
│                  └──> Core::expandEntityFields()                       │
│                                                                          │
│  Core::entityCreate() (ECK, etc.) has no RawContext step in front of    │
│  it, so a stub reaching it directly still carries raw cell text:        │
│  'uri: "https://example.com", title: "Example"' hits                    │
│  expandEntityFields() unparsed.                                         │
└──────────────────────────────────────────────────────────────────────────┘

┌─ AFTER ─────────────────────────────────────────────────────────────────┐
│                                                                          │
│  RawContext::nodeCreate() / userCreate() / termCreate()                 │
│        └──> Core::nodeCreate() / userCreate() / termCreate() /          │
│             entityCreate()                                             │
│                  │                                                      │
│                  ├──> Core::parseEntityFields($stub)                   │
│                  │       ├─ skip if $stub->isParsed()                  │
│                  │       ├─ ignore getCreationAliases($entity_type)    │
│                  │       └─ EntityFieldParser::parse() + markParsed()  │
│                  │                                                      │
│                  └──> Core::expandEntityFields()                       │
│                                                                          │
│  Every create path parses the same way; a stub RawContext already       │
│  parsed is marked and skipped instead of being read twice.              │
└──────────────────────────────────────────────────────────────────────────┘
```

## Changes

- Driver core (`src/Driver/Core/Core.php`, `CoreInterface.php`): added `getFieldParser()` and `parseEntityFields()` to `CoreInterface`; `Core::parseEntityFields()` merges `getCreationAliases()` keys with any caller-supplied ignored properties, returns early when the stub already reports `isParsed()`, and calls `markParsed()` after `EntityFieldParser::parse()`; `nodeCreate()`, `userCreate()`, `termCreate()` and `entityCreate()` each call it ahead of `expandEntityFields()`.
- Vocabulary bundle resolution (`Core::termCreate()`, `RawContext::termCreate()`): `Core::termCreate()` parses only once `vid` carries the vocabulary; `RawContext::termCreate()` seeds `vid` from the resolved vocabulary machine name under the same `getBundle() === NULL && !$stub->hasValue('vid')` guard `VocabularyMachineNameAlias` uses, so parsing resolves the same bundle whether the stub named its vocabulary through `vid` or the alias.
- Behat context layer (`src/Behat/Context/RawContext.php`): `parseEntityFields()` is now a one-line delegation to `Core::parseEntityFields()`; `parseCreatedEntityFields()` no longer takes an `$ignored_properties` argument or hardcodes `['author']`, `['role']`, `['vocabulary_machine_name']`; the `getFieldParser()` factory method is removed, leaving `Core::getFieldParser()` as the override point for a custom parser.
- Entity stub (`src/Driver/Entity/EntityStub.php`, `EntityStubInterface.php`): added `markParsed()` and `isParsed()`, mirroring the existing `markSaved()`/`isSaved()` pair, so a stub `RawContext` parses ahead of the driver is not parsed a second time inside `Core`.
- Parser (`src/Driver/Core/Field/Parser/EntityFieldParser.php`): `parse()` passes a non-string, non-multicolumn field value straight through (dropping the key when the value is `NULL`) instead of casting it to a string, so a caller that hands the parser records it assembled itself - `EckTrait`, the field-handler kernel tests - is unaffected.
- Exception (`src/Driver/Core/Field/Parser/Exception/MultipleParseException.php`): `buildDescription()` reads the single-error case with `reset($errors)` instead of `$errors[0]`, matching how the constructor already reads the list, so a caller-filtered error list with non-sequential keys does not throw.
- Documentation (`src/Driver/Core/Field/README.md`): the `entityCreate()` walkthrough gets a new first step describing the parse call, renumbering the remaining steps.
- Tests: added `EntityFieldParserTest` (75 unit tests over the cell grammar), `ParseExceptionTest`, `MultipleParseExceptionTest`, `CoreEntityParseKernelTest` (11 kernel tests driving `Core` with no Behat layer), and cases in `RawContextTest`, `RawContextVocabularyKernelTest` and `EntityStubTest`.
